### PR TITLE
add signal-to-campaign by Bojan Berisavljevic

### DIFF
--- a/skills/bojan-berisavljevic/author.md
+++ b/skills/bojan-berisavljevic/author.md
@@ -1,0 +1,9 @@
+---
+name: Bojan Djakonovic Berisavljevic
+avatarUrl: https://avatars.githubusercontent.com/u/218655203?v=4
+title: Head of Innovation & GTM, Blynked
+linkedinUrl: https://www.linkedin.com/in/bojandjb/
+companyDomain: blynked.io
+---
+
+Bojan builds signal-led revenue infrastructure and AI-assisted GTM systems at Blynked. His work turns observable account events into evidence-backed campaigns with clear targeting, provenance, and human approval gates.

--- a/skills/bojan-berisavljevic/signal-to-campaign/SKILL.md
+++ b/skills/bojan-berisavljevic/signal-to-campaign/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: signal-to-campaign
+title: Signal to campaign
+description: |
+  Use this skill when a team has an offer, target market, or observed account event and needs to turn it into a launch-ready signal-led campaign. Produces a signal thesis, evidence-backed account cohort, buyer map, channel-ready drafts, and a QA gate. Trigger on “build a campaign around this signal,” “find companies showing this problem,” “who should we contact now,” or “turn this market event into pipeline.”
+category: Signals
+tags: [Sales, Demand Gen]
+---
+
+Use this play before enriching contacts or writing campaign copy. It turns an observable market event into a small, defensible campaign package staged for human approval.
+
+## Prove the signal carries pain
+
+Translate the offer into the operational problem it solves. Generate several candidate signals, then score each on:
+
+- **Specificity:** does it point to this problem or merely describe the company?
+- **Observability:** can every account be tied to evidence another operator can inspect?
+- **Timing:** does it explain why action makes sense now?
+- **Ownership:** is there a recognisable buyer who owns the implied problem?
+- **Offer fit:** does the offer resolve the situation without a logical leap?
+- **Noise:** what common cases would create a false positive?
+
+Select one primary signal and one backup. A visible event is not automatically a buying signal. Funding, generic hiring, technology use, and broad growth become useful only when combined with current evidence of the relevant workflow, constraint, or complexity.
+
+## Build the evidence layer
+
+Create an account record for every candidate with:
+
+- normalised company identity and domain;
+- source and exact evidence excerpt;
+- observation date or verified current status;
+- the operational implication;
+- the likely pain owner;
+- a false-positive note;
+- a decision: **keep, investigate, or remove**.
+
+Reject accounts that cannot survive the sentence: “This company belongs because the evidence shows ___, which likely creates ___ for ___.” Do not enrich people yet. Replace weak rows instead of padding the cohort to hit a volume target.
+
+## Map buyers after the account passes
+
+For each kept account, identify the role that owns the affected process, the role that feels the consequence, and any likely blocker. Titles are clues, not proof of ownership. Map one to three contacts per account, deduplicate against existing relationships, and record why each person belongs in the motion.
+
+Enrich contact details only after the account and persona gates pass. Preserve strong accounts with missing contact data in a separate research queue rather than weakening the campaign.
+
+## Turn evidence into a campaign
+
+Write the thesis in one sentence:
+
+> Companies showing **[observable situation]** are likely dealing with **[operational consequence]**; **[offer]** helps them reach **[credible outcome]**.
+
+Turn raw evidence into a short human-readable context line. React to the business situation; do not exhibit scraped facts or announce surveillance. Draft one core message per persona, one proof point that matches the account’s scale, and one low-friction ask. Adapt that thesis to each channel instead of copying the same message everywhere.
+
+Before launch, produce:
+
+1. the signal thesis and false-positive definition;
+2. the kept account cohort with evidence;
+3. the buyer map and inclusion reasoning;
+4. staged channel drafts with required variables;
+5. a QA report and a small learning cohort.
+
+## What good looks like
+
+A strong campaign can defend every account, every contact, and every sentence. The signal is current and pain-bearing, not merely easy to collect. Company concentration is controlled, evidence is traceable, variables render naturally, and the first cohort is small enough to learn from replies before scaling.
+
+The expert tell is **resistance**: actively look for evidence that the signal does *not* imply pain. Mediocre work celebrates a data match, enriches hundreds of contacts, then writes “personalisation” from one keyword. Strong work removes false positives before spending enrichment effort and can explain what a positive reply would validate about the thesis.
+
+## Rules
+
+- MUST retain source evidence and a reason for inclusion for every account.
+- MUST define false positives before building the full cohort.
+- MUST separate fit, signal strength, and contactability; one cannot substitute for another.
+- MUST stage outreach for human approval and define the reply-learning goal.
+- NEVER invent urgency, pain, observations, proof, or customer outcomes.
+- NEVER enrich at scale before the account-level gate passes.
+- NEVER launch just to satisfy a lead-count target.


### PR DESCRIPTION
## What this skill does

Turns an observable market event into a QA-gated, launch-ready signal-led campaign: signal thesis, evidence-backed account cohort, buyer map, channel drafts, and a small learning cohort. Its core judgment is to test resistance and false positives before enrichment rather than mistaking an easy data match for buying intent.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/bojan-berisavljevic/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn’t own; no secrets, no injection patterns, no ungated destructive actions
- [x] I’m okay with this being MIT-licensed with attribution via my creator profile