### PR TITLE
add track-contact-job-changes by gtm-engineering

### DIFF
--- a/skills/gtm-engineering/author.md
+++ b/skills/gtm-engineering/author.md
@@ -1,0 +1,12 @@
+---
+name: Jorge Macias
+avatarUrl: https://github.com/jorgethegtme.png
+title: Founder, GTM Engineering
+linkedinUrl: https://www.linkedin.com/in/jorge-b-macias/
+companyDomain: gtm-engineering.io
+---
+
+Jorge Macias runs GTM Engineering, where he builds go-to-market automation and packages repeatable
+RevOps plays as portable agent skills. His skills focus on keeping CRM data honest and turning signals
+like job changes into pipeline — tool-agnostic, review-gated, and built to run against whatever stack a
+team already uses.

--- a/skills/gtm-engineering/track-contact-job-changes/SKILL.md
+++ b/skills/gtm-engineering/track-contact-job-changes/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: track-contact-job-changes
+title: Track contact job changes
+description: |
+  Use this skill when you need to find which contacts in the CRM have changed jobs and act on it —
+  a quarterly database refresh, a "did anyone move?" sweep, a churn-risk or new-champion check, or a
+  job-change signal firing on a known contact. It reads each contact's current role from their
+  work history, compares it to what the CRM believes, and routes the movers: still-there contacts get
+  refreshed, confirmed leavers get their old and new roles separated, movers to non-fit companies get
+  flagged and opted out, and movers to net-new fit companies get the company enriched, tiered, and
+  optionally created as an account. Every CRM write is proposed for approval first — the database is
+  never polluted and no contact is silently overwritten. Also known as: job change detection, contact
+  data refresh, champion tracking, buyer-moved alerts.
+category: RevOps
+---
+
+One line: run this when you want the CRM's contacts to reflect where those people actually work now,
+and to catch champions who moved to a new account. It produces a reviewed batch of CRM changes, never a
+silent rewrite.
+
+**Golden rule: propose, then confirm.** Collect every proposed change and show it as one table before
+touching the CRM. And **never act on the wrong person** — if the enriched identity doesn't match the
+contact, it goes to "can't confirm", not to a write.
+
+## Setup (once)
+
+Before the first run, capture the operator's configuration and save it — see
+[references/setup-checklist.md](references/setup-checklist.md). It records: the CRM and whether writes
+are allowed; the **match keys** for a person (record id, email, LinkedIn URL) and a **company** (domain,
+LinkedIn company URL, name); the four data sources the play needs (a LinkedIn-URL finder, a work-history
+source that returns current + past roles, an email lookup, a company-enrichment source); the **tier
+rules** that define a create-worthy account; the **opt-out rules** that mark a move as a dead end; and
+the CRM field names to write. On a later run, load the saved config; if none exists, run setup first.
+
+## The play (per contact)
+
+1. **Confirm the contact is in the CRM** using the person match keys, and read their current company,
+   title, and LinkedIn URL.
+2. **Have a LinkedIn URL?** If not, look one up from name + company and **validate the found profile's
+   name against the contact** before trusting it. Retry once. Still nothing → mark *can't confirm* and stop.
+3. **Pull current + past roles** from the work-history source. Validate the returned person's name against
+   the contact. On a name mismatch → the stored URL is likely wrong → mark *can't confirm* (re-find), stop.
+4. **Compare the current employer to the CRM company** using the matching rules in
+   [references/matching.md](references/matching.md) — domain and LinkedIn-page agreement decide it; a name
+   alone never does. Three outcomes:
+   - **Still there** → propose refreshing title/tenure if they changed; otherwise mark verified. Done.
+   - **Can't confirm** (weak or conflicting signals) → propose re-finding the URL or flag for review. Never guess. Done.
+   - **Confirmed left** → separate old (the CRM company) from new (the current employer), and continue.
+5. **Is the new company already in the CRM?** Match it with the same rules.
+   - **Yes** → apply the opt-out rules. If the new company is a customer, competitor, or otherwise
+     disqualifying → **flag & opt out** (stop outreach, record the move). Otherwise → **update the
+     contact** to the new company/title and re-associate to the existing account.
+   - **No** → **enrich the company**, then **tier it** against the rules in
+     [references/tiering.md](references/tiering.md). A **fit** account → propose **creating the account**,
+     then update the contact onto it. A **non-fit** account → **skip & flag** (don't create it), but still
+     update the contact's new company/title so the record is honest. Both paths end at an updated contact.
+6. **Approve & apply.** Present the batch as one table — contact, old → new company, outcome, fields to
+   write, and the evidence/confidence behind it. Apply only what's approved. If writes are disabled,
+   export the table instead of writing.
+
+## What good looks like
+
+A great run leaves every still-employed contact quietly verified, every real mover refreshed to their
+actual new role, and every champion who landed at a net-new fit account surfaced as a new opportunity —
+with a one-glance approval table the operator can trust and audit. Confidence is earned from domains and
+LinkedIn pages, not from fuzzy name overlap; acquisitions and rebrands are treated as "same company" only
+when the hard identifiers agree.
+
+The mediocre version pollutes the database: it overwrites a contact because two company names looked
+similar, acts on a same-name stranger's profile, creates duplicate accounts for a company already in the
+CRM under a different name, or auto-writes a pile of changes no human ever saw. The tell of the expert:
+they trust "confirmed left" only when the new employer is hard-identified, and they would rather leave a
+record as "can't confirm" than write a confident lie.
+
+## Rules
+
+- MUST propose every CRM create/update in a single review step and apply only what a human approves.
+- MUST validate the enriched person's name against the contact before using any profile; on mismatch, route to "can't confirm".
+- MUST decide company sameness from domain / LinkedIn-page agreement first; a name-only match is never sufficient to write.
+- MUST keep the old company as previous-role history when a contact is updated — never erase where they came from.
+- NEVER create a new account for a company that already exists in the CRM under a different name or domain.
+- NEVER opt a contact out, or overwrite their role, on low-confidence or single-signal evidence.
+- NEVER continue when writes are disabled — export the proposed changes instead.

--- a/skills/gtm-engineering/track-contact-job-changes/references/matching.md
+++ b/skills/gtm-engineering/track-contact-job-changes/references/matching.md
@@ -1,0 +1,37 @@
+# Company matching rules
+
+Deciding whether two company references are the same is the crux of this play — it drives both
+"still there vs left" and "is the new company already in the CRM?". Company names are noisy; hard
+identifiers are not. Rank the signals accordingly.
+
+## Signal order (strongest first)
+
+1. **Domain** — normalize both (lowercase, drop scheme, `www.`, path, and port; reduce to the
+   registrable domain, keeping the extra label for known two-part suffixes like `co.uk`). Equal
+   normalized domains → **same company**. Explicitly different domains → treat as **different**
+   unless a LinkedIn page agrees.
+2. **LinkedIn company page** — compare the `/company/<slug>` slug. Equal slugs → **same company**
+   (near-certain).
+3. **Name** — only a supporting signal. Normalize before comparing: lowercase, strip punctuation,
+   drop a leading "the", and remove legal/suffix noise (inc, llc, ltd, corp, gmbh, co, holdings,
+   group, technologies, labs, software, solutions, …). Identical normalized names, or one fully
+   contained in the other, is a moderate signal — never enough on its own to justify a CRM write.
+
+## Verdict bands
+
+- **Match** — a hard identifier (domain or LinkedIn slug) agrees. Safe to treat as the same company.
+- **Ambiguous** — only names are similar, or signals partially conflict. This is the **"can't confirm"**
+  outcome: re-find the LinkedIn URL or flag for review. Do not write.
+- **Different** — domains disagree and nothing else confirms a match. Even a high name similarity does
+  not override disagreeing domains.
+
+## Edge cases
+
+- **Acquisitions / rebrands / subsidiaries** — count as the same company only when domains or LinkedIn
+  pages agree. Matching names across a rebrand without an identifier is "can't confirm".
+- **Holding companies and DBAs** — a shared parent name with different operating domains is *different*.
+- **Thin current-employer data** — if the new employer came back with only a name and no domain/LinkedIn,
+  a "left" verdict is not confident enough. Fall to "can't confirm".
+
+The principle: earn "confirmed left" from a hard-identified new employer. Prefer leaving a record as
+"can't confirm" over writing a confident guess.

--- a/skills/gtm-engineering/track-contact-job-changes/references/setup-checklist.md
+++ b/skills/gtm-engineering/track-contact-job-changes/references/setup-checklist.md
@@ -1,0 +1,35 @@
+# Setup checklist
+
+Run once, then save the answers so later runs load them instead of re-asking. Detect what the operator
+already has connected and pre-fill from it; only ask for what you can't infer. Confirm a summary before saving.
+
+Capture:
+
+## CRM & write policy
+- Which CRM holds the contacts.
+- Whether the skill may **write** to it. If not, the play runs in report-only mode — it proposes changes and exports them, but never writes.
+
+## Match keys
+- **Person** — how to locate and dedupe a contact, in priority order: record id → email → LinkedIn URL.
+- **Company** — how to decide two companies are the same, in priority order: domain/website → LinkedIn company page → name. These drive both "still there?" and "is the new company already in the CRM?".
+
+## Data sources (four capabilities)
+Name the tool the operator will use for each. If a capability has nothing available, suggest current market options and have them pick or connect one — do not proceed without a work-history source, which is required.
+1. **LinkedIn-URL finder** — resolves a profile URL from name + company, with name validation.
+2. **Work-history source** — returns current employer + title + start date AND past employers. Required.
+3. **Email lookup** — a verified email for the moved contact (for opt-out / update / verification).
+4. **Company enrichment** — size, industry, revenue, domain, LinkedIn, geo for a net-new company (feeds tiering).
+
+## Tier rules
+- The criteria that make a net-new company worth creating as an account (a **fit** account → Tier 1). See [tiering.md](tiering.md). Anything not a fit → skip & flag.
+
+## Opt-out rules
+- The conditions that make a move a dead end when the **new company is already in the CRM** — e.g. it's a current customer, a competitor, or a partner. When one matches → flag & opt out. Otherwise → update the contact.
+
+## Field mapping
+- The CRM property names to write: current company, title, LinkedIn URL, job-change flag, job-change date, previous company, opt-out flag, account tier, review/needs-attention flag. Only map the fields the operator wants written.
+
+## Confidence thresholds
+- The bar that separates "still there" / "confirmed left" from "can't confirm". A high bar keeps the database clean; borderline comparisons should fall to "can't confirm" rather than a guessed write.
+
+Re-running setup overwrites the saved config after showing current values as defaults. The operator can also edit it by hand.

--- a/skills/gtm-engineering/track-contact-job-changes/references/tiering.md
+++ b/skills/gtm-engineering/track-contact-job-changes/references/tiering.md
@@ -1,0 +1,34 @@
+# Tiering a net-new company
+
+When a confirmed mover lands at a company **not** already in the CRM, decide whether it's worth creating
+as an account. Score the enriched company against the operator's fit criteria from setup. Keep it
+deterministic and auditable — the operator should be able to read why a company was or wasn't a fit.
+
+## The rubric
+
+Evaluate only the criteria the operator actually defined; a criterion they left blank is not a filter.
+Typical criteria:
+
+- **Employee count** within a floor/ceiling range.
+- **Revenue** above a floor.
+- **Industry / market** matches one of the target verticals (check industry, description, and keywords).
+- **Keywords** — target technologies, motions, or descriptors appear in the company's profile.
+- **Geography** — headquartered in a target country/region.
+
+**Fit (Tier 1):** every defined criterion that was evaluated passes → propose creating the account, then
+update the contact onto it and set the account tier.
+
+**Non-fit (Tier 2/3):** any defined criterion fails → **skip & flag** (do not create the account), record
+the tier and a needs-attention flag, but still update the contact's new company and title so the record
+is honest.
+
+**No criteria evaluated:** if nothing could be scored (missing enrichment, or no rules defined), do **not**
+auto-promote to fit — treat as non-fit / needs review, and surface why.
+
+## Notes
+
+- Record the pass/fail reasons alongside the proposal so the approval step shows the operator the
+  evidence, not just a verdict.
+- Both tiers end at an updated contact — the difference is only whether a new account is created.
+- Never create an account here for a company that a stronger identifier shows is already in the CRM under
+  a different name; that belongs to the "already in CRM" branch, not this one. See [matching.md](matching.md).


### PR DESCRIPTION
## What this skill does

Detects which CRM contacts have changed jobs and acts on it: reads each contact's current role from their work history, compares it to what the CRM believes, and routes the movers — still-there contacts refreshed, confirmed leavers' old/new roles separated, movers to non-fit companies flagged and opted out, and movers to net-new fit companies enriched, tiered, and optionally created as accounts. Every CRM write is proposed for approval first.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only (`skills/gtm-engineering/`)
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions (all CRM writes are human-approved)
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
