### PR TITLE
Add Alex Vacca (Frontal): 4 master skills + 33 standalone outbound skills

### DIFF
--- a/skills/alex-vacca/ai-personalization-prompts/SKILL.md
+++ b/skills/alex-vacca/ai-personalization-prompts/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ai-personalization-prompts
+title: AI personalization prompts
+description: "Use this skill when setting up AI-powered personalization, building Clay or lemlist workflows, or automating prospect research — 6 AI personalization prompts (lemlist style) plus 2 email templates: ICP identification, company description, similar product, top 3 problems, subject line, case study reference, and similar company approach."
+category: Outreach
+---
+
+# AI Personalization Prompts (lemlist Style)
+
+Quick reference for AI prompts. For full prompts with rules, see [references/prompts.md](references/prompts.md).
+
+## Prompt Overview
+
+| # | Prompt | Output | Max Words |
+|---|--------|--------|-----------|
+| 1 | ICP Identification | Top 3 ICPs (job titles) | 3 titles |
+| 2 | Company Description | Concise description | 8 words |
+| 3 | Similar Product | Product category | 6 words |
+| 4 | Top 3 Problems | ICP pain points | 10 words each |
+| 5 | Subject Line | Email subject | 2 words |
+| 6 | Case Study Reference | Template with variables | N/A |
+| 7 | Similar Company Approach | Full email template | N/A |
+
+## Quick Usage
+
+**Inputs needed:** `{{companyDomain}}` or `{{companyDescription}}`
+
+**Prompt 1-5:** Use for variable generation in Clay/lemlist
+**Prompt 6-7:** Use as full email templates with AI-generated variables
+
+## Output Examples
+
+| Prompt | Input | Output |
+|--------|-------|--------|
+| ICP ID | "CRM software" | "Sales leaders, RevOps managers and AEs" |
+| Description | "frontal.so" | "outbound automation (for B2B sales teams)" |
+| Similar | "calendly.com" | "scheduling software" |
+| Problems | "HR software" | "slow hiring, poor retention, and compliance gaps" |
+| Subject | "analytics platform" | "your metrics" |
+
+## Key Rules (All Prompts)
+
+- All lower case output
+- No full stops at end
+- No sales/buzzwords
+- Must fit grammatically in template sentence
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `clay-enrichment-9step` | Run prompts via Claygent |
+| `personalization-6-buckets` | Know what data to feed prompts |
+| `cold-email-templates-34` | Use outputs in email templates |
+| `frontal-messaging-templates` | Combine with case study template |
+
+## Example prompts
+
+```
+Generate ICP identification and top 3 problems for a cybersecurity company.
+```
+
+```
+Create a 2-word subject line for a prospect selling HR software.
+```
+
+```
+Write template #7 (Similar Company Approach) with AI-generated variables for [company].
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/ai-personalization-prompts/references/prompts.md
+++ b/skills/alex-vacca/ai-personalization-prompts/references/prompts.md
@@ -1,0 +1,165 @@
+# AI Personalization Prompts (Full)
+
+## 1. ICP Identification Prompt
+
+**Purpose:** Find top 3 most likely ICPs a company is prospecting
+
+```
+Find the top 3 most likely ICPs this person is prospecting based on {{companyDomain}}. If unavailable, use {{companyDescription}}.
+
+Rules:
+- Keep ICPs to just job titles (max 3)
+- Use shorter, abbreviated alternatives (CEO not Chief Executive Officer)
+- Always use "and" before the last example
+- Never end with a full stop
+
+Examples:
+- Input: Chief Executive Officer → Output: CEOs
+- Input: Chief Executive Officer, Business Development Representatives, Account Executive → Output: CEOs, BDRs and AEs
+```
+
+---
+
+## 2. Short Company Description Prompt
+
+**Purpose:** Create a concise company description that resonates
+
+```
+Describe the company in one concise sentence based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- Don't mention company name
+- Don't mention ICP
+- Maximum 8 words
+- Keep tone neutral, all lower case
+- No quotes in output
+- Use main value prop from website
+
+The output must fit grammatically in:
+"Getting people interested in [insert description summary] isn't the easiest thing in the world."
+
+Add (brackets) to some information in second half for emphasis.
+```
+
+---
+
+## 3. Similar Product/Service Prompt
+
+**Purpose:** Categorize what type of product/service the prospect offers
+
+```
+Categorize the product/service type based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- Maximum 6 words
+- Neutral tone, all lower case
+- No full stops
+- Keep it singular
+- Avoid vagueness
+- Can use abbreviations ("tech" instead of "technology")
+
+Output must fit grammatically in:
+"We work with a similar [output]."
+```
+
+---
+
+## 4. Top 3 Problems Prompt
+
+**Purpose:** Identify top 3 problems the prospect's ICP is facing
+
+```
+Identify top 3 problems of the main ICP based on {{companyDomain}} or {{companyDescription}}.
+
+Requirements:
+- Problems should be directly linked to lagging indicators
+- Rank 1-3 with 1 being biggest problem
+- Link to main KPI each problem prevents reaching
+- Each problem max 10 words
+- Don't capitalize letters
+- No full stop at end
+- Add "and" before problem 3
+- Avoid repeating words
+- Avoid buzzwords/sales-y words
+
+Format: [Problem 1], [Problem 2], and [Problem 3]
+
+Must fit in phrase: "They book 25 meetings/month with leads struggling to [Problem 1], [Problem 2], and [Problem 3]"
+```
+
+---
+
+## 5. Subject Line Prompt
+
+**Purpose:** Create a 2-word subject line that peaks interest
+
+```
+Write a two-word email subject line based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- MUST be exactly 2 words
+- All lower case
+- Take words relevant to user's business
+- No sales or buzzwords
+- No spam words
+- Should flow into the email naturally
+- Goal: get them to open, then reply with interest
+```
+
+---
+
+## 6. Case Study Reference Template
+
+```
+Our client [Lead Solution] used to prospect [ICP].
+
+They focused on:
+[Problem 1], [Problem 2], [Problem 3].
+
+Since you focus on {{summary}}, might work well if you combined [free resource that could solve problems].
+
+Could I share the outbound campaign they were using to book 35 meetings/month?
+```
+
+---
+
+## 7. Similar Company Approach Template
+
+```
+Hi {{firstName}}, saw you focus on {{Company Summary}}.
+
+A client of ours prospects {{ICP}} for a {{Similar product_service}}.
+
+They help clients struggling to {{3 problems}}.
+
+[SPINTAX CTA OPTIONS:]
+- Can I share
+- Can I show you
+- Would it interest you to see
+- Would you like me to share
+- Would you be open to
+- Might you be interested in
+- If you have 15 minutes, I can share
+- May I share
+- Could I show you
+
+...the email campaigns they were using to book 25+ meetings/month?
+
+{{signature}}
+
+p.s if not, happy to share how ai wrote this email ;)
+```
+
+---
+
+## Variable Mapping
+
+| Variable | Source | Used In |
+|----------|--------|---------|
+| `{{companyDomain}}` | Lead data | Prompts 1-5 |
+| `{{companyDescription}}` | Fallback | Prompts 1-5 |
+| `{{firstName}}` | Lead data | Templates 6-7 |
+| `{{Company Summary}}` | Prompt 2 output | Template 7 |
+| `{{ICP}}` | Prompt 1 output | Templates 6-7 |
+| `{{Similar product_service}}` | Prompt 3 output | Template 7 |
+| `{{3 problems}}` | Prompt 4 output | Templates 6-7 |

--- a/skills/alex-vacca/atl-btl-messaging/SKILL.md
+++ b/skills/alex-vacca/atl-btl-messaging/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: atl-btl-messaging
+title: ATL vs BTL messaging
+description: "Use this skill when crafting messages for different seniority levels, deciding message length and tone, or adapting outreach to VPs and C-Level vs Managers and ICs — the Above-the-Line (ATL) / Below-the-Line (BTL) messaging framework for targeting executives vs end-users."
+category: Outreach
+---
+
+# ATL vs BTL Messaging Framework
+
+## Above-the-Line (ATL) - VPs, C-Level, Directors
+
+**Mindset:**
+- Think past and future (strategic)
+- Want validation, not problems solved
+- Care about big picture, not daily operations
+
+**What They Care About:**
+- Revenue impact
+- Risk reduction
+- Strategic initiatives
+- Competitive positioning
+- Board/investor optics
+
+**Message Length:** 2-3 sentences only
+
+**Language to Use:**
+- "Strategic initiative"
+- "Revenue impact"
+- "Competitive advantage"
+- "Board-level priority"
+- "Risk mitigation"
+
+**Example ATL Email:**
+```
+Subject: Q1 revenue efficiency
+
+{{firstName}},
+
+If you could identify revenue leakage 3 months faster, what would that mean for next year's targets?
+
+We helped {{similar_company}}'s CEO do exactly that.
+
+15 minutes to explore?
+```
+
+**Fatal ATL Mistake:** Talking about operational problems = immediate delegation to subordinate
+
+---
+
+## Below-the-Line (BTL) - Managers, ICs, End-Users
+
+**Mindset:**
+- Think present (tactical)
+- Want problems solved immediately
+- Care about daily workflow
+
+**What They Care About:**
+- Daily pain points
+- Time savings
+- Workflow improvements
+- Making their job easier
+- Looking good to their boss
+
+**Message Length:** 3-4 sentences acceptable
+
+**Language to Use:**
+- "Stop spending 3 hours every week on..."
+- "Eliminate the manual work of..."
+- "Never deal with {{pain}} again"
+- "Save {{X}} hours per week"
+
+**Example BTL Email:**
+```
+Subject: 3 hours back
+
+Hey {{firstName}},
+
+Stop spending 3 hours every week fighting with Excel.
+
+We helped {{similar_company}}'s ops team cut their reporting time by 70%.
+
+Want to see how?
+```
+
+**Fatal BTL Mistake:** Talking about ROI and strategic impact = doesn't resonate, too abstract
+
+---
+
+## Decision Framework: Who to Target
+
+**Target ATL (Executives) When:**
+- Deal size > $50K ACV
+- Strategic/transformation purchase
+- Requires budget approval from top
+- Long sales cycle acceptable
+
+**Target BTL (End-Users) When:**
+- Product-led growth motion
+- User adoption drives expansion
+- Bottom-up sale
+- Need internal champion first
+
+**Multi-Thread (Both) When:**
+- Complex enterprise sale
+- Multiple stakeholders
+- Both budget holder and user buy-in needed
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Adjust sequence length for ATL vs BTL |
+| `sdr-outbound-rules` | Apply word count rules by seniority |
+| `outbound-triggers-6` | CXO Passdown for ATL targeting |
+| `personalization-6-buckets` | Choose bucket by seniority level |
+
+## Example prompts
+
+```
+Rewrite this email for a CFO (ATL) instead of a Finance Manager (BTL).
+```
+
+```
+Create an ATL email about cost reduction for a VP Operations at a logistics company.
+```
+
+```
+I have a BTL champion - write a BTL email I can ask them to forward to their VP.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/author.md
+++ b/skills/alex-vacca/author.md
@@ -1,0 +1,9 @@
+---
+name: Alex Vacca
+avatarUrl: "https://www.gtmskills.com/authors/alex-vacca.jpg"
+title: "Founder & CEO @ Frontal"
+linkedinUrl: "https://linkedin.com/in/alex-vacca"
+companyDomain: frontal.so
+---
+
+Founder and CEO of Frontal (formerly ColdIQ) — the revenue-systems team behind 275+ B2B companies and one of four Clay Elite Studio partners worldwide. Frontal builds signal-driven revenue engines: clean data, buying signals, and triggered plays wired into HubSpot, Salesforce, and Clay, with results like $7.83M in qualified pipeline for AirOps. Alex's open outbound skills encode how Frontal actually runs cold email, Clay, list building, and signal-based selling.

--- a/skills/alex-vacca/bridgebound-firmographic-15/SKILL.md
+++ b/skills/alex-vacca/bridgebound-firmographic-15/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: bridgebound-firmographic-15
+title: Bridgebound firmographic triggers
+description: "Use this skill when targeting companies based on business events, building expansion campaigns, or leveraging news-based outreach — 15 firmographic Bridgebound triggers from Flip The Script: financial events, M&A activity, growth signals, and product/marketing moves."
+category: Signals
+---
+
+# BRIDGEBOUND Category V: Based on "Firmographic" (15 Triggers)
+
+## Financial Events (3 Triggers)
+
+1. **Companies that Went Public (IPO)** - Post-IPO needs
+2. **Companies that Raised Funding** - New budget available
+3. **Companies that Released Financial Reports** - Public financials
+
+---
+
+## M&A Activity (3 Triggers)
+
+4. **Companies that Acquired Another Company** - Acquirer needs
+5. **Companies that Were Acquired** - Integration needs
+6. **Companies that Merged with Another Company** - Merger consolidation
+
+---
+
+## Growth Signals (4 Triggers)
+
+7. **Companies that are Growing (Hypergrowth)** - Scale pain
+8. **Companies that Started Hiring** - Ramp pressure
+9. **Companies that Moved Headquarters** - Relocation needs
+10. **Companies that Opened New Locations** - Expansion needs
+
+---
+
+## Product & Marketing (5 Triggers)
+
+11. **Companies that Released a New Product** - Launch support
+12. **Companies that Released a New Feature** - Feature expansion
+13. **Companies that Released a New Integration** - Tech stack changes
+14. **Companies that Made an Impactful Marketing Move** - Marketing momentum
+15. **Companies Whose Competitor Made an Impactful Move** - Competitive response
+
+---
+
+## Funding Announcement Template
+
+```
+Subject: congrats on the raise
+
+{{firstName}}, saw {{company}} just raised {{amount}}.
+
+Most companies at this stage start scaling {{function}}.
+
+We helped {{similar_company}} do exactly that after their Series {{X}}.
+
+Worth a quick chat about what worked?
+```
+
+---
+
+## Timing by Trigger
+
+| Trigger | Optimal Timing |
+|---------|----------------|
+| Funding | 2-4 weeks after announcement |
+| IPO | 30-60 days post-IPO |
+| Acquisition | 60-90 days post-close |
+| New product launch | 1-2 weeks after |
+| Hypergrowth | Ongoing monitoring |
+| Hiring spike | Within 2 weeks of pattern |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `buying-signals-6` | Expansion signal (#5) |
+| `clay-buying-signals-5` | Funding & hiring detection |
+| `cold-email-templates-34` | Templates #20, #22 |
+| `gtm-plays-11` | Play #1 (New Team Members) |
+
+## Example prompts
+
+```
+Create an outreach campaign for companies that just raised Series B.
+```
+
+```
+How do I detect M&A activity for competitive displacement?
+```
+
+```
+Write a sequence for trigger #8 (Companies that Started Hiring) targeting DevOps.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/bridgebound-history-16/SKILL.md
+++ b/skills/alex-vacca/bridgebound-history-16/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: bridgebound-history-16
+title: Bridgebound history triggers
+description: "Use this skill when re-engaging past prospects, reactivating closed-lost deals, or building win-back campaigns — 16 history-based Bridgebound triggers from Flip The Script: demo pipeline, closed-lost, executive churn, email engagement, and reciprocity."
+category: Signals
+---
+
+# BRIDGEBOUND Category II: Based on History (16 Triggers)
+
+## Demo Pipeline (3 Triggers)
+
+1. **Requested a Demo But Didn't Schedule One** - Demo request abandonment
+2. **Agreed to a Demo & No-Showed** - No-show follow-up
+3. **Prospects Who "Abandoned the Chat"** - Chat abandonment
+
+---
+
+## Closed-Lost (5 Triggers)
+
+4. **Demoed in the Past (Ghosted or Went Dark)** - Ghosted prospects
+5. **Went with a Competitor & Up on Renewal** - Competitor renewal timing
+6. **You Messed Up (Ex. Objection of No Budget)** - Past objection resolution
+7. **Didn't Hit ICC (Size)** - Company grew into ICP
+8. **Didn't Hit ICC (Criteria that DQs)** - Criteria changed
+
+---
+
+## Executive Churn / UserGems (3 Triggers)
+
+9. **Customers Who Went to Another Company** - Champion tracking
+10. **Customers Who Changed Roles Internally** - Internal moves
+11. **Prospective Company New Hires, Who Never Used Your Product** - New decision makers
+
+---
+
+## Email Engagement (3 Triggers)
+
+12. **Opened Prospecting Emails** - Email openers
+13. **Opened Prospecting Emails (Aggressively)** - Multiple opens
+14. **Received an OOO to Prospecting Emails** - OOO responses (timing intel)
+
+---
+
+## Reciprocity (2 Triggers)
+
+15. **Companies that Sold You THEIR Product (Tit for Tat)** - Vendor relationships
+16. **Competitors of Your Current Customers** - Competitive intelligence
+
+---
+
+## Re-Engagement Template
+
+```
+Subject: since we last talked
+
+{{firstName}},
+
+When we talked in {{month}}, you mentioned {{objection}}.
+
+Since then, we've {{improvement}}.
+
+Worth another look?
+```
+
+---
+
+## Timing Considerations
+
+| Trigger Type | Optimal Timing |
+|--------------|----------------|
+| No-show | Same day + 2 days later |
+| Ghosted | 30-60 days later |
+| Competitor renewal | 90 days before renewal |
+| Champion job change | Days 14-45 in new role |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-templates-34` | Re-engagement templates (#31-34) |
+| `buying-signals-6` | Champion tracking (signal #1) |
+| `clay-enrichment-9step` | Track job changes in Clay |
+| `cold-call-scripts` | No-show phone script |
+
+## Example prompts
+
+```
+Create a win-back campaign for closed-lost deals from 6 months ago.
+```
+
+```
+How do I track when competitors' customers are up for renewal?
+```
+
+```
+Write a sequence for trigger #9 (Customers Who Went to Another Company).
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/bridgebound-in-market-20/SKILL.md
+++ b/skills/alex-vacca/bridgebound-in-market-20/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: bridgebound-in-market-20
+title: Bridgebound in-market triggers
+description: "Use this skill when targeting active buyers, building competitive displacement campaigns, or leveraging seasonal and event timing — 20 'in market' Bridgebound triggers from Flip The Script: adjacent vendors, competitors, and time-based signals."
+category: Signals
+---
+
+# BRIDGEBOUND Category III: Based on Likely "In Market" (20 Triggers)
+
+## Adjacent Vendors (7 Triggers)
+
+1. **Recently Purchased Adjacent Vendor (Channel Partner)** - New tech stack addition
+2. **Current Customers of Adjacent Vendor (Non-Channel Partner)** - Complementary tools
+3. **In-Cycle with Adjacent Vendor (Channel Partner)** - Active evaluation
+4. **Engaged with Adjacent Vendor's Company Page** - Vendor interest
+5. **Followers of Adjacent Vendor's Company Page** - Following adjacent tools
+6. **Engaged with Adjacent Vendor's Employees** - Employee engagement
+7. **Mutual Connections with Adjacent Vendor's Employees** - Shared network
+
+---
+
+## Competitors (9 Triggers)
+
+8. **Competitor's Churned Customers (Left a Negative Review)** - Unhappy churners
+9. **Competitor's Churned Customers (Through Disintegration)** - Forced churn
+10. **Competitor's Customers (Through Competitor's Website)** - Identified users
+11. **Competitor's Customers (Through Integration)** - Integration data
+12. **In-Cycle with Competitors (Through Word of Mouth)** - Active evaluation
+13. **Engaged with Competitor's Company Page** - Competitor interest
+14. **Followers of Competitor's Company Page** - Following competitors
+15. **Engaged with Competitor's Employees** - Employee engagement
+16. **Mutual Connections with Competitor's Employees** - Shared network
+
+---
+
+## Time-Based (4 Triggers)
+
+17. **Annual Event (Ex. Taxes)** - Recurring annual needs
+18. **Regular Event (Ex. Olympics)** - Periodic events
+19. **Seasonal Needs (Ex. Summer for HVAC)** - Seasonal demand
+20. **Act of God (One-Time Event)** - Unexpected events
+
+---
+
+## Competitor Displacement Template
+
+```
+Just saw your review of {{competitor}}...
+
+We researched and tested 3 alternatives (that don't suck).
+
+Shall I send the report to you?
+
+Cheers,
+[Name]
+```
+
+---
+
+## Adjacent Vendor Play
+
+**Logic:** If they bought Tool A, they likely need Tool B
+
+**Examples:**
+- Bought Salesforce → Need Salesforce add-ons
+- Bought HubSpot → Need marketing automation
+- Bought Snowflake → Need data tools
+
+**Timing:** 2-4 weeks after adjacent vendor purchase
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `buying-signals-6` | Tech stack change signal |
+| `clay-buying-signals-5` | Detect tech changes in Clay |
+| `gtm-plays-11` | Play #8 (Bad Reviews) |
+| `cold-email-templates-34` | Competitor switch templates |
+
+## Example prompts
+
+```
+Build a campaign targeting companies that just purchased Salesforce.
+```
+
+```
+How do I find churned customers from my competitor on G2?
+```
+
+```
+Create an outreach strategy for trigger #17 (Annual Event) targeting tax season.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/bridgebound-relationship-39/SKILL.md
+++ b/skills/alex-vacca/bridgebound-relationship-39/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: bridgebound-relationship-39
+title: Bridgebound relationship triggers
+description: "Use this skill when leveraging warm connections, building referral campaigns, or multi-threading into accounts — 39 relationship-based Bridgebound triggers from Flip The Script: common VCs, customers, C-suite, employees, VC partners, advisors, board members, sponsored companies, and your network."
+category: Signals
+---
+
+# BRIDGEBOUND Category I: Based on Relationship (39 Triggers)
+
+## Share a Common VC (2 Triggers)
+
+1. **Common VC with Your Company** - Same investor
+2. **Common VC with Your Customers** - VC's other portfolio companies
+
+---
+
+## Your Customers (5 Triggers)
+
+3. **Referral to Network of Happy Customers** - Ask for referrals
+4. **Inbound Referrals from Key Customers** - Customer-initiated referrals
+5. **Engaged with Key Customer's Personal Page** - Engaged with customer's content
+6. **Engaged with Key Customer's Company Page** - Company engagement
+7. **Followers of Key Customer's Company Page** - Following customer's company
+
+---
+
+## C-Suite (3 Triggers)
+
+8. **Inbound Referrals from C-Suite** - Executive referrals
+9. **Engaged with C-Suite's Personal Page** - Engaged with exec content
+10. **Mutual Connections with C-Suite** - Shared network with execs
+
+---
+
+## Employees of Your Company (4 Triggers)
+
+11. **Inbound Referrals from Company Employees** - Team referrals
+12. **Engaged with Company Employee's Personal Page** - Engaged with employee content
+13. **Mutual Connections with Company Employees** - Shared network
+14. **Previous Employers of Company Employees** - Alumni network
+
+---
+
+## VC Partners (5 Triggers)
+
+15. **Inbound Referrals from VC Partners** - VC introductions
+16. **Engaged with VC Partner's Personal Page** - VC engagement
+17. **Mutual Connections with VC Partners** - Shared VC network
+18. **Engaged with VC's Company Page** - VC firm engagement
+19. **Followers of VC's Company Page** - Following VC firm
+
+---
+
+## Advisors (3 Triggers)
+
+20. **Inbound Referrals from Advisors** - Advisor introductions
+21. **Engaged with Advisor's Personal Page** - Advisor engagement
+22. **Mutual Connections with Advisors** - Shared advisor network
+
+---
+
+## Board Members (3 Triggers)
+
+23. **Inbound Referrals from Board Members** - Board introductions
+24. **Engaged with Board Member's Personal Page** - Board engagement
+25. **Mutual Connections with Board Members** - Shared board network
+
+---
+
+## Customer Advisors (3 Triggers)
+
+26. **Inbound Referrals from Customer Advisors** - Customer advisor intros
+27. **Engaged with Customer Advisor's Personal Page** - Engagement
+28. **Mutual Connections with Customer Advisors** - Shared network
+
+---
+
+## Sponsored Company / Joint Marketing (5 Triggers)
+
+29. **Engaged with Sponsored Company's Company Page** - Partner engagement
+30. **Followers of Sponsored Company's Company Page** - Partner followers
+31. **Inbound Referrals from Sponsored Company's Employees** - Partner referrals
+32. **Engaged with Sponsored Company's Employee's Personal Page** - Employee engagement
+33. **Mutual Connections with Sponsored Company's Employees** - Shared network
+
+---
+
+## Your Network (6 Triggers)
+
+34. **Currently Employed at Prospective Company (Decision Maker)** - Direct connection
+35. **Currently Employed at Prospective Company ("Groundswell")** - Internal champion
+36. **Past Employees of a Prospective Company** - Alumni connection
+37. **Mutual Connections with DM at Prospective Company** - Warm intro path
+38. **Prospects Met at a Networking Event** - Event connections
+39. **Engaged with Your Personal Page** - Engaged with your content
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `outreach-4-categories` | Understand Bridgebound category |
+| `personalization-playbooks` | Get Bridgebound messaging |
+| `linkedin-campaign-complete` | Leverage LinkedIn relationships |
+| `outbound-triggers-6` | Compare with Outbound approach |
+
+## Example prompts
+
+```
+Create an outreach strategy leveraging trigger #3 (Referral to Network of Happy Customers).
+```
+
+```
+How do I find mutual connections with VCs in my portfolio company's network?
+```
+
+```
+Write an email using trigger #37 (Mutual Connections with DM at Prospective Company).
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/bridgebound-symptoms-11/SKILL.md
+++ b/skills/alex-vacca/bridgebound-symptoms-11/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: bridgebound-symptoms-11
+title: Bridgebound symptoms and signs triggers
+description: "Use this skill when identifying pain-based opportunities, building problem-aware campaigns, or leveraging influencer audiences — 11 symptoms-and-signs Bridgebound triggers from Flip The Script: overt negatives, lacking positives, and industry influencers."
+category: Signals
+---
+
+# BRIDGEBOUND Category IV: Based on Symptoms & Signs, Pains & Problems (11 Triggers)
+
+## Has an Overt Negative (3 Triggers)
+
+1. **Output (Business Problem)** - Visible business issues (revenue down, churn up)
+2. **Midput (Tactical Problem)** - Process problems (slow delivery, quality issues)
+3. **Input (Root Cause)** - Underlying causes (bad data, wrong tools)
+
+---
+
+## Lacks an Overt Positive (3 Triggers)
+
+4. **Output (Business Problem)** - Missing business outcomes (no growth, flat revenue)
+5. **Midput (Tactical Problem)** - Missing capabilities (no automation, manual processes)
+6. **Input (Root Cause)** - Missing foundations (no data, no tools)
+
+---
+
+## Industry Influencers - Unsponsored (5 Triggers)
+
+7. **Engaged with Industry Influencer's Personal Page** - Influencer engagement
+8. **Followers of Industry Influencer's Personal Page** - Following influencers
+9. **Mutual Connections with Industry Influencer** - Shared network
+10. **Engaged with Industry Influencer's Company Page** - Company engagement
+11. **Followers of Industry Influencer's Company Page** - Company followers
+
+---
+
+## Pain Identification Framework
+
+### Business Problems (Outputs)
+- Revenue declining
+- Churn increasing
+- CAC rising
+- Pipeline shrinking
+
+### Tactical Problems (Midputs)
+- Slow sales cycles
+- Low conversion rates
+- Manual processes
+- Data quality issues
+
+### Root Causes (Inputs)
+- Wrong tools
+- Missing skills
+- Bad data
+- Poor processes
+
+---
+
+## Symptom-Based Messaging
+
+```
+Companies doing [X revenue] in [industry] often struggle with [symptom].
+
+Usually it's because [root cause].
+
+We helped [similar company] fix this by [solution].
+
+Is this something you're seeing?
+```
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `email-writing-frameworks` | "Challenge of Similar Companies" framework |
+| `personalization-6-buckets` | Bucket 6 (Company Level) for symptoms |
+| `josh-braun-copywriting` | Lead with pain principle |
+| `atl-btl-messaging` | Match symptom to seniority |
+
+## Example prompts
+
+```
+Identify symptoms for SaaS companies with declining NRR.
+```
+
+```
+Write an email targeting companies lacking marketing automation (trigger #5).
+```
+
+```
+How do I find companies with visible business problems in my ICP?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/buying-signals-6/SKILL.md
+++ b/skills/alex-vacca/buying-signals-6/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: buying-signals-6
+title: Buying signals ranked by purchase correlation
+description: "Use this skill when prioritizing outreach, building signal-based campaigns, or setting up intent tracking — 6 buying signals ranked by purchase correlation: former customers and alumni users, new leadership, high-intent website visits, tech stack changes, expansion, and hiring or downsizing."
+category: Signals
+---
+
+# 6 Buying Signals (Ranked by Purchase Correlation)
+
+## 1. Former Customers & Alumni Users (Highest Correlation)
+
+**Why it works:**
+- Trust already established + known playbook
+- Faster proof of value
+
+**Query:** Previous users of your product at new companies
+
+**Outreach timing:** Immediately upon detection
+
+---
+
+## 2. New Leadership ≤90 days
+
+**Why it works:**
+- Mandate for early wins
+- Vendor amnesty period
+- Budget air cover for new initiatives
+
+**Query:** LinkedIn job changes, press releases
+
+**Outreach timing:** Days 14-45 (peak engagement window)
+
+---
+
+## 3. High-Intent Website & Content
+
+**Why it works:**
+- BOFU pages: pricing, competitor comparisons, demo, integrations
+- Shows active evaluation
+
+**Query:** Website visitor tracking, content downloads
+
+**Outreach timing:** Within 24-48 hours (highest intent signal)
+
+**Reply rate:** 25-30% (they know you)
+
+---
+
+## 4. Tech Stack Change
+
+**Why it works:**
+- Active change project indicates openness
+- Fresh pain from transition
+- New gaps in workflow
+
+**Query:** BuiltWith, job postings mentioning new tools
+
+**Outreach timing:** 1-2 weeks after detection
+
+---
+
+## 5. Expansion (Raise, New Region/Product)
+
+**Why it works:**
+- Board targets create urgency
+- Scale pain emerges
+- Standardization moment
+
+**Query:** Crunchbase, press releases, job postings
+
+**Outreach timing:** 2-4 weeks after announcement
+
+---
+
+## 6. Hiring or Downsizing
+
+**Why it works:**
+- Hiring = ramp pressure, need efficiency
+- Downsizing = do-more-with-less mandate
+
+**Query:** LinkedIn company growth, layoff news
+
+**Outreach timing:** 1-2 weeks after pattern detected
+
+---
+
+## Signal Performance Benchmarks
+
+| Outreach Type | Reply Rate |
+|---------------|------------|
+| Cold outreach | 6-8% |
+| Signal-based | 18-22% |
+| Multi-signal stacked | 35-40% |
+
+**Key insight:** Signal-based outreach = 3-4x higher contract values
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `clay-buying-signals-5` | Implement signals in Clay workflows |
+| `gtm-plays-11` | Match signals to specific GTM plays |
+| `cold-email-4-sequence` | Build sequences around each signal |
+| `bridgebound-in-market-20` | Deep-dive on in-market triggers |
+
+## Example prompts
+
+```
+Which buying signal should I prioritize for a $50K ACV enterprise deal?
+```
+
+```
+Create an outreach strategy combining job change + funding signals for fintech companies.
+```
+
+```
+How do I detect tech stack changes for companies using Salesforce?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-buying-signals-5/SKILL.md
+++ b/skills/alex-vacca/clay-buying-signals-5/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: clay-buying-signals-5
+title: Clay buying signals
+description: "Use this skill when setting up signal-based Clay tables, prioritizing outreach triggers, or building intent-based campaigns — 5 buying signals for Clay workflows with performance benchmarks and workflow tips."
+category: Signals
+---
+
+# 5 Buying Signals for Clay Workflows
+
+## 1. Recent Job Changes (0-90 days)
+
+**Why it works:**
+- 3x higher response rate
+- Peak engagement: days 14-45
+- They're actively building their stack
+
+**Clay setup:**
+- Track LinkedIn job changes
+- Filter by title/seniority
+- Alert within 24 hours of detection
+
+---
+
+## 2. Company Hiring for Specific Roles
+
+**Why it works:**
+- Signals budget allocation
+- Shows growth trajectory
+- Indicates priority areas
+
+**Clay setup:**
+- Monitor job postings (LinkedIn, Indeed)
+- Filter by relevant roles
+- Track posting volume/velocity
+
+---
+
+## 3. Website Visitors
+
+**Why it works:**
+- 25-30% reply rate (they know you)
+- Highest intent signal
+- Act within 24-48 hours
+
+**Clay setup:**
+- Integrate RB2B or similar
+- Enrich visitor data
+- Auto-route to outreach sequence
+
+---
+
+## 4. Funding Announcements
+
+**Why it works:**
+- New budget available
+- Mandate for growth spending
+- Reach out 2-4 weeks after
+
+**Clay setup:**
+- Crunchbase integration
+- Filter by round size
+- Delay outreach 2-4 weeks
+
+---
+
+## 5. Technology Changes
+
+**Why it works:**
+- Active buying window
+- Fresh pain from transition
+- Open to new solutions
+
+**Clay setup:**
+- BuiltWith integration
+- Track additions/removals
+- Filter by relevant tech
+
+---
+
+## Performance Benchmarks
+
+| Outreach Type | Reply Rate |
+|---------------|------------|
+| Cold outreach | 6-8% |
+| Signal-based | 18-22% |
+| Multi-signal stacked | 35-40% |
+
+---
+
+## Signal Workflow Tips
+
+### Don't Mention Signal Explicitly
+- Prospects get these constantly
+- Instead, use signal to inform timing and angle
+- Reference the underlying pain, not the trigger
+
+### Act Fast
+- Hot signals expire in 3-7 days
+- Job changes: days 14-45 optimal
+- Website visitors: within 24-48 hours
+
+### Stack Signals for Heat Scoring
+- 1 signal = Standard priority
+- 2 signals = High priority
+- 3+ signals = Reach out same day
+
+---
+
+## Signal Priority Matrix
+
+| Signal | Priority | Timing | Reply Rate |
+|--------|----------|--------|------------|
+| Website visitor | Highest | <24 hours | 25-30% |
+| Job change | High | Days 14-45 | 20-25% |
+| Funding | Medium-High | 2-4 weeks | 18-22% |
+| Hiring | Medium | 1-2 weeks | 15-20% |
+| Tech change | Medium | 1-2 weeks | 15-18% |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `buying-signals-6` | Strategic view of all signals |
+| `clay-enrichment-9step` | Integrate signals into workflow |
+| `gtm-plays-11` | Match signals to specific plays |
+| `cold-email-templates-34` | Get templates for each signal |
+
+## Example prompts
+
+```
+Set up Clay to detect job changes and auto-route to outreach.
+```
+
+```
+How do I stack multiple signals for heat scoring in Clay?
+```
+
+```
+Create a workflow that detects funding + hiring signals together.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-enrichment-9step/SKILL.md
+++ b/skills/alex-vacca/clay-enrichment-9step/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: clay-enrichment-9step
+title: Clay enrichment workflow
+description: "Use this skill when building enrichment workflows, setting up Clay tables, or maximizing data quality — the complete 9-step Clay enrichment workflow for 90%+ data coverage plus 58 Clay templates across 8 categories."
+category: Prospecting
+---
+
+# Clay 9-Step Enrichment Workflow (90%+ Coverage)
+
+For detailed templates, see [references/templates.md](references/templates.md).
+
+## Quick Reference
+
+| Step | Action | Tools |
+|------|--------|-------|
+| 1 | Upload & Clean | CSV import |
+| 2 | Company Enrichment | Apollo, Ocean.io, LinkedIn |
+| 3 | People Enrichment | Sales Navigator, Apollo |
+| 4 | Email Waterfall | Apollo, Prospeo, LeadMagic, Findymail |
+| 5 | Email Verification | MillionVerifier |
+| 6 | Phone Numbers | LeadMagic, BetterContact |
+| 7 | Custom Data | Claygent |
+| 8 | Scoring | Lead scoring (100 pts) |
+| 9 | Export | Instantly, LemList, CRM |
+
+## Step 4: Email Waterfall (The Money Step)
+
+**Single finder = 40% coverage**
+**Waterfall = 85%+ coverage**
+
+Sequence: Apollo → Prospeo → LeadMagic → Findymail → Clay patterns
+
+## Step 8: Scoring & Segmentation
+
+**Lead Score (100 points):**
+- Company size match: 25 pts
+- Recent signals: 25 pts
+- Email deliverability: 25 pts
+- ICP fit: 25 pts
+
+**Tiers:**
+- Tier 1 (80-100): Immediate outreach
+- Tier 2 (60-79): Nurture sequence
+- Tier 3 (<60): Long-term nurture
+
+## Pro Tips
+
+- Run in batches of 250 (optimizes Clay credits)
+- Test with 50 records first before full run
+- Timeline: 1,000 prospects = 2-3 hours vs 40+ hours manual
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `clay-buying-signals-5` | Add signal detection to workflow |
+| `lead-sources-guide` | Know where to source initial data |
+| `ai-personalization-prompts` | Use Claygent for AI personalization |
+| `buying-signals-6` | Understand which signals to track |
+
+## Example prompts
+
+```
+Set up a Clay workflow for job change signals with email waterfall.
+```
+
+```
+How do I configure Step 4 (Email Waterfall) to maximize coverage?
+```
+
+```
+Create a scoring model for SaaS companies targeting enterprise accounts.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-enrichment-9step/references/templates.md
+++ b/skills/alex-vacca/clay-enrichment-9step/references/templates.md
@@ -1,0 +1,125 @@
+# 58 Clay Templates (8 Categories)
+
+## 1. List Building & Prospecting (8 templates, Beginner)
+
+| Template | Use Case |
+|----------|----------|
+| Apollo → Clay Import | Bulk import from Apollo |
+| Sales Navigator → Clay | LinkedIn search import |
+| Clay Find Companies | Native company search |
+| Clay Find People | Native people search |
+| Lookalike Finder | Find similar companies |
+| Competitor Customer Finder | Identify competitor users |
+| TAM/SAM Builder | Market sizing |
+| Industry List Builder | Vertical targeting |
+
+---
+
+## 2. Contact Discovery & Enrichment (7 templates, Beginner)
+
+| Template | Use Case |
+|----------|----------|
+| Email Waterfall (5-step) | Maximum email coverage |
+| Phone Enrichment Waterfall | Mobile number discovery |
+| Email Validation Workflow | Verify before sending |
+| LinkedIn Profile Enricher | Add profile data |
+| Title Normalization | Standardize job titles |
+| Company Data Enricher | Add firmographics |
+| Tech Stack Identifier | Discover technologies |
+
+---
+
+## 3. Signal-Based Campaigns (9 templates, Intermediate)
+
+| Template | Use Case | Signal Type |
+|----------|----------|-------------|
+| Job Change Tracker | New role monitoring | High intent |
+| Champion Reactivation | Former customer contacts | Warm |
+| Hiring Signal Detector | Company growth indicators | Medium |
+| Funding Tracker | Investment monitoring | High intent |
+| Tech Stack Change Detector | Technology shifts | Medium |
+| Headcount Growth Trigger | Scaling companies | Medium |
+| News-Based Outreach | PR/announcement triggers | Timely |
+| Leadership Change Tracker | Executive movements | High intent |
+| Multi-Signal Stacker | Combined signal scoring | Highest |
+
+---
+
+## 4. Inbound & Intent Workflows (7 templates, Intermediate)
+
+| Template | Use Case |
+|----------|----------|
+| Website Visitor Follow-up | RB2B integration |
+| Form Abandonment Recovery | Incomplete submissions |
+| Content Engagement Trigger | Download/view tracking |
+| Webinar Attendee Enrichment | Event follow-up |
+| Product Signup Enrichment | Trial user research |
+| Pricing Page Visitor | High-intent detection |
+| Demo Request Enricher | Inbound qualification |
+
+---
+
+## 5. AI Research & Personalization (8 templates, Intermediate-Advanced)
+
+| Template | Use Case |
+|----------|----------|
+| Deep Company Research | Claygent analysis |
+| Personalized Opening Lines | AI-generated intros |
+| Pain Point Identifier | Problem discovery |
+| Competitor Analysis | Market positioning |
+| Recent News Summary | Company updates |
+| LinkedIn Post Analyzer | Content engagement |
+| 10-K/Annual Report Parser | Public company research |
+| Case Study Matcher | Social proof alignment |
+
+---
+
+## 6. Account Intelligence (6 templates, Advanced)
+
+| Template | Use Case |
+|----------|----------|
+| Buying Committee Mapper | Multi-stakeholder ID |
+| Account Scoring Model | Prioritization |
+| Expansion Opportunity Finder | Upsell triggers |
+| Churn Risk Identifier | Retention signals |
+| Competitive Displacement | Switch indicators |
+| Account Health Dashboard | Customer monitoring |
+
+---
+
+## 7. RevOps & Integrations (7 templates, Advanced)
+
+| Template | Use Case |
+|----------|----------|
+| CRM Data Cleaner | Duplicate removal |
+| Salesforce Sync | Bidirectional updates |
+| HubSpot Integration | Marketing alignment |
+| Slack Alerts | Real-time notifications |
+| Spreadsheet Export | Reporting |
+| Webhook Triggers | Custom automations |
+| API Data Push | Custom integrations |
+
+---
+
+## 8. Industry-Specific Plays (6 templates, All Levels)
+
+| Template | Industry | Focus |
+|----------|----------|-------|
+| SaaS Expansion | Technology | Product-led signals |
+| Agency New Business | Services | Budget timing |
+| E-commerce Growth | Retail | Seasonal triggers |
+| Healthcare Compliance | Medical | Regulatory changes |
+| Financial Services | Finance | M&A activity |
+| Manufacturing Scale | Industrial | Capacity signals |
+
+---
+
+## Template Selection Guide
+
+| Goal | Start With | Then Add |
+|------|------------|----------|
+| Build list from scratch | #1 List Building | #2 Contact Discovery |
+| Signal-based outreach | #3 Signal Campaigns | #5 AI Research |
+| Inbound follow-up | #4 Intent Workflows | #2 Enrichment |
+| Account-based selling | #6 Account Intelligence | #3 Signal Campaigns |
+| Data quality | #7 RevOps | #2 Contact Discovery |

--- a/skills/alex-vacca/clay-expert/SKILL.md
+++ b/skills/alex-vacca/clay-expert/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: clay-expert
+title: The Clay expert
+description: "Use this skill when working in Clay — tables, waterfall enrichment, Clay credits and pricing, Claygent, Clayscript formulas, CRM sync, enrichment workflows, integrations, or building data pipelines in Clay. Triggers on 'Clay workflow', 'enrichment waterfall', 'Clay credits', 'Claygent', 'Clayscript', 'Clay + HubSpot', 'Clay + Salesforce', 'Clay table', 'Clay providers', 'enrich in Clay', 'Clay formulas', 'find emails', 'email waterfall', 'phone waterfall', 'lead scoring', 'Clay debugging'."
+category: Prospecting
+contributors:
+  - ivan-falco
+---
+
+Reference files for this skill live in `references/` next to this file — load them with the relative paths given below.
+
+# Clay Platform Expert — Orchestrator
+
+You are an expert Clay consultant who has built 500+ enrichment workflows and manages millions of rows. You route user questions to the appropriate specialized sub-skill for deep, actionable guidance.
+
+## Sub-Skill Routing
+
+Analyze the user's question and load the matching sub-skill. If a question spans multiple areas, load the primary sub-skill first, then reference others as needed.
+
+### 1. Email Waterfall
+**Triggers:** "find emails", "email waterfall", "email enrichment", "email coverage", "provider ordering", "email discovery", "work email", "bounce rate"
+**Load:** Read `references/email-waterfall.md`
+
+### 2. Company Enrichment
+**Triggers:** "company data", "firmographics", "technographics", "company enrichment", "revenue data", "headcount", "industry data", "tech stack", "company research"
+**Load:** Read `references/company-enrichment.md`
+
+### 3. People Enrichment
+**Triggers:** "find contacts", "people enrichment", "decision makers", "LinkedIn enrichment", "title filtering", "seniority", "find people at company", "buying committee"
+**Load:** Read `references/people-enrichment.md`
+
+### 4. Phone Enrichment
+**Triggers:** "phone numbers", "mobile numbers", "phone waterfall", "direct dial", "phone enrichment", "cell phone"
+**Load:** Read `references/phone-enrichment.md`
+
+### 5. Table Setup
+**Triggers:** "create table", "table setup", "column types", "data import", "auto-update", "Clay table", "workbook", "views", "filters", "CSV import", "Chrome extension"
+**Load:** Read `references/table-setup.md`
+
+### 6. Claygent
+**Triggers:** "Claygent", "AI research", "web scraping with AI", "Clay AI agent", "browse web", "research agent", "custom data points"
+**Load:** Read `references/claygent.md`
+
+### 7. Conditional Logic
+**Triggers:** "Clayscript", "formula", "conditional run", "credit saving", "data manipulation", "if/then", "JavaScript formula", "conditional formula", "save credits"
+**Load:** Read `references/conditional-logic.md`
+
+### 8. Scoring
+**Triggers:** "lead scoring", "scoring system", "ICP fit", "segmentation", "lead qualification", "tier assignment", "prioritize leads", "score leads"
+**Load:** Read `references/scoring.md`
+
+### 9. Debugging
+**Triggers:** "not working", "error", "troubleshoot", "debug", "credits wasted", "auto-update issue", "Clay problem", "wrong results", "fix my workflow", "common mistakes"
+**Load:** Read `references/debugging.md`
+
+### 10. Clay Operations
+**Triggers:** "Clay credits", "save credits", "credit optimization", "Clay providers", "which provider", "Clay templates", "workflow template", "batch processing", "Clay cost", "reduce Clay spend", "Clay API keys", "provider ranking", "credit-saving", "provider selection", "Clay pricing strategy"
+**Load:** Read `references/clay-operations.md`
+
+## Cross-Cutting Resources
+
+For questions about pricing, plans, or credit costs, also reference:
+- Read `references/credits-and-pricing.md`
+
+For questions about CRM sync (HubSpot, Salesforce, Pipedrive), also reference:
+- Read `references/crm-sync.md`
+
+For operational guidance (credit optimization, provider rankings, templates), also reference:
+- Read `references/clay-operations-credit-optimization.md`
+- Read `references/clay-operations-guide.md`
+- Read `references/clay-operations-templates.md`
+
+For ready-to-use formulas, table layout, and column naming conventions:
+- Read `references/copy-paste-formulas.md`
+
+For production-tested Claygent prompts (qualification, personalization, tech stack):
+- Read `references/claygent-guide.md` (includes Frontal production prompts section)
+
+## Universal Principles
+
+These apply to ALL Clay workflows regardless of sub-skill:
+
+1. **Conditional formulas on ALL paid integrations** — never run a paid enrichment without checking if data already exists
+2. **Waterfall ordering** — cheapest/fastest provider first, most expensive last
+3. **GPT-4 Mini for 90% of AI tasks** — only use GPT-4/Claude for complex reasoning
+4. **Save all paid data** — push to CRM or Supabase ($30/month for 11.4M+ records), never pay twice
+5. **Test with 50 rows first** — before running on full table
+6. **Formulas cost 0 credits** — always prefer Clayscript over AI for data manipulation
+7. **Single provider = ~40% coverage, waterfall = 85%+** — always use waterfalls for email/phone
+
+## Response Format
+
+1. Recommend the specific Clay features/columns needed
+2. Provide exact setup steps (which enrichment, which inputs, which conditions)
+3. Estimate credit cost and suggest optimizations
+4. Warn about common mistakes (missing conditionals, wrong AI model, auto-update traps)
+5. Include Clayscript formulas when relevant
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/clay-enrichment-workflows.md
+++ b/skills/alex-vacca/clay-expert/references/clay-enrichment-workflows.md
@@ -1,0 +1,146 @@
+# Clay Enrichment Workflows
+
+## 9-Step Workflow (90%+ Data Coverage)
+
+### Step 1: Upload & Clean
+- Import CSV (minimum: company + domain)
+- Remove duplicates
+- Clay auto-standardizes names
+- Clean any errors manually
+
+### Step 2: Company Enrichment Waterfall
+
+Sequence (each fills gaps from previous):
+1. Apollo → employee count, revenue, industry
+2. Ocean.io → missing firmographic data
+3. LinkedIn → recent company updates
+4. Claygent → funding news, press mentions
+5. RB2B → website visitor data (if applicable)
+
+### Step 3: People Enrichment
+- LinkedIn Sales Navigator search within companies
+- Filter: titles, seniority, recent hires (90 days)
+- Apollo as backup source
+- Limit: 3-5 decision makers per company
+
+### Step 4: Email Waterfall (The Money Step)
+- Single finder = 40% coverage
+- Waterfall = 85%+ coverage
+
+Sequence:
+1. Apollo
+2. Prospeo
+3. LeadMagic
+4. Findymail
+5. Clay native patterns
+
+### Step 5: Email Verification
+- MillionVerifier bulk verification (primary)
+- Clay native verification (backup)
+- Remove: invalid, disposable
+- Flag: risky emails for manual review
+- Target: Under 2% bounce rate (critical)
+
+### Step 6: Phone Numbers
+- LeadMagic (primary)
+- BetterContact (for missing)
+- Clay pattern matching for direct lines
+- Verify against do-not-call lists
+
+### Step 7: Custom Data Points (Claygent)
+- Recent job changes (hiring intent)
+- Tech stack indicators
+- Funding/growth signals
+- Competitor mentions
+- Social activity patterns
+
+### Step 8: Scoring & Segmentation
+
+Lead Score Components (100 points total):
+- Company size match: 25 pts
+- Recent signals: 25 pts
+- Email deliverability: 25 pts
+- ICP fit: 25 pts
+
+Tier Assignments:
+- Tier 1 (80-100): Immediate outreach
+- Tier 2 (60-79): Nurture sequence
+- Tier 3 (<60): Long-term nurture
+
+### Step 9: Export & Integrate
+- Export to Instantly/LemList
+- Push high-value leads to CRM
+- Set up Make/n8n automation for ongoing enrichment
+
+## Pro Tips
+- Run in batches of 250 (optimizes Clay credits)
+- Set up templates for repeatable workflows
+- Monitor credit usage (waterfall burns fast)
+- Test with 50 records first before full run
+- Timeline: 1,000 prospects = 2-3 hours vs 40+ hours manual
+
+## 58 Clay Templates (8 Categories)
+
+**1. List Building & Prospecting (8 templates, Beginner)**
+- Apollo → Clay Import
+- Sales Navigator → Clay
+- Clay Find Companies/People
+- Lookalike Finder
+- Competitor Customer Finder
+- TAM/SAM Builder
+
+**2. Contact Discovery & Enrichment (7 templates, Beginner)**
+- Email waterfalls
+- Phone enrichment
+- Email validation workflows
+
+**3. Signal-Based Campaigns (9 templates, Intermediate)**
+- Job Change Tracker
+- Champion Reactivation
+- Hiring Signal Detector
+- Funding Tracker
+- Tech Stack Change Detector
+- Headcount Growth Trigger
+- News-Based Outreach
+- Leadership Change Tracker
+- Multi-Signal Stacker
+
+**4. Inbound & Intent Workflows (7 templates, Intermediate)**
+- Website visitor follow-up
+- Form abandonment recovery
+- Content engagement triggers
+
+**5. AI Research & Personalization (8 templates, Intermediate-Advanced)**
+- Deep company research
+- Personalized messaging at scale
+- AI-generated insights
+
+**6. Account Intelligence (6 templates, Advanced)**
+- Deep-dive research workflows
+- Qualification automation
+
+**7. RevOps & Integrations (7 templates, Advanced)**
+- Data cleanliness automation
+- System connections
+- CRM sync workflows
+
+**8. Industry-Specific Plays (6 templates, All Levels)**
+- Vertical-specific templates
+- Industry trigger configurations
+
+## Delivery-Ready Templates
+
+**General High-Volume:**
+- Leadmagic - Apollo - Bouncebean - Import Template
+
+**Segmented by Title/Industry:**
+- Leadmagic - Apollo Import - Persona Segment
+
+**Email Enrichment:**
+- Leadmagic - Clay - Enrich Prospect Emails
+
+**Standard Sales Nav Workflow:**
+- Prospeo - Sales Nav - Leads Import Template
+
+**Alternative Sales Nav Flow:**
+- Vayne - Sales Nav - Import Template

--- a/skills/alex-vacca/clay-expert/references/clay-operations-credit-optimization.md
+++ b/skills/alex-vacca/clay-expert/references/clay-operations-credit-optimization.md
@@ -1,0 +1,188 @@
+# Clay Operations — Credit Optimization
+
+How to save up to $1,000/month on Clay credits through smart provider selection, conditional logic, and workflow automation.
+
+---
+
+## Credit Management Fundamentals
+
+### Track Usage
+
+Clay's dashboard shows credit consumption per integration. Monitor high-usage tools weekly.
+
+### Pause Auto-Update
+
+- **Why:** Auto-update enriches ALL new entries — wastes credits on duplicates or irrelevant data
+- **How:** Run Settings → toggle off Auto-Update for specific columns until workflows are finalized
+
+### Credit Rollovers
+
+- Accumulate up to **2x your plan's limit** (e.g., 50K → 100K) for seasonal campaigns
+- Buy mid-cycle credits at **1.5x standard rate** during surges without upgrading
+
+### Downgrade with Retention
+
+When reducing your plan, you retain up to **2x the new plan's credit limit** (e.g., downgrade from 50K/month to 25K/month but keep 50K credits temporarily).
+
+---
+
+## Optimizing Enrichments with Conditional Logic
+
+### Multi-Stage Filtering (Tiered Enrichments)
+
+Start with free/low-cost tools. Only trigger expensive options if free tools fail.
+
+**Example workflow:**
+1. **Step 1:** Clearbit (free) → fetch company domains
+2. **Step 2:** If Clearbit fails → Google Search (1 credit)
+3. **Step 3:** Enrich only verified data with LeadMagic (~$0.009/record)
+
+### AI-Powered Conditional Rules
+
+Use Clay's AI Formula Writer to create logic-based workflows:
+
+- `"Only enrich if LinkedIn URL exists"`
+- `"Skip enrichment for companies with <50 employees"`
+- `IF(Clearbit Domain = blank, Run Google Search, "Skip")`
+
+### Avoid Redundant Enrichments
+
+- **Lookup Columns:** Integrate existing CRM data (Salesforce, HubSpot) to skip re-enriching the same records
+- **Exclude low-value leads:** Filter out companies without emails or with <10 employees BEFORE enriching
+- **Check for existing data:** Before running an enrichment, check if the column already has a value
+
+---
+
+## Cost-Efficient Alternatives
+
+### Zero-Credit Options
+
+| Task | Tool | Cost |
+|---|---|---|
+| News/scraping | Serper API | 0 |
+| AI generation | GPT 4o-mini (API) | 0 |
+| Domain lookup | Clearbit | 0 |
+| Email verification | Reoon (one-time AppSumo purchase) | 0 |
+| Google Maps scraping | Outscraper | 0 |
+| Tech stack data | BuiltWith links | 0 |
+| Cell manipulation | Clay AI Formula Writer | 0 |
+| LinkedIn ad tracking | Serper API | 0 |
+
+### Low-Cost Replacements
+
+| Instead Of | Use | Savings |
+|---|---|---|
+| LinkedIn enrichment for company growth | LeadMagic ($0.009) | ~90% cost reduction |
+| Clay email finder | Trykitt.ai via API ($0.004) | ~60% cheaper |
+| Google Search + GPT | Serper API + GPT 4o-mini ($0.004) | Much cheaper |
+| Semrush for e-com (2 credits) | Store Leads (1 credit) | 50% savings |
+
+### HTTP/API Free Actions
+
+Perform non-credit-consuming tasks like:
+- Normalizing domains
+- Generating notes
+- Data formatting
+- Replace Clay's email finder with Findymail or Prospeo via API keys
+
+---
+
+## Workflow Automation
+
+### Automate with Trigify.io
+
+Set up webhook-based workflows for:
+- Tracking new funding rounds
+- Monitoring hiring trends or competitor updates
+- Alerts for new-in-role leads
+- Evergreen campaigns (reduces manual intervention)
+
+### Standardize with Templates
+
+Pre-built templates minimize setup time and avoid redundant workflows:
+
+- **Domain Name Template:** Clearbit → Serper → enrich domain data
+- **LinkedIn Ads Template:** Serper API for ad campaign tracking
+- **Email Waterfall Template:** Trykitt.ai → Prospeo → Datagma → LeadMagic → Reoon verify
+
+### AI Formula Prompts
+
+Automate data personalization and trend detection:
+
+- **Extract first names:** `"Extract the first name from {{Full Name}}"`
+- **Hiring trends:** `"If {{Job Title}} includes 'Manager' and {{Company Size}} > 200, flag for outreach"`
+- **Industry categorization:** Use AI to categorize companies by vertical from description
+
+---
+
+## Batch Processing: The 5-for-1 Workflow
+
+Chain multiple enrichments in one streamlined workflow:
+
+1. **Find emails** — Trykitt.ai or Prospeo
+2. **Verify emails** — Reoon Email Verifier
+3. **Fetch LinkedIn data** — Clay LinkedIn integration
+4. **Enrich tech stacks** — BuiltWith
+5. **Append headcount** — LinkedIn + PredictLeads
+
+---
+
+## Scraping & Data Sourcing Hacks
+
+### Google Maps Scraping
+Use Outscraper (free with login) for bulk location scraping.
+
+### Amazon / E-Commerce Data
+Pair SmartScout (seller insights) with Store Leads (traffic trends).
+
+### Competitor Profiling
+Serper API + GPT 4o-mini for automated competitor insights (~$0.004/scrape).
+
+### Tech Stack Data
+Bypass expensive enrichments by using BuiltWith (free) and pairing with GPT 4o-mini for analysis.
+
+### LinkedIn Data
+Pull headcounts for just 1 credit using Clay's built-in LinkedIn integration instead of pricier HR tools.
+
+### Ethical Scraping
+
+- **Residential proxies:** Use tools like Bright Data's Scraping Browser to rotate IPs
+- **Random delays:** Introduce 2–5 second delays between scrapes to avoid detection
+- **CAPTCHA avoidance:** Mimic human behavior patterns
+
+---
+
+## Weekly Audit Checklist
+
+- [ ] Review credit usage on Clay dashboard
+- [ ] Identify failed API calls or high-cost enrichments
+- [ ] Check for redundant enrichments across tables
+- [ ] Verify auto-update is off on non-finalized tables
+- [ ] Set alerts for high-consumption tools (Semrush: 2 credits, Zenrows: 3 credits)
+- [ ] Review conditional logic — are free tools being tried first?
+- [ ] Check Lookup Columns — is CRM data being reused?
+
+---
+
+## Key Takeaways
+
+1. **Prioritize free tools** — Serper, Clearbit, BuiltWith, Reoon, Clay AI Formulas
+2. **Optimize with conditional logic** — tiered enrichments, AI rules, modular templates
+3. **Automate with purpose** — Trigify.io webhooks, evergreen campaigns
+4. **Monitor and audit weekly** — credit dashboard, failed calls, inefficiencies
+5. **Invest in lifetime solutions** — Reoon (one-time buy), Bright Data proxies
+6. **Use API keys** — Replace Clay-native tools with cheaper API alternatives when possible
+
+---
+
+## Learning Resources
+
+- **Clay University** — CRM enrichment, automated outbound, intent data modules
+- **Clay Help Center** — [docs.clay.com](https://docs.clay.com/en/)
+- **Clay Templates** — [clay.com/templates](https://www.clay.com/templates)
+- **Frontal Coaching** — [frontal.so/coaching](https://www.frontal.so/coaching)
+- **Bright Data** — [brightdata.com](https://brightdata.com/) (scraping browser, proxies)
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/clay-expert/references/clay-operations-guide.md
+++ b/skills/alex-vacca/clay-expert/references/clay-operations-guide.md
@@ -1,0 +1,219 @@
+# Clay Operations — Guide
+
+How to use Clay effectively: choosing the right data providers, managing credits, and building efficient GTM workflows.
+
+For the full template library, see [clay-operations-templates.md](clay-operations-templates.md).
+For credit optimization deep dive, see [clay-operations-credit-optimization.md](clay-operations-credit-optimization.md).
+
+---
+
+## Choosing Data Providers
+
+### The Principle
+
+Don't guess which provider is best — use [Clay's Data Tests](https://www.clay.com/data-tests) to see real performance by use case, region, and input type.
+
+### Best Providers by Category (2025)
+
+**Mobile Phone — By Region:**
+1. BetterContact
+2. Datagma
+3. Forager
+4. Prospeo
+5. SMARTe
+
+**European Mobile Phone — By Country:**
+1. BetterContact
+2. Zeliq
+3. Prospeo
+4. Pubrio
+5. SMARTe
+
+**European Work Email — By Country:**
+1. BetterContact
+2. Prospeo
+3. SMARTe
+4. Zeliq
+5. Hunter
+
+**Work Email — By Region:**
+1. Hunter
+2. Prospeo
+3. Kitt AI
+4. FullEnrich
+5. Zeliq
+
+**Non Catch-All Email Verifiers:**
+1. ZeroBounce
+2. Findymail
+3. LeadMagic
+4. Listmint
+5. Hunter
+
+**Catch-All Email Verifiers:**
+1. Kitt AI
+2. Findymail
+3. LeadMagic
+4. Enrichley
+5. Enrow
+
+**Professional Profile Finder — By Input Type:**
+1. Wiza
+2. Snov.io
+3. ReverseContact
+4. People Data Labs
+5. Mixrank
+
+**Personal Email Finder (2024):**
+1. People Data Labs
+2. Mixrank
+3. Limadata
+4. Forager
+
+**Work Email — By Company Size (2024):**
+1. Wiza
+2. Snov.io
+3. Prospeo
+4. People Data Labs
+5. LeadMagic
+
+---
+
+## Complete Tool Table
+
+The best tool for each data point, with cost and notes.
+
+| Data Point | Best Tool | Cost (Credits) | Notes |
+|---|---|---|---|
+| **News** | Serper (API) | 0 | Trustpilot/Crunchbase scraping, domain searches |
+| **Gen AI** | GPT 4o-mini (API) | 0 | Generative tasks; fallback to Neon only when 4o-mini fails |
+| **Company Growth** | LeadMagic | ~$0.009/enrichment | Replaces LinkedIn enrichment for ~90% cost savings |
+| **Finding Email** | Trykitt.ai, Prospeo, Datagma | $0.004–$0.006/email | Trykitt.ai ($0.004) is most cost-efficient |
+| **Email Verification** | Reoon, Debounce (API) | 0 (Reoon: one-time buy) | Buy Reoon on AppSumo for unlimited verifications |
+| **Domain Name** | Clearbit, Serper (API) | 0 | Start Clearbit (free), fallback to Serper |
+| **Website Competitors** | Serper API + GPT 4o-mini | ~$0.004/scrape | Replaces Google Search + GPT combo |
+| **Website Data** | Store Leads | 1 | Better for e-com than Semrush (2 credits) |
+| **Google Maps Scraping** | Outscraper | 0 | Free with login credentials |
+| **Technology** | BuiltWith links, GPT 4o-mini | ~$0.005/scrape | Free tech-stack data + GPT for analysis |
+| **Company Enrichment** | LeadMagic, Trigify.io | ~$0.009/enrichment | Trigify.io for webhook automation |
+| **Contact Enrichment** | Export Apollo.io, LeadMagic | ~$20/10K leads | Apollo bulk LinkedIn data at reduced cost |
+| **Headcount Data** | LinkedIn, PredictLeads | 1 | Combine for granular data |
+| **Fundraising Data** | Intellizence, Polaris API | 1 | Polaris ~1 credit/7 data points |
+| **Site Traffic (e-com)** | Store Leads | 1 | Use before Semrush for efficiency |
+| **Reviews** | Serper API + GPT 4o-mini | ~$0.004/scrape | Summarize Capterra, G2, etc. |
+| **Cell Data Manipulation** | Clay AI Formula Writer | 0 | Automate transformations |
+| **LinkedIn Ads** | Serper (API) | 0 | Track ad campaigns |
+| **Open Jobs** | Export Apollo.io, PredictLeads | ~$20/10K leads | Bulk job posting data |
+
+### Key Principle: Free First, Paid Second
+
+1. **Start with free tools:** Serper, Clearbit, BuiltWith, Clay AI Formulas
+2. **Then low-cost:** LeadMagic ($0.009), Trykitt.ai ($0.004), Prospeo
+3. **Then standard:** Clay enrichments (1 credit), LinkedIn (1 credit)
+4. **Last resort:** Semrush (2 credits), Zenrows (3 credits)
+
+---
+
+## Waterfall Strategy
+
+For any data point, use multiple providers in sequence — stop when you get a result.
+
+### Email Waterfall Example
+
+1. Trykitt.ai ($0.004) → if no result:
+2. Prospeo ($0.005) → if no result:
+3. Datagma ($0.006) → if no result:
+4. LeadMagic ($0.009)
+5. Verify with Reoon (free) or Debounce
+
+### Domain Waterfall Example
+
+1. Clearbit (free) → if no result:
+2. Serper API (free) → if no result:
+3. Google Search (1 credit)
+
+### Tech Stack Detection Waterfall
+
+1. HG Insights (primary — enterprise-focused, best for Adobe/Salesforce/ServiceNow)
+2. BuiltWith (validation — web-visible tech, marketing, pixels)
+3. PredictLeads (supplemental — job posting analysis, hiring signals + tech requirements)
+
+---
+
+## The 5 Buying Signals That Matter
+
+| Signal | Reply Rate Impact | Best Timing |
+|---|---|---|
+| Recent Job Changes (0–90 days) | 3x higher response | Days 14–45 (building their stack) |
+| Hiring for Specific Roles | Signals budget + growth | Act within days of posting |
+| Website Visitors | 25–30% reply rate | Same day (they know you) |
+| Funding Announcements | Fresh capital to spend | 2–4 weeks after announcement |
+| Technology Changes | Active buying window | Act immediately |
+
+**Performance comparison:**
+- Cold prospects: 6–8% reply rate
+- Signal-based: 18–22% reply rate
+- Multi-signal stacked: 35–40% reply rate
+
+---
+
+## Essential Clay Workflows
+
+### Batch Processing: The 5-for-1 Credit Workflow
+
+Chain multiple enrichments in one streamlined flow:
+1. Find emails (Trykitt.ai or Prospeo)
+2. Verify emails (Reoon)
+3. Fetch LinkedIn data
+4. Enrich company tech stacks (BuiltWith)
+5. Append headcount data
+
+### Competitor Analysis Workflow
+
+1. Serper API (0 credits) → scrape competitor data from Trustpilot/Google Maps
+2. GPT 4o-mini → automated summarization (~$0.004/scrape)
+3. LinkedIn integration (1 credit) → track competitor hiring trends
+
+### E-Commerce Tracking Workflow
+
+1. Store Leads (1 credit) → traffic insights
+2. Semrush (2 credits) → deeper performance metrics (only if needed)
+3. Trigify.io webhooks → automate recurring updates
+
+### Fundraising Prospecting Workflow
+
+1. Intellizence (1 credit) → identify fundraising opportunities
+2. LeadMagic ($0.009/record) → enrich company and contact details
+3. Lookup Columns → prevent duplicate enrichments
+
+---
+
+## Blocklist Best Practices
+
+**Non-negotiable:** Build your blocklist before your first campaign.
+
+**What to include per entry:**
+- Domain or email
+- Reason (opted out, competitor, wrong fit, bounce)
+- Date added
+- Campaign where blocked
+- Added by (team member)
+
+**Saves 10+ hours/week** by automating blocklist checks in every Clay table.
+
+---
+
+## Key Resources
+
+- [Clay Data Tests](https://www.clay.com/data-tests) — provider performance by use case
+- [Clay Help Center](https://docs.clay.com/en/) — credit tracking and tutorials
+- [Clay Templates Gallery](https://www.clay.com/templates) — official templates
+- [Clay University](https://www.clay.com/university) — learning modules
+- [Frontal AI Sales Tools](https://www.frontal.so/ai-sales-tools) — tool glossary
+- [Frontal 55 B2B Data Sources](https://www.frontal.so/b2b-data-sources) — data source guide
+- [Frontal 37 Sales Triggers](https://www.frontal.so/sales-triggers) — signal reference
+- [Trigify.io Guide](https://b2b-boosted.subpage.co/trigify-social-signals) — campaign automation
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/clay-expert/references/clay-operations-templates.md
+++ b/skills/alex-vacca/clay-expert/references/clay-operations-templates.md
@@ -1,0 +1,206 @@
+# Clay Operations — Templates Library
+
+58 battle-tested Clay templates organized by skill level and category.
+
+---
+
+## Skill Levels
+
+- ⭐ **Beginner** — Core workflows everyone needs
+- ⭐⭐ **Intermediate** — Signal-based and intent workflows
+- ⭐⭐⭐ **Advanced** — AI research, account intelligence, RevOps
+
+---
+
+## Quick Start Packs
+
+**First Campaign Pack (Beginner):**
+Apollo Import + Email Waterfall + Validation + Sequencer Push
+→ Get first campaign live in under 2 hours
+
+**Signal-Based Pack (Intermediate):**
+Job Change Tracker + Website Visitors + LinkedIn Engagers
+→ Boost reply rates from 7% to 20%+
+
+**Full GTM Flywheel Pack (Advanced):**
+10+ templates for complete inbound-led outbound motion
+→ The system Frontal uses internally
+
+---
+
+## Category Overview
+
+| Category | Templates | Level |
+|---|---|---|
+| List Building & Prospecting | 8+ | ⭐ |
+| Contact Discovery & Enrichment | 7 | ⭐ |
+| Signal-Based Campaigns | 9 | ⭐⭐ |
+| Inbound & Intent Workflows | 7 | ⭐⭐ |
+| AI Research & Personalization | 8 | ⭐⭐–⭐⭐⭐ |
+| Account Intelligence | 6 | ⭐⭐⭐ |
+| RevOps & Integrations | 7 | ⭐⭐⭐ |
+| Industry-Specific Plays | 6 | All |
+| **Total** | **58** | |
+
+---
+
+## ⭐ List Building & Prospecting
+
+Finding and building lists of target accounts and contacts.
+
+| Template | Difficulty | Description |
+|---|---|---|
+| Apollo → Clay Import (LeadMagic) | ⭐ | Standard Apollo export to Clay enrichment |
+| Sales Navigator → Clay (Prospeo) | ⭐ | LinkedIn Sales Nav scrape and enrich |
+| Clay Find Companies | ⭐ | ICP-based company discovery using Clay native |
+| Clay Find People | ⭐ | Title-based people discovery |
+| Lookalike Company Finder | ⭐⭐ | Find similar companies via Ocean.io |
+| Competitor Customer Finder | ⭐⭐ | Find companies using competitor products |
+| TAM/SAM Builder | ⭐⭐ | Map total addressable market with enrichment |
+| Clean Company Names (No Credits) | ⭐ | Normalize company names without spending credits |
+| Email Waterfall Template | ⭐ | Create your own multi-provider email waterfall |
+| Find People Clay + Emails | ⭐ | Find people using Clay native + email enrichment |
+| Local Business (Google Maps/Clay) | ⭐ | Local biz using Google Maps + owner emails |
+| Local Business (Openmart) | ⭐ | US local biz via Openmart + owner emails |
+| eCommerce (Store Leads) | ⭐ | E-com brands via Store Leads + decision makers |
+| Look-a-Like Companies (Ocean + Clay) | ⭐⭐ | Lookalike discovery using Ocean.io |
+| Finding Product Competitors (HS Insights) | ⭐⭐ | Competitive product discovery |
+| Mapping Job Titles to Personas | ⭐⭐ | Map raw titles to buying personas |
+| Finding Niche Prospects | ⭐⭐ | Niche market prospecting |
+
+**Data sources:** Apollo.io, LinkedIn Sales Nav, LeadMagic, Prospeo, Vayne, Ocean.io, Clay Native, Store Leads, Openmart, Google Maps
+
+**Pro tips:**
+- Always duplicate templates before using — never edit the original
+- Start broad, filter down — pull larger lists then qualify in Clay
+- Use multiple sources — Apollo + Sales Nav often give different results
+- Check volume first — ensure at least 500–1,000 accounts before building
+
+---
+
+## ⭐ Contact Discovery & Enrichment
+
+Finding emails, phones, and enriching contact data.
+
+| Template | Difficulty | Description |
+|---|---|---|
+| LinkedIn Profile Enricher | ⭐ | Enrich with LinkedIn data (premium status, posts) |
+| Champion Identifier | ⭐⭐⭐ | Find previous customers at new companies |
+
+**Key insight:** The waterfall approach gets 85–90% email coverage vs 40% from a single source.
+
+---
+
+## ⭐⭐ Signal-Based Campaigns
+
+Trigger outreach when buying signals appear.
+
+| Template | Difficulty | Signal Type |
+|---|---|---|
+| Job Change Tracker | ⭐⭐ | People who changed jobs (0–90 days) |
+| Champion Reactivation | ⭐⭐ | Past customers at new companies |
+| Hiring Signal Detector | ⭐⭐ | Companies posting relevant jobs |
+| Funding Announcement Tracker | ⭐⭐ | Series A-C funding rounds |
+| Tech Stack Change Detector | ⭐⭐⭐ | New tool adoption or competitor removal |
+| Headcount Growth Trigger | ⭐⭐ | Companies crossing growth thresholds |
+| News-Based Outreach | ⭐⭐⭐ | Companies in relevant news |
+| Leadership Change Tracker | ⭐⭐ | New VP/C-level appointments |
+| Multi-Signal Stacker | ⭐⭐⭐ | Combine 3+ signals for hot prospects |
+
+**Performance comparison:**
+- Cold prospects: 6–8% reply rate
+- Signal-based: 18–22% reply rate
+- Multi-signal stacked: 35–40% reply rate
+
+**Pro tips:**
+- Don't mention the signal in the email — prospects get these constantly
+- Act fast — hot signals expire in 3–7 days
+- Stack signals for heat scoring — 3+ signals = reach out same day
+- Job changes peak at days 14–45 — new hires are building their stack
+
+---
+
+## ⭐⭐ Inbound & Intent Workflows
+
+Capture and convert people showing interest.
+
+| Template | Difficulty | Description |
+|---|---|---|
+| 7 templates | ⭐⭐ | Website visitors, content engagement, intent signals |
+
+---
+
+## ⭐⭐–⭐⭐⭐ AI Research & Personalization
+
+Deep research and personalized messaging at scale.
+
+| Template | Difficulty | AI Function |
+|---|---|---|
+| Pre-Call Research Table | ⭐⭐ | LinkedIn URL → full prospect intel for sales calls |
+| Customer Domain → Campaign Ideas | ⭐⭐⭐ | Input customer domain → 3 campaign ideas output |
+| Pain Point Finder | ⭐⭐⭐ | AI research for contact-level challenges |
+| Company Research Deep Dive | ⭐⭐ | USPs, goals, metrics, ICP via Perplexity |
+| AI Campaign Idea Generator | ⭐⭐⭐ | Generate tailored campaign angles per prospect |
+| Case Study Matcher | ⭐⭐⭐ | Match prospects to relevant case studies |
+| Personalized First Line Writer | ⭐⭐ | AI-generated opening lines |
+| Twain Integration Table | ⭐⭐⭐ | Full AI copywriting for email + LinkedIn |
+
+**The "Golden Prompt" Framework for campaign idea generation:**
+1. **USPs** — What makes them unique?
+2. **Goals** — What are they trying to achieve?
+3. **Metrics** — What KPIs do they track?
+4. **ICP** — Who do they sell to?
+5. **Current challenges** — What are their pain points?
+
+**Pro tips:**
+- LinkedIn URLs required for best results (95% success rate)
+- Quality prompting is essential — the campaign idea drives all research
+- Use majority rules for accuracy — run Perplexity, Claude, AND GPT
+- Twain outperforms raw Claude at scale (Claude struggles after 500+ contacts)
+
+---
+
+## ⭐⭐⭐ Account Intelligence
+
+Deep-dive research and qualification on target accounts.
+
+| Template | Difficulty | Use Case |
+|---|---|---|
+| ICP Fit Scorer | ⭐⭐ | Score accounts against ICP criteria |
+| Tech Stack Analysis | ⭐⭐⭐ | HG Insights → BuiltWith → PredictLeads waterfall |
+| Competitive Intelligence | ⭐⭐⭐ | Track competitor customers/moves |
+| Account Tiering System | ⭐⭐⭐ | Tier 1/2/3 qualification with AI |
+| Closed-Won Pattern Analysis | ⭐⭐⭐ | Find patterns in won deals |
+| Market Research Table | ⭐⭐⭐ | Industry/segment analysis |
+
+---
+
+## ⭐⭐⭐ RevOps & Integrations
+
+Keep data clean and systems connected.
+
+| Template | Difficulty | Function |
+|---|---|---|
+| Master Blocklist System | ⭐⭐ | Central blocklist management |
+| CRM Enrichment Sync (HubSpot) | ⭐⭐⭐ | Auto-enrich CRM contacts |
+| CRM Enrichment Sync (Salesforce) | ⭐⭐⭐ | Auto-enrich CRM contacts |
+| Clay → Instantly Push | ⭐⭐ | Auto-send qualified leads to sequences |
+| Clay → Smartlead Push | ⭐⭐ | Auto-send qualified leads to sequences |
+| Deduplication Table | ⭐⭐ | Remove duplicates across sources |
+| Slack Notification Workflow | ⭐⭐ | Alert team on hot prospects |
+
+**Pro tips:**
+- Blocklist is non-negotiable — build it before your first campaign
+- Dedupe on full name + email — catches most duplicates
+- CRM sync should enrich, not overwrite — protect manual data entry
+- Slack alerts for hot prospects — speed to lead matters
+
+---
+
+## Industry-Specific Plays
+
+Ready-to-use templates for specific verticals (6 templates across various industries).
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/clay-expert/references/clay-operations.md
+++ b/skills/alex-vacca/clay-expert/references/clay-operations.md
@@ -1,0 +1,60 @@
+# Clay Operations
+
+You help users optimize their Clay platform usage: credit management, provider selection, and pre-built workflow templates.
+
+## Reference
+
+Read these resources based on the user's question:
+
+- **Credit optimization, cost reduction, conditional logic for savings** → Read `clay-operations-credit-optimization.md`
+- **Data provider rankings, waterfall strategies, buying signals, blocklists** → Read `clay-operations-guide.md`
+- **58 pre-built templates, quick start packs, workflow catalog** → Read `clay-operations-templates.md`
+
+## Key Concepts
+
+### Credit Optimization
+- Multi-stage filtering: free tools first, expensive as fallback
+- AI-powered conditional logic for intelligent enrichment routing
+- Batch processing (5-for-1 workflows combining multiple enrichments)
+- Lookup columns to prevent duplicate enrichments
+- Prioritize free tools: Serper, Clearbit, BuiltWith, Reoon, Clay AI Formulas
+- Use API keys to replace expensive Clay-native tools
+
+### Provider Rankings (2025)
+| Data Type | Top Providers |
+|-----------|--------------|
+| Email | Hunter, Prospeo, Kitt AI, FullEnrich |
+| Mobile phones | BetterContact, Datagma, Forager, Prospeo |
+| Company growth | LeadMagic (~$0.009/enrichment) |
+| Email verification | ZeroBounce, Findymail, LeadMagic |
+
+### Template Categories (58 total)
+1. List Building & Prospecting (8+)
+2. Contact Discovery & Enrichment (7)
+3. Signal-Based Campaigns (9)
+4. Inbound & Intent Workflows (7)
+5. AI Research & Personalization (8)
+6. Account Intelligence (6)
+7. RevOps & Integrations (7)
+8. Industry-Specific Plays (6)
+
+### 3 Quick Start Packs
+- **First Campaign** (beginner): Apollo import → enrich → validate → push
+- **Signal-Based** (intermediate): Job changes + funding + hiring triggers
+- **Full GTM Flywheel** (advanced): Multi-source + scoring + CRM sync
+
+## Examples
+
+**Example 1:** "How do I reduce my Clay costs?"
+→ Read credit-optimization guide. Audit current usage, implement conditional logic, switch to API keys, enable batch processing.
+
+**Example 2:** "Which email provider should I use in Clay?"
+→ Read operations guide. Recommend waterfall: cheapest first (Hunter) → mid-tier (Prospeo) → premium (FullEnrich). Always with conditional checks.
+
+**Example 3:** "Give me a Clay template for job change outreach"
+→ Read templates catalog. Route to Signal-Based Campaigns section. Provide the job change tracker template with days 14-45 window.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/claygent-guide.md
+++ b/skills/alex-vacca/clay-expert/references/claygent-guide.md
@@ -1,0 +1,187 @@
+# Claygent Guide
+
+## What is Claygent?
+
+AI research agent that combines Google Search, ChatGPT, and web scraping into a single tool. It browses the web, finds public data, and reports results. Use Claygent when data doesn't exist in standard databases and you need real-time, nuanced information from the web.
+
+## How to Access
+
+1. Open a table
+2. Go to the Enrichment panel (right side)
+3. Select "Claygent" under the AI section
+
+## Model Selection
+
+| Model | When to Use | Cost |
+|---|---|---|
+| **Claygent Neon** | 90% of tasks — extraction, formatting, simple lookups | Lowest |
+| **GPT-4 Mini** | Slightly more complex reasoning, still cheap | Low |
+| **GPT-4** | Deep reasoning, multi-step analysis | Higher |
+| **Claude Opus** | Deep reasoning, nuanced interpretation | Higher |
+
+**Rule: Use Neon or GPT-4 Mini for everything.** Advanced models are benchmarked for solving calculus — you just want to say "I saw on your website you help fitness enthusiasts breathe better." Fix problems with better prompts, not more expensive models.
+
+## Credit Cost
+
+- Simple questions (yes/no, single lookup): 1 credit
+- Deeper analyses (multi-page scraping, reasoning): 2-3 credits
+- Always use conditional runs to avoid wasting credits on empty rows
+
+## Claygent vs Standard Enrichments
+
+| Use Case | Use This |
+|---|---|
+| Email/phone/company data | Standard enrichments (Apollo, Prospeo, etc.) |
+| Data exists in a database | Standard enrichments |
+| Data doesn't exist in databases | **Claygent** |
+| Need real-time web context | **Claygent** |
+| Very specific/nuanced information | **Claygent** |
+| Scraping a specific webpage | **Claygent** |
+
+## 8 Prompting Rules (Eric Noski)
+
+### Rule 1: The 10-Minute Manual Research Rule
+Ask yourself: "What would I do if I researched this person for 10 minutes?" What information would I look for? THEN automate that with Claygent. Never guess what you could do — start from manual research.
+
+### Rule 2: One Task Per Claygent
+**Bad:** Claygent that checks site content + decides if e-commerce + classifies industry
+**Good:** Claygent #1: Retrieve site content → Use AI #2: Is it a CPG? → Use AI #3: What products? → Use AI #4: What industry?
+
+AI fails when given too many tasks. GPT-4 Mini costs almost nothing — separate the tasks.
+
+### Rule 3: Use "purple" as Null Keyword
+When nothing is found, output a specific keyword like **"purple"** instead of letting AI say "No information found" in 100 different ways. Makes downstream filtering easy.
+
+```
+If no case study found, output 'purple'
+```
+
+### Rule 4: Always Include Examples in Prompts
+Even a mediocre prompt becomes excellent with 3-4 examples. Manually research a few cases, include them in the prompt. Shows AI exactly what you want.
+
+### Rule 5: Use the Metaprompter
+1. Go to ChatGPT
+2. Explain what you want to accomplish
+3. Ask: "Create a prompt for this"
+4. Ask: "What questions do you have to improve this prompt?"
+5. Answer the questions → improved prompt
+
+### Rule 6: Ask for Reasoning Before the Answer
+"Tell me the reasoning why you think it's this kind of company before you give me the final answer." AI predicts the next word — by explaining first, it has more context to answer better.
+
+### Rule 7: Prepare for Edge Cases
+20% of the work = putting integrations together. **80% = adjusting the AI.** Review outputs constantly — as soon as an output doesn't look right, adjust the prompt.
+
+### Rule 8: Iterate Without Spending Credits
+Use the builder to test and iterate on prompts before running on the full table. Test on 1-3 rows in the builder until the output is exactly what you want.
+
+## Prompt Template
+
+```
+Visit {{company_url}}.
+
+[Specific instruction — one task only]
+
+Return format: [text/number/URL/true-false]
+
+If not found, output 'purple'.
+
+Examples:
+- Input: Acme Corp → Output: "Series B, $25M, 2024"
+- Input: Widget Inc → Output: "purple"
+```
+
+## Output Formatting
+
+Available formats: text, number, URL, true/false, custom
+
+Always specify the exact format you want in the prompt to avoid inconsistent outputs.
+
+## Frontal Production Prompts
+
+### Company Qualification
+```
+You are qualifying companies for a B2B outbound campaign. Based on the company information provided, assign a tier:
+
+Tier 1: B2B software companies with 40+ headcount that sell to other businesses
+Tier 2: B2B companies that sell digitally but are not software companies
+Tier 3: Companies in a relevant industry but not our ideal fit
+
+Company: {{Company Name}}
+Industry: {{Industry}}
+Employee Count: {{Employee Count}}
+Description: {{Company Description}}
+
+Return ONLY: "Tier 1", "Tier 2", or "Tier 3" followed by a one-sentence reason.
+```
+
+### Contact Qualification
+```
+Based on the following job title, assign a seniority tier:
+
+Tier 1: C-level, VP, Founder, Head of, Director (decision-makers with budget authority)
+Tier 2: Manager, Senior (influencers who can champion internally)
+Tier 3: Associate, Coordinator, Specialist (end users, not decision-makers)
+
+Title: {{Title}}
+
+Return ONLY: "Tier 1", "Tier 2", or "Tier 3"
+```
+
+### Personalized Opening Line
+```
+Write a cold email opening line (1 sentence, under 20 words) based on this signal:
+
+Signal: {{Signal/Trigger}}
+Company: {{Company Name}}
+Person: {{First Name}}, {{Title}}
+
+Rules:
+- Reference the signal naturally, don't force it
+- Sound like a human, not AI
+- Don't pitch anything yet
+- Don't start with "I noticed" or "I saw"
+- Make it about THEM, not you
+```
+
+### Tech Stack Detection (0 credits via GPT-4o-mini API)
+```
+Visit this BuiltWith URL and list the key technologies used by this company:
+{{BuiltWith URL}}
+
+Return a comma-separated list of the top 10 most relevant technologies (CRM, marketing automation, analytics, web framework only). Ignore tracking pixels and common libraries.
+```
+
+---
+
+## Examples
+
+**Example 1: Detect free trial availability**
+```
+Visit {{company_url}}. Does this company offer a free trial?
+Look for: "free trial", "try for free", "start free", "demo", "trial period".
+Return 'Yes' if found, 'No' if not found, 'purple' if the page cannot be loaded.
+```
+
+**Example 2: Extract case study industries**
+```
+Visit {{company_url}}/customers or {{company_url}}/case-studies.
+List the industries of the first 3 case studies shown.
+Format: "Industry1, Industry2, Industry3"
+If no case studies page exists, output 'purple'.
+```
+
+**Example 3: Check for competitor mentions**
+```
+Search Google for: site:{{company_domain}} "{{competitor_name}}"
+Does this company mention {{competitor_name}} on their website?
+Return 'Yes' if found with the specific page URL, 'No' if not found.
+```
+
+**Example 4: Find hiring signals from careers page**
+```
+Visit {{company_url}}/careers or {{company_url}}/jobs.
+Count the number of open roles. List the departments hiring.
+Format: "X open roles — Engineering, Sales, Marketing"
+If no careers page exists, output 'purple'.
+```

--- a/skills/alex-vacca/clay-expert/references/claygent.md
+++ b/skills/alex-vacca/clay-expert/references/claygent.md
@@ -1,0 +1,81 @@
+# Claygent -- AI Research Agent
+
+You help users leverage Claygent for research tasks that require web browsing and custom data extraction beyond standard enrichment providers.
+
+## Reference
+
+Read `claygent-guide.md` for model options, credit costs, output formatting, and best practices.
+
+## When to Use Claygent vs Standard Enrichment
+
+| Use Claygent | Use Standard Enrichment |
+|-------------|------------------------|
+| Data not in any database | Email, phone, firmographics |
+| Real-time web research needed | Static company/people data |
+| Custom/nuanced questions | Industry, revenue, headcount |
+| Competitor mentions, case studies | Tech stack (use HG Insights) |
+| Funding news, press mentions | LinkedIn profile data |
+
+## Model Selection
+
+- **Claygent Neon** (1-2 credits) -- Clay's flagship, optimized for extraction into columns. Use this 90% of the time.
+- **GPT-4** (2-3 credits) -- only for complex reasoning tasks
+- **Claude Opus** (2-3 credits) -- only for complex reasoning tasks
+
+**Rule:** GPT-4 Mini / Claygent Neon handles 90% of tasks. Do not overspend on advanced models.
+
+## Prompting Rules (from Eric Noski)
+
+1. **One task per Claygent column** -- never combine "check site + classify + extract" in one prompt
+2. **Use "purple" as null keyword** -- "If not found, output 'purple'" (easy to filter downstream)
+3. **Include 3-4 examples** in every prompt -- even mediocre prompts become excellent with examples
+4. **Ask for reasoning before answer** on complex tasks -- improves accuracy significantly
+5. **10-minute manual research rule** -- research 3-4 records manually first, then automate that exact process
+
+## Prompt Template
+
+```
+Visit /company_domain and answer: [SPECIFIC QUESTION]
+
+Rules:
+- Only use information found on the website
+- If not found, output "purple"
+- Output format: [text/number/true-false/URL]
+
+Example outputs:
+- "Series B, $25M from Sequoia"
+- "purple"
+```
+
+## Credit Optimization
+
+- Simple yes/no questions: 1 credit
+- Deeper analysis: 2-3 credits
+- Iterate in the builder (free) before running on full table
+- Add conditional run: only run Claygent on rows where standard enrichment left gaps
+- Never use Claygent for data available via standard providers (email, phone, revenue)
+
+## Common Use Cases
+
+1. **Free trial detection** -- "Does this company offer a free trial?"
+2. **Case study extraction** -- "Find customer case studies and extract metrics"
+3. **Hiring signals** -- "Check careers page for open [role] positions"
+4. **Competitor mentions** -- "Does this company mention [competitor] on their site?"
+5. **Content topics** -- "What are the last 3 blog post topics?"
+6. **Technology signals** -- "Does the website use [specific tool]?"
+
+## Examples
+
+**Example 1:** "I want to know if my prospects offer a free trial"
+--> Claygent column with prompt: "Visit /domain. Does this company offer a free trial, demo, or trial period? Output 'Yes' or 'No'. If unclear, output 'purple'." Cost: 1 credit/row. Model: Claygent Neon.
+
+**Example 2:** "I need to find recent funding rounds for 500 companies"
+--> Claygent column: "Search Google for '/company_name funding round'. What is the most recent funding round? Output format: '[Series], $[Amount] from [Investor]'. If nothing found, output 'purple'." Cost: 2 credits/row.
+
+**Example 3:** "I want personalized icebreakers based on their latest blog post"
+--> Step 1: Claygent to extract latest blog topic (1 credit). Step 2: Separate AI column (GPT-4 Mini) to write icebreaker from that topic (1 credit). Never combine both in one column.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/clayscript-guide.md
+++ b/skills/alex-vacca/clay-expert/references/clayscript-guide.md
@@ -1,0 +1,102 @@
+# Clayscript & Formulas Guide
+
+## Overview
+
+Formulas manipulate data without spending credits. They're based on **Clayscript** (JavaScript) and evaluate expressions row by row.
+
+## Supported Libraries
+
+**JavaScript standard:**
+- Math, String, Array, Date, RegExp, Number, Object
+
+**Lodash:**
+- Full access via `_` for advanced data manipulation
+
+**Moment.js:**
+- Date/time operations via `moment`
+
+**FormulaJS:**
+- Familiar spreadsheet functions: VLOOKUP, IF, SUM, CONCATENATE, etc.
+
+## Syntax
+
+**Describe mode:** Use `/field` to reference columns
+**Raw formula mode:** Use `{{FieldName}}`
+
+## AI Formula Generator
+
+1. Add a new column → select Formula
+2. Type instructions in the AI Formula Generator box
+3. Use "/" to reference columns
+4. Click "Generate Formula"
+5. Verify the sample output
+6. Click "Save Formula"
+
+## 3 Main Use Cases
+
+1. **Conditional Formula:** Execute if a condition is true
+2. **Formatting Data:** Format data properly
+3. **Cleaning Data:** Clean and normalize data
+
+## Common Conditional Formulas
+
+```javascript
+// Email exists
+/email is not empty
+
+// Email valid or valid catchall
+/validation_result equals "valid" OR equals "catchall valid"
+
+// Company type match
+/company_type equals "B2B"
+
+// Minimum score
+/lead_score is greater than 50
+
+// Combined conditions
+/email is not empty AND /company_fit equals "true"
+
+// Check column completion status
+Clay.getCellStatus(#{{field_id}}) == "completed" AND {{previous_column}} == ""
+```
+
+## Prompt Templates for AI Columns
+
+**Company Summary:**
+```
+Visit /company_domain and give me an exhaustive summary of what the company does.
+```
+
+**Fit Check:**
+```
+Based on this summary: /company_summary
+Is this company a [TYPE]?
+Output "true" if yes, "false" if no.
+Only output true or false, nothing else.
+```
+
+**LinkedIn Post Summary:**
+```
+Here is a LinkedIn post: /linkedin_post
+Summarize what they're talking about in one sentence.
+If it's about politics, religion, or controversial topics, output "SKIP".
+```
+
+**Case Study Extraction:**
+```
+Visit /company_domain/case-studies and find their customer case studies.
+For each case study, extract:
+- Customer name
+- What they helped them achieve
+- Any metrics mentioned
+
+If no case studies found, output "purple".
+```
+
+## Important Tips
+
+- Replace smart quotes " " with straight quotes ""
+- Column names must match exactly
+- Add `|| ""` to avoid errors on null values
+- No custom function or variable definitions supported
+- Formulas cost 0 credits — always prefer them over AI when possible

--- a/skills/alex-vacca/clay-expert/references/company-enrichment.md
+++ b/skills/alex-vacca/clay-expert/references/company-enrichment.md
@@ -1,0 +1,68 @@
+# Company Enrichment
+
+You help users enrich company records in Clay with firmographic, technographic, and contextual data using the optimal provider sequence.
+
+## References
+
+- Read `core-concepts.md` for Clay table fundamentals and column types.
+- Read `clay-enrichment-workflows.md` for the 9-step pipeline and company enrichment templates.
+
+## Company Enrichment Waterfall (Recommended Order)
+
+1. **Apollo** (2-3 credits) -- employee count, revenue, industry, founding year
+2. **Ocean.io** (2-3 credits) -- fills gaps in firmographic data
+3. **LinkedIn Company Enrichment** (2 credits) -- recent updates, description, specialties
+4. **Claygent** (1-3 credits) -- funding news, press mentions, custom research
+5. **HG Insights** (3-5 credits) -- deep tech stack data (enterprise-grade)
+
+Always add conditional runs: only call the next provider if the previous one left gaps.
+
+## Key Data Points to Collect
+
+| Data Point | Best Provider | Credits |
+|-----------|---------------|---------|
+| Employee count | Apollo, LinkedIn | 2-3 |
+| Revenue | Apollo, PDL, HG Insights | 2-5 |
+| Industry | Apollo, LinkedIn | 2-3 |
+| Tech stack | HG Insights, BuiltWith | 3-5 |
+| Funding | Claygent, Harmonic.ai | 1-3 |
+| Company description | LinkedIn, Claygent | 1-2 |
+| Location/HQ | Apollo, Clearbit | 2-3 |
+
+## Minimum Required Input
+
+- **Best:** Company domain (e.g., `acme.com`)
+- **Fallback:** Company name + location (less accurate)
+- **From people table:** Use a formula to extract domain from email: `{{email}}.split("@")[1]`
+
+## Setup Steps
+
+1. Import company list (CSV with domain column, or CRM import)
+2. Add Apollo enrichment with conditional: "Only run if /employee_count is empty"
+3. Add LinkedIn enrichment with conditional: "Only run if /industry is empty"
+4. Add tech stack enrichment if needed (HG Insights or BuiltWith)
+5. Use Claygent for custom data not in standard databases
+6. Test on 50 rows before running full table
+
+## Credit Optimization
+
+- Apollo covers 60-70% of standard firmographic fields in one call
+- Only run expensive providers (HG Insights) on rows where Apollo returned empty
+- Use formulas (0 credits) to derive data: e.g., company size category from headcount
+- Save all results to CRM or Supabase -- never pay twice for the same company
+
+## Examples
+
+**Example 1:** "I have 2,000 company domains and need revenue + headcount"
+--> Apollo enrichment first (covers most). Conditional Ocean.io for gaps. Formula to bucket revenue ranges. Estimated cost: 2,000 x 3 credits = ~6,000 credits.
+
+**Example 2:** "I need to know what tech stack my target accounts use"
+--> HG Insights for enterprise-grade tech data (3-5 credits/row). Conditional: only run on companies with 50+ employees. Alternative: BuiltWith for website tech only (cheaper).
+
+**Example 3:** "I imported 30K companies from Salesforce with only names, no domains"
+--> Use Google Search via Claygent to find domains first. Then run standard company enrichment waterfall. Save enriched data back to Salesforce via CRM sync.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/conditional-logic.md
+++ b/skills/alex-vacca/clay-expert/references/conditional-logic.md
@@ -1,0 +1,102 @@
+# Conditional Logic & Clayscript
+
+You help users write Clayscript formulas, set up conditional runs, and build credit-saving logic in Clay.
+
+## References
+
+- Read `clayscript-guide.md` for syntax, libraries, and AI formula generator.
+- Read `copy-paste-formulas.md` for ready-to-use formulas (name cleaning, domain extraction, email waterfall, seniority check, employee buckets, table layout).
+- Read `expert-tips-eric-noski.md` for Rule 1 (conditionals on all paid integrations) and Rule 5 (formulas over AI).
+
+## Core Rule: Formulas Cost 0 Credits
+
+Formulas are FREE. Always prefer formulas over AI columns for:
+- Cleaning/formatting data
+- Combining fields (first + last name)
+- If/then logic and scoring
+- Abbreviations (New Jersey --> NJ)
+- Extracting domain from email
+- Any standard JavaScript operation
+
+## Syntax
+
+- **Describe mode:** Use `/field_name` to reference columns
+- **Raw mode:** Use `{{FieldName}}`
+- **Libraries available:** Lodash (`_`), Moment.js (`moment`), FormulaJS (VLOOKUP, IF, SUM)
+- **Null safety:** Always add `|| ""` to avoid errors on empty cells
+
+## Essential Conditional Run Formulas
+
+```javascript
+// Only run if field is empty (most common)
+/email is empty
+
+// Only run if previous enrichment completed but returned nothing
+Clay.getCellStatus(#{{field_id}}) == "completed" AND {{previous_column}} == ""
+
+// Only run on high-value leads
+/lead_score > 70 AND /industry equals "SaaS"
+
+// Only run if email is valid
+/email_validation equals "valid" OR /email_validation equals "catchall valid"
+
+// Skip already-enriched rows
+/revenue is empty AND /domain is not empty
+
+// Combined: CRM push only if ready
+/email is not empty AND /email_validation equals "valid" AND /lead_score > 50
+```
+
+## Common Data Manipulation Formulas
+
+```javascript
+// Extract domain from email
+{{email}}.split("@")[1] || ""
+
+// Combine first + last name
+({{first_name}} || "") + " " + ({{last_name}} || "")
+
+// Capitalize first letter
+({{name}} || "").charAt(0).toUpperCase() + ({{name}} || "").slice(1).toLowerCase()
+
+// Bucket company size
+{{employee_count}} > 1000 ? "Enterprise" : {{employee_count}} > 200 ? "Mid-Market" : {{employee_count}} > 50 ? "SMB" : "Startup"
+
+// Clean LinkedIn URL
+({{linkedin_url}} || "").replace(/\/$/, "").split("?")[0]
+```
+
+## AI Formula Generator
+
+1. Add column --> select Formula type
+2. Type instructions in plain English: "Extract the domain from the email column"
+3. Use `/` to reference columns
+4. Click "Generate Formula"
+5. Verify sample output on 3-5 rows
+6. Save
+
+**Tip:** If the AI generator fails, screenshot the formula need and use ChatGPT -- it sometimes writes better Clayscript.
+
+## Credit-Saving Checklist
+
+1. Every paid enrichment MUST have a conditional run (non-negotiable)
+2. Check if data already exists before calling a provider
+3. Use formulas to derive data instead of enriching (e.g., company size bucket from headcount)
+4. Chain conditionals: only run Provider 2 if Provider 1 returned empty
+5. Disable auto-update on expensive columns during testing
+
+## Examples
+
+**Example 1:** "I want to only push leads to HubSpot if they have a valid email and score above 80"
+--> Conditional run on CRM push column: `/email_validation equals "valid" AND /lead_score > 80`. This prevents bad data from entering your CRM.
+
+**Example 2:** "How do I extract the company name from an email domain?"
+--> Formula column: `({{email}} || "").split("@")[1].split(".")[0]`. Capitalize: `.charAt(0).toUpperCase() + .slice(1)`. Cost: 0 credits.
+
+**Example 3:** "My Clay table is burning credits because enrichments run on every row"
+--> Add conditional runs to every paid column. Minimum: "field is empty". Better: "field is empty AND /domain is not empty". Check auto-update settings (disable during testing). Review credit usage report.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/copy-paste-formulas.md
+++ b/skills/alex-vacca/clay-expert/references/copy-paste-formulas.md
@@ -1,0 +1,93 @@
+# Copy-Paste Clay Formulas
+
+Ready-to-use Clayscript formulas for common data manipulation tasks. All formulas cost 0 credits.
+
+## Name & Text Cleaning
+
+### First Name Cleaning
+Removes special characters, normalizes casing, keeps only first name.
+```javascript
+{{First Name}}?.replace(/[^a-zA-Z- ]/g, "").trim().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ').replace(/\s.*/,'')
+```
+
+### Company Name Cleaning (Remove Suffixes)
+Strips legal entities, regional suffixes, and common noise.
+```javascript
+{{Company Name}}?.replace(/(Technologies|Solutions|Services|Limited|LLC|KGga|Software|Telecommunications|Business|Sales|Ltd|Co|Corp|Company|Marketing|Partners|Advisors|Recruitment|Executive Search|&)$|(Solutions|Services|& |,|\/|\\|\\\\|:).*|(USA|US|Australia|UK|China|Canada|Germany|India|Worldwide)$|[. ]$|self employed/gi, match => match.toLowerCase() === 'self employed' ? 'your company' : '')
+```
+
+### Combine First + Last Name
+```javascript
+[{{First Name}}, {{Last Name}}].filter(Boolean).join(' ').trim()
+```
+
+## URL & Domain Extraction
+
+### Domain from Website URL
+```javascript
+{{Website}}?.replace(/^https?:\/\/(www\.)?/, '').replace(/\/.*/, '').toLowerCase()
+```
+
+### Domain from Email Address
+```javascript
+{{Email}}?.split('@')[1]?.toLowerCase()
+```
+
+### LinkedIn URL Cleanup (Remove Tracking Parameters)
+```javascript
+{{LinkedIn URL}}?.replace(/\?.*/, '').replace(/\/+$/, '').toLowerCase()
+```
+
+## Email Waterfall (Pick First Non-Empty)
+
+### 5-Provider Email Waterfall
+Adapt column names to match your table.
+```javascript
+{{Prospeo - Work Email}} || {{LeadMagic - Work Email}} || {{Wiza - Work Email}} || {{Hunter - Work Email}} || {{FullEnrich - Work Email}} || ""
+```
+
+### 3-Provider Email Waterfall (Simplified)
+```javascript
+{{Provider 1 Email}} || {{Provider 2 Email}} || {{Provider 3 Email}} || ""
+```
+
+## Classification & Scoring
+
+### Title Seniority Check
+Returns `true` for senior/executive titles.
+```javascript
+/^(C[A-Z]O|Chief|VP|Vice President|Director|Head of|SVP|EVP|President|Founder|Co-Founder|Partner|Owner|Managing Director)/i.test({{Title}} || '')
+```
+
+### Employee Count Bucket
+```javascript
+(n => n <= 10 ? '1-10' : n <= 50 ? '11-50' : n <= 200 ? '51-200' : n <= 500 ? '201-500' : n <= 1000 ? '501-1000' : '1000+')({{Employee Count}} || 0)
+```
+
+### Revenue Bucket
+```javascript
+(r => r <= 1000000 ? '<$1M' : r <= 5000000 ? '$1-5M' : r <= 10000000 ? '$5-10M' : r <= 50000000 ? '$10-50M' : r <= 100000000 ? '$50-100M' : '$100M+')({{Revenue}} || 0)
+```
+
+## Table Architecture — Standard Column Layout
+
+When building a new Clay table, follow this column ordering:
+
+| Phase | Columns | Purpose |
+|-------|---------|---------|
+| **Input** | Company Name, Domain, LinkedIn URL | Starting data |
+| **Company Enrichment** | Industry, Employee Count, Revenue, Funding, Tech Stack | Firmographics |
+| **Signal Detection** | Hiring Count, News, LinkedIn Ads, Growth Rate | Intent signals |
+| **Contact Discovery** | Full Name, Title, Email, LinkedIn URL | People data |
+| **Email Waterfall** | Provider 1 Email, Provider 2 Email, ... | Cascading email finding |
+| **Email Verification** | Verified Email, Verification Status | Final clean email |
+| **AI Qualification** | Company Tier, Contact Tier, ICP Score | Scoring |
+| **AI Personalization** | Custom Signal, Opening Line, Value Prop | Copy variables |
+| **Output** | Final Email, Sequence Tag, Campaign Assignment | Export-ready |
+
+### Naming Conventions
+- Descriptive names: `Prospeo - Work Email`, not `Email 1`
+- AI columns prefixed: `AI - Company Tier`, `AI - Opening Line`
+- Source-prefixed: `LI - Employee Count`, `Apollo - Revenue`
+- Title Case for all column names
+- Left-to-right = execution order

--- a/skills/alex-vacca/clay-expert/references/core-concepts.md
+++ b/skills/alex-vacca/clay-expert/references/core-concepts.md
@@ -1,0 +1,100 @@
+# Clay Core Concepts
+
+## What is Clay?
+
+Clay is a data enrichment and automation platform for sales and marketing teams. It enables:
+- Sourcing leads from multiple sources
+- Enriching data with 75+ providers (296+ integrations)
+- Building automated workflows
+- Personalizing outreach at scale
+- Syncing with CRMs
+
+## Tables
+
+The foundation of Clay. Each table contains data (people, companies, etc.) that you can enrich and manipulate.
+
+**Table types:**
+- People tables (contacts)
+- Company tables (companies)
+- Custom tables (custom data)
+
+**Table actions:**
+- Rename, Duplicate, Delete
+- Edit descriptions
+- Convert formats
+- Create from template
+- Import files (CSV, etc.)
+- Export/Download
+
+## Columns
+
+Each column represents a data type.
+
+**Limits:**
+- 70 columns max per table
+- 30 action/integration columns max (40 with waterfall)
+- 8,000 characters max per cell
+
+**Column operations:**
+- Rename, Pin, Duplicate, Delete
+- Insert left/right
+- Hide, Reorder, Sort, Filter, Merge
+- Data type selection (crucial for proper functioning)
+- AI-powered columns
+- Colored columns for organization
+
+**Data types available:**
+- Text
+- Number
+- Date
+- Text with tokens (default)
+- Message drafting
+- Enrichment waterfall
+- Formula
+
+**Changing data type:**
+- Method 1: Right-click header → Edit Column → Select Data Type → Save
+- Method 2: Click column title → hover on current type → dropdown → select
+
+**Tips:**
+- Use colors to group related columns (e.g., all email columns in blue)
+- Deduplication is case-sensitive ("Clay" ≠ "clay"), whitespace counts ("Clay " ≠ "Clay")
+- Create child columns to map specific enrichment endpoints
+
+## Rows
+
+Each row = one record (a person, a company, etc.)
+
+**Row management:**
+- Add rows manually
+- Import from files
+- Import from integrations
+- Format rows (starting point, limits)
+- Inspect cell details
+
+## Workbooks
+
+Connect and visualize multiple tables together. Useful for complex workflows that pass from one table to another.
+
+## Folders
+
+Organize tables by categories/projects.
+
+## Clay as Data Intermediary
+
+```
+[INBOUND]                    [CLAY]                    [OUTPUT]
+LinkedIn Ads      →          ┌─────────┐              → HubSpot
+Organic Content   →          │ Enrich  │              → Salesforce
+Newsletter        →          │ Score   │              → SmartLead
+Webinars          →          │ Clean   │              → Instantly
+Events            →          │ Qualify │              → Outreach
+CRM Stale Data    →          └─────────┘              → Salesloft
+```
+
+**Key principle:** Data flows in → Transformation in Clay → Data flows out to other tools
+
+**What Clay is NOT:**
+- Not a CRM replacement (HubSpot/Salesforce)
+- Not an email finder replacement (ZoomInfo/Apollo)
+- It's a **complementary layer** that maximizes all your tools

--- a/skills/alex-vacca/clay-expert/references/credits-and-pricing.md
+++ b/skills/alex-vacca/clay-expert/references/credits-and-pricing.md
@@ -1,0 +1,112 @@
+# Credits & Pricing
+
+## What Costs Credits
+
+**Enrichments (variable costs):**
+- Email discovery: 2-5 credits depending on provider (Hunter = 2, People Data Labs = 5)
+- Mobile phone numbers: 2-25 credits (harder to obtain data)
+- Company revenue, LinkedIn profiles, contact research: variable
+- AI features: based on model selected and token usage
+
+**Important points:**
+- Each row processed by AI costs credits, regardless of result quality
+- Auto-Update enabled triggers enrichments = credits consumed
+- Duplicate enrichments (re-run or re-enable columns) = new credits
+- **Failed searches also cost** — you pay for the attempt, not the result
+
+## What's FREE
+
+**Prospecting & List Building:**
+- Prospecting doesn't cost credits — only enrichment does
+- Google Maps, GitHub, CRM imports, web scraping sources = free
+
+**Using Your Own API Keys:**
+- If you have your own API key (e.g., OpenAI), connect it and use for free
+- External sources (Zoominfo, Cognism, 6Sense) via HTTP/API = free
+- Existing external plans with a provider = usable for free in Clay
+
+**Internal Clay Actions:**
+- Formulas (all data manipulation)
+- Cleaning/formatting data
+- CRM connections (on Pro Plan!)
+- Emailer connections (on Pro Plan!)
+
+## Tips to Save Credits
+
+1. **Disable Auto-Update** when not needed
+2. **Pause/delete AI columns** that aren't producing good results
+3. **Check settings** before re-running enrichments
+4. **Use "Lookup"** if data already exists in another Clay table or CRM
+5. **Custom budgets** to control spend per run
+6. **Don't delete** columns/tables while actions are running
+
+## Rollover Policy
+
+**Monthly plans:**
+- Unused credits accumulate
+- Maximum: 2× your monthly limit (e.g., 50K/month → max 100K)
+
+**Annual plans:**
+- 15% rollover of unused credits
+- Condition: renew on same plan or higher
+
+## Plans & Pricing
+
+### Free Plan
+- **Price:** Free
+- **Credits:** 100/month
+- **Usage:** Platform testing, small explorations
+
+### Starter Plan
+- **Price:** $149/month ($134/month annual)
+- **Credits:** 2,000/month (24K-36K/year)
+- **Features:**
+  - Up to 5,000 people/company searches
+  - Phone number enrichments
+  - Use your own API keys
+
+### Explorer Plan
+- **Price:** $349/month ($314/month annual)
+- **Credits:** 10,000/month (120K-240K/year)
+- **Features (everything in Starter +):**
+  - Up to 10,000 searches
+  - HTTP API integration
+  - Clay Webhooks
+  - Email sequencing integrations (Outreach, Salesloft)
+
+### Pro Plan
+- **Price:** $800/month ($720/month annual)
+- **Credits:** 50,000/month (600K-1.8M/year)
+- **Features (everything in Explorer +):**
+  - CRM integrations (Salesforce, HubSpot)
+  - Cost per credit up to 7x cheaper than Starter
+  - Free CRM connections
+  - Free emailer connections
+
+### Enterprise Plan
+- **Price:** Custom (median ~$30,400/year, up to $154,000/year)
+- **Credits:** Customizable
+- **Features (everything in Pro +):**
+  - Passthrough Tables (unlimited rows)
+  - Up to 40 column actions per table
+  - Dedicated AI prompting support
+  - Snowflake integration
+  - Dedicated Slack support
+  - Credit reporting analytics
+  - SSO
+
+### Cost per Credit by Plan
+- Starter: ~$75 / 1,000 credits
+- Pro: ~$16 / 1,000 credits (up to 7x cheaper)
+
+## Credit System Explained
+
+- Clay = marketplace of enrichment providers
+- You pay in Clay Credits
+- Clay pays the providers for you
+- No need for individual contracts
+
+**Advantages:**
+1. Access to enterprise tools (HG Insights = $100K+/year normally)
+2. No signup for each provider
+3. Waterfall = max coverage at min cost

--- a/skills/alex-vacca/clay-expert/references/crm-sync.md
+++ b/skills/alex-vacca/clay-expert/references/crm-sync.md
@@ -1,0 +1,105 @@
+# CRM Sync — HubSpot & Salesforce
+
+## Supported CRMs
+HubSpot, Salesforce, Pipedrive, Close, Attio
+
+## Action Types
+
+### Lookup (Read-Only)
+- Pull data FROM CRM INTO Clay
+- Doesn't modify anything in your CRM
+- Experiment freely without risk
+
+### Create & Update (Write)
+- Push data FROM Clay TO CRM
+- Real and permanent modifications
+- Be careful and methodical
+
+## HubSpot Setup
+
+1. Click "Import"
+2. Select "HubSpot"
+3. Authenticate your account
+4. Permissions granted automatically
+
+## Salesforce Setup
+
+1. Navigate to import action
+2. Select Salesforce
+3. Login and grant permissions
+4. Choose: list or static report
+5. **Note:** Reports limited to 2,000 records — prefer imports from lists
+
+## Push to Email Sequencers
+
+Clay integrates with:
+- Instantly.ai
+- lemlist
+- Smartlead.ai
+- HeyReach
+- Sendspark
+- Salesloft
+- Outreach
+
+## Best Practices
+
+- Match by HubSpot ID for accuracy
+- Use "ignore blank values" to protect clean fields
+- Automate via API connections for continuous sync
+- Test with one row first before bulk operations
+
+## CRM Enrichment Example — Salesforce Cleanup
+
+*30,000 records enriched and cleaned*
+
+### Problem
+- 30K Salesforce records
+- Only: Company Name, Billing State, Company Owner
+- No website, no LinkedIn, no revenue, no contacts
+
+### Solution Workflow
+
+```
+Salesforce Import (30K records)
+          ↓
+    Google Search: "[Company Name] LinkedIn"
+          ↓
+    Extract LinkedIn Company URL
+          ↓
+    Enrich Company from LinkedIn
+          ↓
+    Find Company Domain
+          ↓
+    Revenue Waterfall
+          ↓
+    Find Marketing Contacts
+          ↓
+    Tech Stack (HG Insights)
+          ↓
+    Find Investors
+          ↓
+    Update Salesforce (push enriched data back)
+```
+
+### New Data Added
+
+| Field | Source | Value |
+|-------|--------|-------|
+| Company LinkedIn URL | Google Search | Matching |
+| Description | LinkedIn Enrich | Context |
+| Industry | LinkedIn Enrich | Segmentation |
+| Location | LinkedIn Enrich | Routing |
+| Employee Count | LinkedIn Enrich | Sizing |
+| Revenue | Waterfall (PDL, HG, Clearbit) | Qualification |
+| Marketing Leaders | Find People | Contacts |
+| Tech Stack | HG Insights | Targeting |
+| Investors | Enrichment | Context |
+
+### Key Insight
+
+**Clay as a CRM cleaning layer:**
+- Import from Salesforce
+- Enrich everything
+- Push back to Salesforce
+- Auto-refresh on schedule
+- CRM always clean and complete

--- a/skills/alex-vacca/clay-expert/references/debugging.md
+++ b/skills/alex-vacca/clay-expert/references/debugging.md
@@ -1,0 +1,90 @@
+# Debugging Clay Workflows
+
+You help users diagnose and fix problems in their Clay tables, enrichments, and automations.
+
+## References
+
+- Read `expert-tips-eric-noski.md` for the 6 table rules and 8 AI prompting rules.
+- Read `workflow-patterns.md` for auto-update behavior and run settings.
+
+## Top 10 Common Mistakes
+
+### 1. No Conditional Runs on Paid Enrichments
+**Symptom:** Credits burning on rows that already have data.
+**Fix:** Add conditional run to every paid column: `/field is empty`. Non-negotiable.
+
+### 2. Auto-Update Enabled During Testing
+**Symptom:** Credits consumed every time new rows are added.
+**Fix:** Set table-level auto-update to OFF while building. Only enable when workflow is finalized.
+
+### 3. Wrong Input Column Mapped
+**Symptom:** Enrichment returns empty or wrong results.
+**Fix:** Verify input mapping. Email waterfall needs domain, not company name. LinkedIn enrichment needs profile URL, not company URL.
+
+### 4. AI Prompt Doing Too Many Things
+**Symptom:** Claygent/AI returns inconsistent or partial results.
+**Fix:** One task per AI column. Split "check site + classify + extract" into 3 separate columns. GPT-4 Mini for each.
+
+### 5. No Null Handling in Formulas
+**Symptom:** Formula errors, "undefined" in cells.
+**Fix:** Add `|| ""` to every variable reference: `({{field}} || "")`. Always handle empty cells.
+
+### 6. Duplicate Rows Consuming Double Credits
+**Symptom:** Same contact enriched multiple times.
+**Fix:** Enable auto-dedupe before importing. Key: email or LinkedIn URL. Note: case-sensitive ("Clay" != "clay").
+
+### 7. Using Expensive AI Models for Simple Tasks
+**Symptom:** 3x credit cost with no quality improvement.
+**Fix:** GPT-4 Mini / Claygent Neon for 90% of tasks. Only use GPT-4/Claude Opus for complex reasoning.
+
+### 8. Not Saving Enriched Data Externally
+**Symptom:** Paying to re-enrich the same records in a new table.
+**Fix:** Push all enriched data to CRM or Supabase ($30/month for 11.4M+ records). Query before re-enriching.
+
+### 9. Running Full Table Before Testing
+**Symptom:** 10,000 credits wasted on a misconfigured column.
+**Fix:** Always test with 50 rows first. Verify outputs. Then run full table.
+
+### 10. Forgetting Column-Level Auto-Update
+**Symptom:** Table auto-update is ON but some columns do not run.
+**Fix:** Check both table-level AND column-level auto-update settings. Both must be ON for a column to auto-run.
+
+## Diagnostic Checklist
+
+When a user reports a problem, ask these questions:
+
+1. **What enrichment/column is failing?** (name and type)
+2. **What input columns are mapped?** (check for wrong mapping)
+3. **Is there a conditional run?** (check the formula)
+4. **What does the cell status show?** (completed, error, pending)
+5. **Is auto-update ON or OFF?** (both table and column level)
+6. **How many rows are affected?** (all vs. some)
+7. **Did it work before?** (regression vs. new issue)
+
+## Quick Fixes by Symptom
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| All cells empty | Wrong input column | Re-map inputs, check domain format |
+| Some cells empty | Provider coverage gaps | Add more providers to waterfall |
+| "Error" in cells | API rate limit or bad input | Wait and retry, or fix input data |
+| Credits burning fast | Missing conditionals + auto-update ON | Add conditionals, disable auto-update |
+| Inconsistent AI results | Prompt too complex | Split into multiple columns, add examples |
+| Duplicates appearing | No auto-dedupe | Enable dedupe on email or LinkedIn URL |
+| Formula showing "undefined" | Null values | Add `|| ""` to all variable references |
+
+## Examples
+
+**Example 1:** "My email waterfall is returning 0 results on all rows"
+--> Check input mapping: is domain column mapped (not company name)? Check domain format: should be "acme.com" not "https://www.acme.com/". Check conditional run: is it blocking all rows? Verify: run manually on 1 row to isolate the issue.
+
+**Example 2:** "My Clay table used 50,000 credits overnight"
+--> Check auto-update: is it ON at table level? Check which columns have auto-update enabled. Check for expensive enrichments (phone = 2-25 credits each). Add conditional runs to all paid columns. Disable auto-update immediately to stop the bleed.
+
+**Example 3:** "Claygent keeps returning different formats for the same question"
+--> Add explicit output format in prompt: "Output exactly 'Yes' or 'No', nothing else." Use "purple" as null keyword. Add 3-4 examples of expected output. Use Claygent Neon, not GPT-4.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/email-waterfall.md
+++ b/skills/alex-vacca/clay-expert/references/email-waterfall.md
@@ -1,0 +1,80 @@
+# Email Waterfall Enrichment
+
+You help users set up email waterfall enrichment in Clay to maximize coverage from ~40% (single provider) to 85%+ (waterfall).
+
+## Reference
+
+Read `waterfall-enrichment.md` for full provider list, setup steps, and validation details.
+
+## Key Benchmarks
+
+- Single email finder: ~40% coverage
+- 4-provider waterfall: 70-80% coverage
+- 6-provider waterfall: 85%+ coverage
+- Target bounce rate: under 2%
+- Credits per provider attempt: 2-5 credits (refunded if not found)
+
+## Recommended Provider Order (Cheapest First)
+
+1. LeadMagic (2 credits)
+2. Prospeo (2 credits)
+3. Hunter (2 credits)
+4. Apollo (3 credits)
+5. RocketReach (3 credits)
+6. FindyMail (2 credits)
+
+You only pay for providers actually used. If found at Provider 3, cost = 2+2+2 = 6 credits, not 14.
+
+## Required Inputs (Best to Worst)
+
+1. **Best:** Company Domain + LinkedIn Profile URL (highest match rate)
+2. **Good:** Company Domain + Full Name
+3. **Fallback:** Full Name + Company Name (lowest precision)
+
+## Setup Steps
+
+1. Click "Add enrichment" and search "Work Email"
+2. Select the waterfall enrichment type
+3. Reorder providers (cheapest first)
+4. Map input columns: domain, LinkedIn URL, full name
+5. Enable ZeroBounce validation (default)
+6. Add conditional run: "Only run if /email is empty"
+7. Test on 50 rows before running full table
+
+## Mandatory Conditional Run Formula
+
+Always add this to avoid wasting credits on rows that already have emails:
+
+```
+/email is empty
+```
+
+For re-enrichment workflows (e.g., CRM cleanup), use:
+
+```
+/email is empty OR /email_validation equals "invalid"
+```
+
+## Validation Step
+
+After the waterfall, add a separate email verification column:
+- Primary: MillionVerifier (bulk, cheapest)
+- Backup: Clay native verification
+- Remove: invalid, disposable addresses
+- Flag: risky/catchall emails for manual review
+
+## Examples
+
+**Example 1:** "I have 5,000 contacts with company domains but no emails"
+--> Set up 6-provider waterfall with domain as primary input. Conditional run: only if email is empty. Estimated cost: 5,000 x avg 6 credits = ~30,000 credits. Expected coverage: 85%+.
+
+**Example 2:** "My email bounce rate is too high"
+--> Add MillionVerifier validation column after waterfall. Filter: keep only "valid" results. Use conditional formula to flag "catchall" for manual review. Target: under 2% bounce rate.
+
+**Example 3:** "Should I run personal email waterfall too?"
+--> Only if work email waterfall returns empty. Add conditional: "Only run if /work_email is empty". Use separate waterfall with personal email providers. Lower priority than work email.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/expert-tips-eric-noski.md
+++ b/skills/alex-vacca/clay-expert/references/expert-tips-eric-noski.md
@@ -1,0 +1,96 @@
+# Expert Tips — Eric Noski
+
+*Source: Eric Noski — Clay's earliest employee, runs the largest Clay usage (37M rows/week, 6M+ emails/month)*
+
+## The 6 Rules for Clay Tables
+
+### Rule 1: Conditional Formula on ALL Paid Integrations
+- Even if it's just "first name must not be empty"
+- Always build this habit to avoid wasting credits
+- This is non-negotiable
+
+### Rule 2: Use Functions (Advanced Feature)
+- Send data to a separate table → run workflow → send data back
+- Allows changing a workflow once for 15+ tables
+- Avoids modifying each table individually
+
+### Rule 3: Save ALL Paid Data
+- To your CRM or a platform like Supabase
+- Supabase: $30/month for 11.4M+ records
+- Clay doesn't save your data like Apollo/ZoomInfo
+- You will reuse this data — save it
+
+### Rule 4: Use Scheduled Sources for Evergreen Campaigns
+- Put your entire TAM in HubSpot ($15/month)
+- Create an active segment/list
+- Let the campaign run automatically
+- No more manual CSV uploads
+
+### Rule 5: Don't Use AI When Formulas Will Do
+- Cleaning data → Formula
+- Combining data → Formula
+- If/then statements → Formula
+- Scoring leads → Formula
+- Abbreviations (New Jersey → NJ) → Formula
+- Everything JavaScript can do = Formula
+
+### Rule 6: Formulas = JavaScript
+- If you need a complex formula: screenshot → ChatGPT
+- The AI formula generator is powerful but sometimes ChatGPT does better
+
+## 8 AI Prompting Rules
+
+### Rule 1: The 10-Minute Manual Research Rule
+- Ask yourself: "What would I do if I researched this person for 10 minutes?"
+- What information would I look for?
+- THEN automate that with Clay
+- Never guess what you could do with Clay
+
+### Rule 2: AI Does Only ONE Thing at a Time
+**Bad:**
+- Claygent that checks site content + decides if e-commerce + classifies industry
+
+**Good:**
+- Claygent #1: Retrieve site content
+- Use AI #2: Is it a CPG?
+- Use AI #3: What products do they sell?
+- Use AI #4: What industry?
+
+AI "farts" if you give it too many tasks. GPT-4 mini costs almost nothing — separate the tasks.
+
+### Rule 3: Safeguards When Not Enough Context
+- Use a keyword like **"purple"** when nothing is found
+- "If no case study found, output 'purple'"
+- Makes downstream filtering easy
+- AI will otherwise say "No information found" in 100 different ways
+
+### Rule 4: ALWAYS Use Examples in Prompts
+- Even a mediocre prompt becomes excellent with examples
+- Manually research 3-4 examples
+- Include them in the prompt
+- Shows AI exactly what you want
+
+### Rule 5: Use the Metaprompter
+1. Go to ChatGPT
+2. Explain what you want to accomplish
+3. Ask: "Create a prompt for this"
+4. Then ask: **"What questions do you have to improve this prompt?"**
+5. Answer the questions
+6. Improved prompt
+
+### Rule 6: For Difficult Prompts, Ask for Reasoning BEFORE the Answer
+- "Tell me the reasoning why you think it's this kind of company before you give me the final answer"
+- AI predicts the next word
+- By explaining first, it has time to answer better
+
+### Rule 7: Prepare for Edge Cases
+- 20% = putting integrations together
+- **80% = adjusting the AI**
+- Most fail because they think the opposite
+- Review constantly — as soon as an output doesn't please → adjust the prompt
+
+### Rule 8: Use GPT-4 Mini for EVERYTHING
+- Advanced models are benchmarked for solving calculus
+- You just want to say "I saw on your website you help fitness enthusiasts breathe better"
+- GPT-4 mini handles this perfectly
+- Fix everything with prompts, not with more expensive models

--- a/skills/alex-vacca/clay-expert/references/people-enrichment.md
+++ b/skills/alex-vacca/clay-expert/references/people-enrichment.md
@@ -1,0 +1,82 @@
+# People Enrichment
+
+You help users find and enrich contacts at target companies using Clay's people search and LinkedIn enrichment capabilities.
+
+## References
+
+- Read `core-concepts.md` for Clay table fundamentals.
+- Read `workflow-patterns.md` for lead sourcing patterns and data import methods.
+
+## People Discovery Workflow
+
+```
+Company List (with domains)
+        |
+   Find People (by title + seniority)
+        |
+   LinkedIn Enrichment (profile data)
+        |
+   Filter (ICP match)
+        |
+   Email/Phone Waterfall (separate sub-skills)
+```
+
+## Best Sources for Finding People
+
+1. **LinkedIn Sales Navigator** -- most accurate for B2B, filter by title/seniority/company
+2. **Apollo Find People** -- large database, good coverage, 2-3 credits
+3. **Clay Find People** -- native Clay search across multiple providers
+4. **CRM Import** -- pull existing contacts from HubSpot/Salesforce
+
+## Key Filtering Criteria
+
+- **Title keywords:** VP, Director, Head of, Manager, Chief, C-level
+- **Seniority levels:** C-Suite, VP, Director, Manager
+- **Department:** Sales, Marketing, Engineering, Finance, Operations
+- **Recent hires:** joined in last 90 days (high intent signal)
+- **Limit:** 3-5 decision makers per company (avoid over-enrichment)
+
+## Setup Steps
+
+1. Start with a company table that has domains or LinkedIn company URLs
+2. Add "Find People" enrichment -- specify title keywords and seniority
+3. Map company domain or LinkedIn company URL as input
+4. Set limit to 3-5 contacts per company
+5. Add LinkedIn Profile enrichment for each found person
+6. Filter by ICP fit using formulas or AI column
+7. Proceed to email/phone waterfall (separate sub-skills)
+
+## LinkedIn Enrichment Data Points
+
+| Data Point | Source | Notes |
+|-----------|--------|-------|
+| Full name | LinkedIn Profile | Auto-split into first/last |
+| Current title | LinkedIn Profile | Most accurate source |
+| Seniority | LinkedIn Profile | C-Suite, VP, Director, etc. |
+| Location | LinkedIn Profile | City, state, country |
+| Tenure | LinkedIn Profile | Time at current company |
+| Past companies | LinkedIn Profile | Career history |
+| Skills | LinkedIn Profile | For personalization |
+| Connections | LinkedIn Profile | Network size indicator |
+
+## Conditional Runs (Save Credits)
+
+- Only enrich people if company matches ICP: `/company_employee_count > 50 AND /industry equals "SaaS"`
+- Only search for more contacts if fewer than 3 found: `/contacts_found < 3`
+- Skip enrichment if LinkedIn URL already exists: `/linkedin_url is not empty`
+
+## Examples
+
+**Example 1:** "I have 500 companies and need to find the VP of Sales at each"
+--> Use Clay Find People with title filter "VP Sales" OR "VP of Sales" OR "Head of Sales". Limit to 2 per company. Then LinkedIn enrich for full profile. Estimated: 500 x 3 credits = ~1,500 credits for discovery + 1,000 x 2 credits for enrichment.
+
+**Example 2:** "I want to map the entire buying committee for enterprise deals"
+--> Search for 3-5 people per company across titles: VP Sales, VP Marketing, CTO, CFO, Head of Ops. Use separate Find People columns for each persona. Total: 5 columns x 500 companies = 2,500 lookups.
+
+**Example 3:** "I imported Sales Navigator leads but they only have LinkedIn URLs"
+--> Add LinkedIn Profile enrichment column with the URL as input. This gives you name, title, company, location. Then extract company domain and run company enrichment. Cost: 2 credits per profile.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/phone-enrichment.md
+++ b/skills/alex-vacca/clay-expert/references/phone-enrichment.md
@@ -1,0 +1,77 @@
+# Phone Enrichment
+
+You help users set up phone number waterfall enrichment in Clay to find direct dials and mobile numbers.
+
+## Reference
+
+Read `waterfall-enrichment.md` for waterfall mechanics, provider list, and conditional run setup.
+
+## Key Benchmarks
+
+- Single phone provider: 20-30% coverage
+- Phone waterfall (3 providers): 50-65% coverage
+- Phone numbers cost more credits than emails (2-25 credits per provider)
+- Mobile numbers are harder to find than work emails
+- Always verify against do-not-call lists before cold calling
+
+## Recommended Provider Order
+
+1. **LeadMagic** (2-5 credits) -- good coverage, cost-effective
+2. **BetterContact** (3-5 credits) -- fills gaps from LeadMagic
+3. **Clay pattern matching** (1-2 credits) -- direct line patterns from company switchboard
+4. **Apollo** (3-5 credits) -- large database, lower direct dial accuracy
+5. **RocketReach** (3-5 credits) -- backup for remaining gaps
+
+## Required Inputs
+
+- **Best:** LinkedIn Profile URL + Company Domain (highest match rate)
+- **Good:** Full Name + Company Domain
+- **Minimum:** Full Name + Company Name
+
+## Setup Steps
+
+1. Click "Add enrichment" and search "Phone" or "Mobile Phone"
+2. Select the phone waterfall enrichment
+3. Reorder providers: LeadMagic first, then BetterContact, then others
+4. Map input columns: LinkedIn URL, full name, company domain
+5. Add conditional run: "Only run if /phone is empty"
+6. Test on 50 rows before full run
+7. Add verification step for do-not-call compliance
+
+## Conditional Run Formula
+
+Only run phone enrichment on high-value leads to avoid wasting credits:
+
+```
+/phone is empty AND /lead_score > 60
+```
+
+Or only after email was found (prioritize email first):
+
+```
+/work_email is not empty AND /phone is empty
+```
+
+## Credit Optimization
+
+- Phone enrichment is expensive (2-25 credits per attempt)
+- Only run on Tier 1 leads (score 80+) or after email outreach fails
+- Use conditional runs aggressively -- phone data is 3-5x more expensive than email
+- Run email waterfall FIRST, then phone only on leads worth calling
+- Save phone numbers to CRM immediately -- never pay twice
+
+## Examples
+
+**Example 1:** "I need direct dials for 1,000 sales leaders"
+--> LeadMagic + BetterContact waterfall. Conditional: only if lead_score > 70. Expected coverage: ~55%. Estimated cost: 1,000 x avg 8 credits = ~8,000 credits. Run email waterfall first (cheaper).
+
+**Example 2:** "I already have emails but want to add phone for multi-channel"
+--> Conditional: "Only run if /work_email is not empty AND /phone is empty". This ensures you only spend credits on leads you can already email. Prioritize Tier 1 leads.
+
+**Example 3:** "My phone numbers keep coming back as switchboard, not direct"
+--> Use LeadMagic or BetterContact (better at direct dials) instead of Apollo. Add a Claygent column to verify if number is direct or switchboard. Filter out non-direct numbers.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/scoring.md
+++ b/skills/alex-vacca/clay-expert/references/scoring.md
@@ -1,0 +1,98 @@
+# Lead Scoring
+
+You help users build lead scoring systems in Clay using formulas and enrichment data to prioritize outreach.
+
+## Reference
+
+Read `clay-enrichment-workflows.md` for the scoring framework (Step 8 of the 9-step pipeline).
+
+## 100-Point Scoring Model
+
+| Component | Points | What It Measures |
+|----------|--------|-----------------|
+| Company size match | 25 pts | Employee count fits ICP range |
+| Recent signals | 25 pts | Job changes, funding, hiring, tech adoption |
+| Email deliverability | 25 pts | Valid email, low bounce risk |
+| ICP fit | 25 pts | Industry, revenue, tech stack match |
+
+## Tier Assignment
+
+| Tier | Score | Action |
+|------|-------|--------|
+| Tier 1 | 80-100 | Immediate outreach, phone + email |
+| Tier 2 | 60-79 | Nurture sequence, email only |
+| Tier 3 | <60 | Long-term nurture or discard |
+
+## Building the Score in Clay
+
+Use formula columns (0 credits) to calculate each component:
+
+```javascript
+// Company size score (25 pts)
+let sizeScore = 0;
+let emp = {{employee_count}} || 0;
+if (emp >= 50 && emp <= 500) sizeScore = 25;      // Sweet spot
+else if (emp >= 20 && emp < 50) sizeScore = 15;    // Acceptable
+else if (emp > 500 && emp <= 2000) sizeScore = 15; // Acceptable
+else sizeScore = 5;                                 // Poor fit
+
+// ICP fit score (25 pts)
+let icpScore = 0;
+if ({{industry}} == "SaaS" || {{industry}} == "Software") icpScore += 15;
+if ({{revenue}} > 5000000) icpScore += 10;
+
+// Signal score (25 pts)
+let signalScore = 0;
+if ({{recent_funding}} && {{recent_funding}} != "purple") signalScore += 10;
+if ({{job_change_90d}} == "true") signalScore += 10;
+if ({{hiring_signals}} == "true") signalScore += 5;
+
+// Deliverability score (25 pts)
+let delivScore = 0;
+if ({{email_validation}} == "valid") delivScore = 25;
+else if ({{email_validation}} == "catchall valid") delivScore = 15;
+else delivScore = 0;
+
+// Total
+sizeScore + icpScore + signalScore + delivScore
+```
+
+## Segmentation Formula (Tier Assignment)
+
+```javascript
+let score = {{lead_score}} || 0;
+score >= 80 ? "Tier 1 - Immediate" : score >= 60 ? "Tier 2 - Nurture" : "Tier 3 - Long-term"
+```
+
+## Customizing for Your ICP
+
+Before building, define:
+1. **Ideal company size range** (e.g., 50-500 employees)
+2. **Target industries** (e.g., SaaS, FinTech, Healthcare)
+3. **Minimum revenue** (e.g., $5M ARR)
+4. **Must-have signals** (e.g., recent funding, hiring for your target role)
+5. **Required tech stack** (e.g., uses Salesforce, runs on AWS)
+
+Adjust point values based on what matters most to your sales team.
+
+## Credit Cost
+
+- Scoring itself: 0 credits (all formulas)
+- Data needed for scoring: depends on enrichments run upstream
+- Scoring should be the LAST step, after all enrichment is complete
+
+## Examples
+
+**Example 1:** "I want to score 5,000 leads before pushing to my sequencer"
+--> Build 4 formula columns (size, ICP, signals, deliverability). Sum into total_score. Add tier formula. Conditional CRM push: only Tier 1 + Tier 2. Cost: 0 credits for scoring itself.
+
+**Example 2:** "My scoring is too simple -- I only use company size"
+--> Add signal-based scoring: Claygent for funding (2 credits), job change detection via LinkedIn (2 credits), hiring signals via careers page (1 credit). Feed all into scoring formula. Adds ~5 credits per row but dramatically improves prioritization.
+
+**Example 3:** "How do I adjust scoring for different campaigns?"
+--> Create separate scoring columns per campaign. ABM campaign: weight company fit 40pts, signals 30pts, deliverability 20pts, size 10pts. Outbound campaign: weight deliverability 30pts, size 25pts, ICP 25pts, signals 20pts. Use views to filter by each campaign's tier.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/table-setup.md
+++ b/skills/alex-vacca/clay-expert/references/table-setup.md
@@ -1,0 +1,86 @@
+# Table Setup
+
+You help users create and configure Clay tables with the right structure, data types, imports, and auto-update settings.
+
+## References
+
+- Read `core-concepts.md` for tables, columns, data types, and workbooks.
+- Read `workflow-patterns.md` for import methods, Chrome extension, views, filters, and auto-update.
+
+## Table Limits
+
+- **70 columns max** per table
+- **30 action/integration columns** max (40 with waterfall)
+- **8,000 characters** max per cell
+- Deduplication is case-sensitive and whitespace-sensitive
+
+## Column Data Types
+
+| Type | Use For |
+|------|---------|
+| Text | Names, titles, descriptions |
+| Number | Revenue, headcount, scores |
+| Date | Founded date, last activity |
+| Text with tokens | Default -- structured text |
+| Enrichment waterfall | Multi-provider sequential enrichment |
+| Formula | Calculated fields (0 credits) |
+| Message drafting | Outreach copy generation |
+
+## Data Import Options
+
+1. **CSV/Excel** -- drag and drop, map columns
+2. **CRM Import** -- HubSpot, Salesforce, Pipedrive, Close
+3. **LinkedIn Sales Navigator** -- search export or URL list
+4. **Chrome Extension** -- scrape structured data from any webpage
+5. **Other Sources** -- Apollo, Google Maps, Yelp, GitHub, Google Scholar
+6. **API/Webhook** -- Zapier, n8n, custom HTTP
+
+## Auto-Update Configuration
+
+| Table Setting | Column Setting | Result |
+|--------------|----------------|--------|
+| OFF | Any | Nothing runs automatically |
+| ON | OFF | That column skipped |
+| ON | ON | Column runs on new rows |
+
+**WARNING:** Auto-update consumes credits on every refresh. Disable it when:
+- You are still building/testing the table
+- The table is a one-time import (not ongoing)
+- Expensive enrichments do not need continuous refresh
+
+## Auto-Dedupe Setup
+
+- Set deduplication key: email, LinkedIn URL, or domain
+- Keeps the OLDEST row, deletes newer duplicates
+- Case-sensitive: "Clay" and "clay" are treated as different
+- Enable before import to prevent duplicate enrichment spend
+
+## Views and Filters
+
+- Create views to segment data: "Enriched", "Missing Email", "Tier 1 Leads"
+- Filter with AND/OR logic (up to 2 levels deep)
+- Sorting: A-Z or Z-A, smallest-largest or reverse
+- Each view = same data, different perspective
+
+## Table Organization Best Practices
+
+- Use colored columns to group related fields (e.g., blue for email, green for company)
+- Create workbooks to connect related tables (companies --> people --> outreach)
+- Name tables descriptively: "[Source] - [Purpose] - [Date]"
+- Save column groups as templates for reuse across tables
+
+## Examples
+
+**Example 1:** "I want to start a new outbound campaign from scratch"
+--> Create table from template "Sales Nav Import". Import CSV or connect Sales Navigator. Columns: name, title, company, domain, LinkedIn URL. Enable auto-dedupe on LinkedIn URL. Keep auto-update OFF until enrichment columns are configured.
+
+**Example 2:** "How do I scrape a conference attendee list into Clay?"
+--> Use Clay Chrome Extension. Navigate to attendee page. Click 2 items to auto-detect the list pattern. Map fields (name, company, title). Export directly to a new Clay table. Then enrich.
+
+**Example 3:** "My table has 60 columns and is getting messy"
+--> Hide completed/intermediate columns. Create views: "Overview" (key fields only), "Enrichment Status" (all enrichment columns), "Export Ready" (final clean data). Use colors to group: blue=contact, green=company, yellow=enrichment, red=scoring.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/clay-expert/references/waterfall-enrichment.md
+++ b/skills/alex-vacca/clay-expert/references/waterfall-enrichment.md
@@ -1,0 +1,108 @@
+# Waterfall Enrichment
+
+## Concept
+
+The waterfall chains multiple enrichment providers sequentially. If the first provider doesn't find the data, the next one takes over. Access to 150+ databases.
+
+**Benefits:**
+- Maximizes coverage (typically triples it)
+- Optimizes costs (stops as soon as data is found)
+- Improves data quality
+- Credits refunded if no data found
+
+## How It Works
+
+1. Provider 1 searches → Found? Stop. Not found? Next.
+2. Continue until data found or all providers exhausted
+3. Automatic validation built-in (ZeroBounce by default)
+
+## Recommended Inputs
+
+- Primary: Company Domain
+- Improves precision: Personal Social Profile URLs
+- Fallback: Full Name + Company Name
+
+## Setup Step-by-Step
+
+**1. Add the enrichment**
+- Click "Add enrichment"
+- Search "Work Email" (or other)
+
+**2. Configure the sequence**
+- Under Waterfalls, select the waterfall
+- Reorder, add, or remove providers
+- Toggle switch to skip a specific provider
+
+**3. Select input columns**
+- Main input: Company Domain
+- Ideal: Personal Social Profile URLs (improves precision)
+- Fallback: Full Name + Company Name or Full Name + Personal Email
+
+**4. Choose validation settings**
+- Default: ZeroBounce
+- Other validators available
+
+**5. Execution**
+- Clay dynamically passes through the waterfall
+- If a provider finds a valid email → stop
+- If no email found → credits refunded, move to next provider
+- Continue until email found or all providers exhausted
+
+## Example: Find Work Email (Enterprise Waterfall)
+
+```
+Provider 1: LeadMagic (2 credits) → Found? STOP
+     ↓ Not found
+Provider 2: Prospeo (2 credits) → Found? STOP
+     ↓ Not found
+Provider 3: Hunter (2 credits) → Found? STOP
+     ↓ Not found
+Provider 4: Apollo (3 credits) → Found? STOP
+     ↓ Not found
+Provider 5: RocketReach (3 credits) → Found? STOP
+     ↓ Not found
+Provider 6: FindyMail (2 credits) → STOP (no email found)
+```
+
+**Cost if found at Provider 4:** 2+2+2+3 = 9 credits (not 14)
+
+**Key insight:** You only pay for providers used, not all of them.
+
+## Coverage Comparison
+
+- Single email finder = ~40% coverage
+- Waterfall = 85%+ coverage
+
+## Conditional Runs (Save Credits)
+
+1. Add a new enrichment
+2. Click "Run Settings" → "Conditional Run"
+3. Use AI to generate a formula
+4. Example: "Only run if existing email field is blank"
+
+## Custom Waterfall
+
+You can create your own combinations of integrations to maximize quality and coverage.
+
+## Enrichment Providers (296+ integrations)
+
+**Email Discovery:**
+Hunter, Prospeo, Apollo.io, RocketReach, FindyMail, LeadMagic, DropContact, Icypeas, Nimbler, Mixrank, Wiza, FullEnrich
+
+**Company Research:**
+Apollo.io, Clearbit, PredictLeads, Harmonic.ai
+
+**Email Validation:**
+NeverBounce, Debounce, Enrichley, Zero Bounce, FindyMail, LeadMagic
+
+**Location & Local Business:**
+Google Maps, Yelp, Mapbox, Lob
+
+**Web Scraping:**
+Bright Data, Zenrows, Apify, PhantomBuster, Clay Scrapers
+
+**Database & Webhooks:**
+Postgres, Snowflake, Airtable, Coda, Google Sheets, Zapier, n8n
+
+**Intent & Signals:**
+Common Room, Teamfluence, Midbound

--- a/skills/alex-vacca/clay-expert/references/workflow-patterns.md
+++ b/skills/alex-vacca/clay-expert/references/workflow-patterns.md
@@ -1,0 +1,165 @@
+# Workflow Patterns & Best Practices
+
+## 5 Standard Workflow Patterns
+
+### Pattern 1: Lead Sourcing
+```
+Source (LinkedIn/Apollo) → Enrichment (Email/Phone) → Validation → Push to CRM/Sequencer
+```
+
+### Pattern 2: Account Research
+```
+Company List → Firmographic Enrichment → Tech Stack → Decision Makers → Outreach
+```
+
+### Pattern 3: Intent-Based Outreach
+```
+Job Change Monitor → Filter (ICP fit) → Personalization → Sequencer
+```
+
+### Pattern 4: Data Hygiene
+```
+CRM Import → Dedupe → Re-enrich → Validate Emails → Update CRM
+```
+
+### Pattern 5: Waterfall Enrichment
+```
+Lead → Provider 1 → (if empty) Provider 2 → (if empty) Provider 3 → Output
+```
+
+## Common Use Cases
+
+### Sales Development
+- Lead sourcing from ICP criteria
+- Contact enrichment (email, phone)
+- Personalization data gathering
+- Push to sales engagement tools
+
+### Account-Based Marketing
+- Target account list building
+- Buying committee mapping
+- Intent signal tracking
+- Multi-channel outreach coordination
+
+### Recruiting
+- Candidate sourcing
+- Contact information finding
+- Company research
+- Outreach automation
+
+### Market Research
+- Company database building
+- Technology landscape mapping
+- Competitive intelligence
+- Industry analysis
+
+## Data Import & Sourcing
+
+### File Sources
+- CSV, Excel, Google Sheets
+
+### CRM Integrations
+- HubSpot, Salesforce, Pipedrive, Close
+
+### LinkedIn
+- LinkedIn Sales Navigator
+- LinkedIn URLs
+- LinkedIn Company Pages
+
+### Other Sources
+- Apollo.io, Google Maps, Yelp, GitHub, Hacker News, Google Scholar
+
+## Chrome Extension
+
+### 1. Clay for Chrome (Primary)
+- Extract structured data from web pages
+- Auto-detect lists on pages
+- Map your own lists (click 2 items → automatic selector)
+- Map Page Recipes (templates for similar pages)
+- Export to Clay table, CSV, or clipboard
+
+### 2. Clip to Clay
+- Save entire pages to Clay tables
+
+### Use Cases
+- Agency directories
+- Competitor pages
+- Case studies
+- Conference participant lists
+- Expert directories
+
+## Views, Filters & Sorting
+
+### Views
+Saved combinations of filters, sorts, and column customizations.
+- Switch via dropdown menu
+- Add/Duplicate/Delete views
+- Each view = different perspective on same data
+
+### Filters
+- AND logic: all conditions must be true
+- OR logic: at least one condition true
+- Up to 2 levels of filter group depth
+- Types: equal to, not equal to, is empty, is not empty, boolean
+
+### Sorting
+- Ascending: A→Z, small→large
+- Descending: Z→A, large→small
+
+## Auto-Update & Auto-Dedupe
+
+### Auto-Update
+- Enable/disable at table level AND column level
+- Table OFF = nothing runs auto (overrides everything)
+- **Caution:** Consumes credits on each refresh
+
+| Table | Column | Result |
+|-------|--------|--------|
+| OFF | Any | Nothing runs automatically |
+| ON | OFF | That column doesn't auto-run |
+| ON | ON | Column runs automatically |
+
+### Auto-Dedupe
+- Based on email, LinkedIn URL, or other unique identifier
+- Keeps data clean, saves credits (no double enrichment)
+- **Limitation:** Keeps the OLDEST row, deletes newer entries
+- Case-sensitive ("Clay" ≠ "clay"), whitespace counts ("Clay " ≠ "Clay")
+
+## Run Settings & Conditional Runs
+
+### How to Access
+1. Add an enrichment
+2. In the side panel, find "Run Settings"
+3. Find the "Only run if" box
+4. Use "Use AI" or write manually
+
+### Logical Operators
+- **AND:** All conditions must be true
+- **OR:** At least one condition true
+- **NOT:** Inverts a condition (e.g., `NOT {{status}} == "Closed"`)
+
+### Common Use Cases
+- Upload to CRM only if valid email
+- Add to sequence if lead_score > 80 AND industry == "SaaS"
+- Run personal email waterfall only if work email not found
+
+## Templates
+
+### Create from Template
+1. +Create New → Table → Use Template
+2. Choose the template
+3. Click "Add to Workspace"
+
+**Note:** Created tables become independent from the original template.
+
+### Save Your Own Template
+- Duplicate your table → move to separate workbook → add "[Template Do Not Delete]" to title
+- Or: Actions → Share as template (creates public template with structure + 1 row only)
+
+### Column Group Templates
+- In a table, click "Add enrichment" → "Templates" → search your template
+
+### Save Templates
+- AI prompts: Save custom prompts as templates in "Use AI"
+- Group columns: Select multiple columns → "Save as Template"
+- Waterfall sequences: Build custom waterfalls → save as template

--- a/skills/alex-vacca/cold-call-scripts/SKILL.md
+++ b/skills/alex-vacca/cold-call-scripts/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cold-call-scripts
+title: Cold call scripts
+description: "Use this skill when training SDRs on calls, building call frameworks, or handling common phone scenarios — a 1-minute cold call script in 5 steps, a no-show phone script, and objection responses."
+category: Outreach
+---
+
+# Cold Call Scripts
+
+For objection responses, see [references/objections.md](references/objections.md).
+
+## 1-Minute Cold Call Script (5 Steps)
+
+| Step | Script | Purpose |
+|------|--------|---------|
+| 1 | "Hey {{firstName}}, this is [Name] from Frontal—I know I'm catching you out of the blue." | Pattern interrupt |
+| 2 | "Mind if I take 30 seconds to tell you why I called? Then you can decide if it's worth continuing." | Earn permission |
+| 3 | "I work with [ICP] who are struggling with [problem]." | Establish relevance |
+| 4 | "We just helped [similar company] achieve [result]." | Social proof |
+| 5 | "Is that something you're dealing with right now?" | Open conversation |
+
+## Full Script Example
+
+```
+"Hey Sarah, this is Mike from Frontal—I know I'm catching you out of the blue.
+
+Mind if I take 30 seconds to tell you why I called? Then you can decide if it's worth continuing.
+
+I work with B2B SaaS companies doing $5-20M who are struggling with inconsistent pipeline.
+
+We just helped a company similar to yours book 40+ qualified meetings per month.
+
+Is pipeline predictability something you're dealing with right now?"
+```
+
+## No-Show Phone Script
+
+```
+"Hey {{firstName}}, it's [Name] from Frontal.
+
+We had a call scheduled for [time]—wanted to make sure everything's okay.
+
+No worries if something came up. Would [alternative time] work better?"
+```
+
+**Key:** No guilt, assume good intent, offer easy reschedule.
+
+## Voicemail Script (Under 20 seconds)
+
+```
+"Hey {{firstName}}, [Name] from Frontal.
+
+Quick message—I work with [ICP] on [problem].
+
+Thought it might be relevant given [trigger/observation].
+
+I'll shoot you an email with some times. Talk soon."
+```
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `sdr-outbound-rules` | Apply same writing rules to scripts |
+| `cold-email-4-sequence` | Coordinate calls with email sequence |
+| `buying-signals-6` | Use signals in Step 3 |
+| `linkedin-campaign-complete` | Multi-channel coordination |
+
+## Example prompts
+
+```
+Adapt the 1-minute script for selling marketing automation to CMOs.
+```
+
+```
+Write a voicemail script for following up after a website visit.
+```
+
+```
+How do I handle "we already have a solution" for CRM software?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-call-scripts/references/objections.md
+++ b/skills/alex-vacca/cold-call-scripts/references/objections.md
@@ -1,0 +1,89 @@
+# Cold Call Objection Responses
+
+## "Not interested"
+
+```
+"Totally fair. Mind if I ask—is it the timing, or is [problem] just not a priority right now?"
+```
+
+**Why it works:** Uncovers real objection (timing vs relevance)
+
+---
+
+## "Send me an email"
+
+```
+"Happy to. Quick question so I can make it relevant—what's your biggest challenge with [topic] right now?"
+```
+
+**Why it works:** Turns brush-off into qualification opportunity
+
+---
+
+## "We already have a solution"
+
+```
+"Got it. How's that working for you? Most companies I talk to are still seeing [common problem] even with [solution type]."
+```
+
+**Why it works:** Opens door to discuss gaps in current solution
+
+---
+
+## "No budget"
+
+```
+"Understood. Out of curiosity—if budget weren't a constraint, would [problem] be worth solving?"
+```
+
+**Why it works:** Separates budget timing from problem priority
+
+---
+
+## "I'm too busy right now"
+
+```
+"Totally get it. When would be a better time to have a 10-minute conversation about this?"
+```
+
+**Why it works:** Accepts the timing, asks for future commitment
+
+---
+
+## "We're not looking to change"
+
+```
+"Makes sense. Just curious—what would need to change for you to consider alternatives?"
+```
+
+**Why it works:** Plants seed for future, uncovers switching triggers
+
+---
+
+## "Can you call back later?"
+
+```
+"Sure. What's a good day and time? I'll put it in my calendar now."
+```
+
+**Why it works:** Gets specific commitment vs vague brush-off
+
+---
+
+## "How did you get my number?"
+
+```
+"Totally fair question. Your company came up in our research as a good fit for what we do. I can send you more context via email if that's easier?"
+```
+
+**Why it works:** Honest, offers alternative channel
+
+---
+
+## Objection Handling Principles
+
+1. **Never argue** - Acknowledge their point first
+2. **Ask questions** - Turn objections into conversations
+3. **Stay curious** - Genuine interest > scripted responses
+4. **Know when to stop** - "No" three times = move on
+5. **Leave door open** - Every call builds familiarity

--- a/skills/alex-vacca/cold-email-4-sequence/SKILL.md
+++ b/skills/alex-vacca/cold-email-4-sequence/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cold-email-4-sequence
+title: Cold email sequence
+description: |
+  Use this skill when building cold email campaigns, creating outreach sequences, or structuring a
+  multi-touch cadence for B2B prospecting. Covers the standard 4-email sequence — trigger-based
+  opener, pain/KPI email, delegation ask, break-up — plus timing, structure checklist, and BTL/ATL
+  length rules.
+category: Outreach
+---
+
+# Cold Email 4-Sequence Framework
+
+Standard 4-email sequence framework for cold outreach.
+
+## Email 1 - Trigger-Based Opening
+
+- Observation about their situation + one-line case study
+- Soft CTA (question-based)
+- Length: 3-4 sentences BTL, 2-3 sentences ATL
+
+## Email 2 - Pain/Main KPI Focus
+
+- Address primary pain point
+- Connect to key metric they care about
+
+## Email 3 - Someone Else's Responsibilities
+
+- Delegation ask ("who handles X?")
+- Opens thread to correct person
+
+## Email 4 - Break-Up
+
+- Timing question ("Is this not a priority right now?")
+- Clean exit that leaves door open
+
+## Email Structure Checklist
+
+```
+Opening (trigger) + Assumption + Social proof with numbers + Open-ended question
+```
+
+- **BTL emails:** 3-4 sentences
+- **ATL emails:** 2-3 sentences
+
+## Timing
+
+- Email 2: Send 3 days after Email 1
+- Email 3: Send 14 days later (new subject line)
+- Email 4: Break-up if no response
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `personalization-hooks` | Add strong/lite hooks to Email 1 |
+| `email-writing-frameworks` | Structure each email with proven frameworks |
+| `email-1-variations-7` | Get 7 variations for Email 1 |
+| `cold-email-templates-34` | Browse 34 templates for inspiration |
+| `buying-signals-6` | Choose the right trigger for Email 1 |
+
+## Example prompts
+
+```
+Write a 4-email sequence for SaaS companies targeting VP Sales, using job change as the trigger.
+```
+
+```
+Create Email 1 and Email 4 for an agency selling to marketing directors at e-commerce companies.
+```
+
+```
+Rewrite this email sequence to be more ATL-friendly (shorter, 2-3 sentences per email).
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/SKILL.md
+++ b/skills/alex-vacca/cold-email-strategist/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: cold-email-strategist
+title: The cold email strategist
+description: "Use this skill when writing or fixing cold email — first-touch and follow-up sequences, re-engagement, subject lines, personalization at scale, ATL/BTL messaging, copywriting frameworks, deliverability, domain warmup, SPF/DKIM/DMARC, and email infrastructure. Triggers on 'cold email', 'email sequence', 'deliverability', 'warmup', 'bounce rate', 'inbox placement', 'email template', 'follow-up email', 'outbound email', 'subject line', 'personalization', 'email copy'."
+category: Outreach
+contributors:
+  - ivan-falco
+---
+
+Reference files for this skill live in `references/` next to this file — load them with the relative paths given below.
+
+# Cold Email Orchestrator
+
+You are an expert cold email strategist who has analyzed 10M+ cold emails and managed campaigns achieving 18-40% reply rates. You route requests to the right sub-skill and provide cross-cutting guidance on deliverability and tooling.
+
+## Routing Table
+
+When a request comes in, identify the type and delegate to the appropriate sub-skill:
+
+| Request Type | Sub-Skill | Trigger Phrases | Load |
+|---|---|---|---|
+| Writing a first cold email | **first-touch** | "write a cold email", "email 1", "first touch", "outbound template" | Read `references/first-touch.md` |
+| Writing follow-up emails | **follow-up** | "follow-up", "email 2/3", "no response", "bump", "breakup email" | Read `references/follow-up.md` |
+| Re-engaging old/lost leads | **re-engagement** | "re-engage", "closed-lost", "win back", "they ghosted", "reactivate" | Read `references/re-engagement.md` |
+| Subject line writing/testing | **subject-lines** | "subject line", "open rate", "A/B test subject" | Read `references/subject-lines.md` |
+| Personalization strategy | **personalization** | "personalize at scale", "custom first lines", "Clay prompts", "hooks" | Read `references/personalization.md` |
+| Emailing VPs/C-Level/Directors | **atl-messaging** | "email a CEO", "VP outreach", "executive email", "C-suite", "ATL" | Read `references/atl-messaging.md` |
+| Emailing Managers/ICs | **btl-messaging** | "email a manager", "IC outreach", "end user email", "BTL" | Read `references/btl-messaging.md` |
+| Copywriting frameworks & principles | **copywriting** | "copywriting framework", "Do the Math", "Short Trigger", "Pattern Interrupt", "email framework", "copy principles", "email variations", "e-com cold email" | Read `references/copywriting.md` |
+| Email infrastructure setup | **email-infra** | "email infra", "setup domains", "DNS setup", "SPF/DKIM/DMARC setup", "warmup", "mailbox setup", "Instantly setup", "how many domains", "email blacklist", "scaling email" | Read `references/email-infra.md` |
+| Deliverability/infrastructure | — | See below | Read resources directly |
+| Sequencing tools | — | See below | Read resources directly |
+
+## Routing Logic
+
+1. **Check persona first** -- If the target is VP/C-Level/Director, route to **atl-messaging**. If Manager/IC, route to **btl-messaging**. These override first-touch.
+2. **Check email position** -- If this is Email 1, route to **first-touch**. If Email 2/3 or follow-up, route to **follow-up**. If old/lost lead, route to **re-engagement**.
+3. **Check specific ask** -- Subject lines only go to **subject-lines**. Personalization strategy goes to **personalization**.
+4. **Check copywriting needs** -- Named frameworks, copy principles, sequence structure, e-com playbook go to **copywriting**.
+5. **Check infrastructure needs** -- Domain setup, DNS, warmup, mailbox provisioning, blacklist recovery go to **email-infra**.
+6. **Cross-cutting concerns** -- General deliverability and tooling are handled directly by this orchestrator using resources below.
+
+## Cross-Cutting: Deliverability & Infrastructure
+
+For general deliverability concepts, read the resource files directly. For hands-on infrastructure setup (domains, DNS, warmup, troubleshooting), route to the **email-infra** sub-skill instead.
+
+- **General deliverability concepts, bounce management, compliance** --> Read `references/deliverability-guide.md`
+- **Advanced strategy, TAM reuse, Golden ICP, benchmarks** --> Read `references/cold-email-mastery.md`
+- **Hands-on infrastructure setup, DNS, warmup, troubleshooting** --> Route to **email-infra** sub-skill
+
+### Additional Copywriting Resources
+
+For deep copywriting guidance beyond the sub-skill's quick reference:
+- **13 named frameworks with templates** --> Read `references/copywriting-frameworks.md`
+- **Core philosophy and email component rules** --> Read `references/copywriting-principles.md`
+- **Sequence structure and variations** --> Read `references/copywriting-sequences.md`
+- **E-commerce vertical playbook** --> Read `references/copywriting-ecom-playbook.md`
+- **Frontal playbook: 3 value prop styles, 3 preview patterns, ready-to-deploy sequences (Referral Ceiling 7-touch, Lead Magnet 2-touch), 250K+ email principles, pain-point angles** --> Read `references/frontal-playbook.md`
+
+### Email Infrastructure Resources
+
+For detailed infrastructure walkthroughs:
+- **Complete setup guide** --> Read `references/email-infra-guide.md`
+- **Step-by-step with video tutorials** --> Read `references/email-infra-step-by-step.md`
+- **Troubleshooting and recovery** --> Read `references/email-infra-troubleshooting.md`
+
+### Quick Deliverability Reference
+
+- 30 emails max per inbox per day
+- 3-5 outreach domains (NEVER send cold from primary domain)
+- Warmup 4-8 weeks before first cold send
+- Verify 100% of emails before any campaign
+- Bounce rate must stay below 2%
+- Reply rate above 5% minimum for sustained sending
+- Plain text only -- no HTML for cold email
+
+## Cross-Cutting: Sequencing Tools
+
+Handle tooling questions directly by reading the resource:
+
+- **Tool comparison, multi-channel setup, Clay integration** --> Read `references/sequencing-tools.md`
+
+### Quick Tool Reference
+
+| Tool | Best For |
+|---|---|
+| SmartLead | High volume, AI warmup |
+| Instantly | Ease of use, good deliverability |
+| Lemlist | Multi-channel, images |
+| Apollo | All-in-one (data + sending) |
+| HeyReach | LinkedIn automation |
+
+## Core Principles (Apply to ALL Sub-Skills)
+
+- **60-90 words max** -- Shorter emails get higher reply rates
+- **Plain text only** -- No HTML, no images for cold outreach
+- **One CTA per email** -- Soft ask, not a hard sell
+- **3-email sequences** -- Introduce, Add Context, Lower Friction (3-5 day delays)
+- **Pain over features** -- Lead with the problem, not your solution
+- **Signal-based > cold** -- Signal-based: 18-22% reply. Multi-signal: 35-40% reply.
+- **Verify 100% of emails** -- Non-negotiable
+- **Change value prop between emails** -- Email 1: save money, Email 2: make money, Email 3: save time
+
+## Response Format
+
+1. Identify the request type from the routing table
+2. If it maps to a sub-skill, follow that sub-skill's process
+3. If it is a cross-cutting concern, read the appropriate resource file
+4. Always include expected benchmarks (reply rate, open rate)
+5. Always flag common mistakes for the specific scenario
+
+## Decision Tree
+
+```
+User Request
+├─ Target is VP/C-Level/Director? → atl-messaging
+├─ Target is Manager/IC/End-User? → btl-messaging
+├─ Writing first email (Email 1)? → first-touch
+├─ Writing follow-up (Email 2/3)? → follow-up
+├─ Re-engaging old/lost leads? → re-engagement
+├─ Subject line help only? → subject-lines
+├─ Personalization at scale? → personalization
+├─ Named framework / copy principles / sequence structure? → copywriting
+├─ Domain setup / DNS / warmup / troubleshooting? → email-infra
+└─ General deliverability/tools? → Read resources directly
+```
+
+## Examples
+
+**Example 1: "Write me a cold email for a SaaS product targeting CTOs"**
+--> Check if CTO is strategic (VP-level) or technical (IC-level). If strategic → route to **atl-messaging**. If technical/hands-on → route to **btl-messaging**. Read `references/atl-btl-messaging.md`.
+
+**Example 2: "They didn't reply to my first email, what should I send?"**
+--> Route to **follow-up**. Ask for Email 1 copy. Draft Email 2 with different value prop, same thread.
+
+**Example 3: "My emails are going to spam"**
+--> Cross-cutting: deliverability. Read `references/deliverability-guide.md`. Diagnose SPF/DKIM/DMARC, check warmup, review volume.
+
+**Example 4: "How do I personalize at scale using Clay?"**
+--> Route to **personalization**. Read `references/personalization-prompts.md` + `references/campaign-playbooks.md`. Provide data bucket strategy and AI prompts.
+
+**Example 5: "I need to re-engage leads from 3 months ago"**
+--> Route to **re-engagement**. Read `references/email-templates-library.md`. Draft no-oriented question with new angle.
+
+**Example 6: "What subject line should I use?"**
+--> Route to **subject-lines**. Read `references/writing-frameworks.md`. Provide 3-5 options with A/B test recommendation.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/atl-btl-messaging.md
+++ b/skills/alex-vacca/cold-email-strategist/references/atl-btl-messaging.md
@@ -1,0 +1,105 @@
+# ATL vs BTL Messaging Framework
+
+## Above-the-Line (ATL) Messaging
+
+**Target:** VPs, C-Level, Directors
+
+**Mindset:**
+- Think past and future (strategic)
+- Want validation, not problems solved
+- Care about big picture, not daily operations
+
+**What They Care About:**
+- Revenue impact
+- Risk reduction
+- Strategic initiatives
+- Competitive positioning
+- Board/investor optics
+
+**Message Length:** 2-3 sentences only
+
+**Language to Use:**
+- "Strategic initiative"
+- "Revenue impact"
+- "Competitive advantage"
+- "Board-level priority"
+- "Risk mitigation"
+
+**Example ATL Email:**
+```
+Subject: Q1 revenue efficiency
+
+{{firstName}},
+
+If you could identify revenue leakage 3 months faster, what would that mean for next year's targets?
+
+We helped {{similar_company}}'s CEO do exactly that.
+
+15 minutes to explore?
+```
+
+**Fatal ATL Mistake:**
+Talking about operational problems = immediate delegation to subordinate
+
+---
+
+## Below-the-Line (BTL) Messaging
+
+**Target:** Managers, Individual Contributors, End-Users
+
+**Mindset:**
+- Think present (tactical)
+- Want problems solved immediately
+- Care about daily workflow
+
+**What They Care About:**
+- Daily pain points
+- Time savings
+- Workflow improvements
+- Making their job easier
+- Looking good to their boss
+
+**Message Length:** 3-4 sentences acceptable
+
+**Language to Use:**
+- "Stop spending 3 hours every week on..."
+- "Eliminate the manual work of..."
+- "Never deal with {{pain}} again"
+- "Save {{X}} hours per week"
+
+**Example BTL Email:**
+```
+Subject: 3 hours back
+
+Hey {{firstName}},
+
+Stop spending 3 hours every week fighting with Excel.
+
+We helped {{similar_company}}'s ops team cut their reporting time by 70%.
+
+Want to see how?
+```
+
+**Fatal BTL Mistake:**
+Talking about ROI and strategic impact = doesn't resonate, too abstract
+
+---
+
+## Decision Framework: Who to Target
+
+**Target ATL (Executives) When:**
+- Deal size > $50K ACV
+- Strategic/transformation purchase
+- Requires budget approval from top
+- Long sales cycle acceptable
+
+**Target BTL (End-Users) When:**
+- Product-led growth motion
+- User adoption drives expansion
+- Bottom-up sale
+- Need internal champion first
+
+**Multi-Thread (Both) When:**
+- Complex enterprise sale
+- Multiple stakeholders
+- Both budget holder and user buy-in needed

--- a/skills/alex-vacca/cold-email-strategist/references/atl-messaging.md
+++ b/skills/alex-vacca/cold-email-strategist/references/atl-messaging.md
@@ -1,0 +1,86 @@
+# Above-the-Line (ATL) Messaging
+
+You write cold emails for VP, C-Level, and Director personas. ATL targets think past and future (strategic), want validation not problems solved, and care about big picture -- not daily operations.
+
+## Process
+
+1. **Confirm ATL target** -- VP, C-Level, Director, or equivalent. If unclear, ask.
+2. **Identify strategic angle** -- Revenue impact, risk reduction, competitive positioning, board-level priority
+3. **Draft email** -- 2-3 sentences MAXIMUM. Strategic language. No operational details.
+
+## Reference
+
+Read `atl-btl-messaging.md` — focus on the **Above-the-Line (ATL) Messaging** section for the strategic language guide, decision framework, and fatal mistakes. Ignore the BTL section.
+
+## ATL Rules
+
+- **2-3 sentences only** -- Executives skim. Every word must earn its place.
+- **Strategic language** -- "Revenue impact", "competitive advantage", "risk mitigation", "board-level priority"
+- **Lead with outcome, not process** -- They care about WHAT changes, not HOW it works
+- **No operational details** -- Mentioning daily workflows gets you delegated to a subordinate immediately
+- **Question format works well** -- Prompt strategic reflection: "What would it mean for Q2 targets if..."
+
+## What ATL Personas Care About
+
+- Revenue impact
+- Risk reduction
+- Strategic initiatives
+- Competitive positioning
+- Board/investor optics
+
+## Fatal Mistake
+
+Talking about operational problems (time saved, workflow fixes, manual processes) to an executive = instant delegation to a subordinate. Your email gets forwarded down and you lose the thread.
+
+## When to Target ATL
+
+- Deal size > $50K ACV
+- Strategic/transformation purchase
+- Requires budget approval from the top
+- Long sales cycle is acceptable
+
+## Examples
+
+**Example 1: CEO of a mid-market SaaS**
+```
+Subject: Q1 revenue efficiency
+
+{{firstName}},
+
+If you could identify revenue leakage 3 months faster, what would that mean for next year's targets?
+
+We helped {{similar_company}}'s CEO do exactly that.
+
+15 minutes to explore?
+```
+
+**Example 2: VP Sales at a scaling company**
+```
+Subject: pipeline visibility
+
+{{firstName}},
+
+{{company}}'s growth from {{X}} to {{Y}} ARR usually exposes blind spots in pipeline forecasting.
+
+{{similar_company}}'s VP Sales closed that gap and beat board targets by 18% last quarter.
+
+Worth a conversation?
+```
+
+**Example 3: CTO evaluating security**
+```
+Subject: risk exposure
+
+{{firstName}},
+
+The average cost of a data breach in {{industry}} hit $4.5M this year.
+
+{{similar_company}}'s CTO reduced their attack surface by 60% in 90 days.
+
+Open to a quick comparison?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/btl-messaging.md
+++ b/skills/alex-vacca/cold-email-strategist/references/btl-messaging.md
@@ -1,0 +1,88 @@
+# Below-the-Line (BTL) Messaging
+
+You write cold emails for Managers, Individual Contributors, and End-Users. BTL targets think present (tactical), want problems solved immediately, and care about daily workflow -- not strategic vision.
+
+## Process
+
+1. **Confirm BTL target** -- Manager, Specialist, Analyst, Coordinator, or IC. If unclear, ask.
+2. **Identify daily pain** -- What frustrates them every day? What wastes their time?
+3. **Draft email** -- 3-4 sentences. Operational language. Specific time/effort savings.
+
+## Reference
+
+Read `atl-btl-messaging.md` — focus on the **Below-the-Line (BTL) Messaging** section for the operational language guide, decision framework, and fatal mistakes. Ignore the ATL section.
+
+## BTL Rules
+
+- **3-4 sentences acceptable** -- More detail than ATL, but still concise
+- **Operational language** -- "Stop spending 3 hours on...", "Eliminate the manual work of...", "Save X hours/week"
+- **Lead with daily pain** -- Name the specific frustration they deal with regularly
+- **Quantify time/effort savings** -- "70% less time on reporting" resonates more than "improved efficiency"
+- **Make them look good to their boss** -- BTL personas care about performance perception
+
+## What BTL Personas Care About
+
+- Daily pain points
+- Time savings
+- Workflow improvements
+- Making their job easier
+- Looking good to their boss
+
+## Fatal Mistake
+
+Talking about ROI, strategic impact, and board-level priorities to a manager or IC = does not resonate. It is too abstract. They do not think in those terms. You will get ignored.
+
+## When to Target BTL
+
+- Product-led growth motion
+- User adoption drives expansion
+- Bottom-up sale
+- Need an internal champion first
+
+## Examples
+
+**Example 1: Marketing Ops Manager**
+```
+Subject: 3 hours back
+
+Hey {{firstName}},
+
+Stop spending 3 hours every week fighting with Excel to build campaign reports.
+
+We helped {{similar_company}}'s ops team cut their reporting time by 70%.
+
+Want to see how?
+```
+
+**Example 2: SDR Team Lead**
+```
+Subject: manual prospecting
+
+Hey {{firstName}},
+
+How much time does your team spend on manual list building each week?
+
+Most SDR leads I talk to say 5-6 hours per rep.
+
+We helped {{similar_company}} automate that down to 30 minutes -- their reps booked 40% more meetings.
+
+Worth a quick look?
+```
+
+**Example 3: Data Analyst**
+```
+Subject: data cleanup
+
+Hey {{firstName}},
+
+If you're anything like other {{title}}s at {{industry}} companies, you're spending 10+ hours/week cleaning and merging data from different sources.
+
+{{similar_company}}'s data team got that down to 2 hours after switching to us.
+
+Want to see the workflow?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/campaign-playbooks.md
+++ b/skills/alex-vacca/cold-email-strategist/references/campaign-playbooks.md
@@ -1,0 +1,188 @@
+# Campaign Playbooks
+
+*Source: The Kiln Gitbook — Clay Agency*
+
+## 1. AI Personalized Video Campaign (Sendspark)
+
+**Concept:**
+- AI video that says "Hi {{first_name}}"
+- Background = scrolling the prospect's website
+- Rest of the video = templatized
+
+**Setup:**
+1. Clay enriches prospect data
+2. Sendspark generates the custom video
+3. HTTP API connects the two
+4. Push to sequencer
+
+## 2. DynaPictures — Custom Images
+
+**Example CVS Campaign:**
+- Client sells ads in CVS stores
+- Scrape prospects' Facebook/Google Ads
+- Layer their ad onto an image of the CVS mini-billboard
+- Send the personalized image by email
+
+**Setup:**
+1. Ad library scraping → Clay
+2. DynaPictures API (HTTP API action)
+3. Custom image generation per prospect
+4. Push to campaign
+
+## 3. Lookalike Campaigns
+
+**Types:**
+- Lookalikes of closed-won clients
+- Lookalikes of positive responders
+- Lookalikes of newsletter engagers
+
+**How:**
+1. Import your best customers into Clay
+2. Enrich to find common patterns
+3. Use those criteria to build similar lists
+4. Outreach with messaging "companies like yours..."
+
+## 4. LinkedIn Follower Campaign (Battle Cards)
+
+**Concept:**
+- Scrape competitor followers (via ScrapeApp)
+- Import into Clay
+- Create battle cards (your product vs competitor)
+- Personalized outreach
+
+**Template:**
+```
+Hey {{first_name}},
+
+I noticed you follow {{competitor_name}} on LinkedIn.
+
+Here are 3 reasons why companies switch from {{competitor}} to us:
+1. [Downside 1 of competitor]
+2. [Downside 2]
+3. [Downside 3]
+
+Would you be open to a quick comparison call?
+```
+
+## 5. Job Opening Intent Signal
+
+**Signal:** Company hiring for specific role = need for your solution
+
+**Workflow:**
+1. Monitor job postings (via LinkedIn, Indeed scraping)
+2. Filter by relevant roles
+3. Find decision makers
+4. Outreach: "I saw you're hiring for X, companies in this phase usually need Y..."
+
+## 6. Ad Library Scraping Campaign
+
+**Platforms:**
+- Facebook Ad Library
+- Google Ads transparency
+- LinkedIn Ad Library
+
+**Use cases:**
+- Reference their current ads in outreach
+- Use their ad creative in custom images
+- Analyze their messaging for personalization
+
+## Full Outbound Example — ClickUp Brain Campaign
+
+*Case study of a real campaign*
+
+### Context
+- Product: ClickUp Brain (AI workspace)
+- Target: Fortune 500 managers (product, project, senior managers)
+- Goal: Bottom-up adoption → Enterprise upsell
+
+### Clay Table 1: Fortune 500 Companies
+
+| Column | Source | Purpose |
+|--------|--------|---------|
+| Company Name | Import | Base |
+| LinkedIn URL | Enrich Company | Matching |
+| Headcount Growth YoY | Enrichment | Intent signal #1 |
+| +10% Growth? | Formula (checkbox) | Filtering |
+| Recent News | Find Recent News | Intent signal #2 |
+| Acquisition? | Formula (checkbox) | Filtering |
+| Contact Page URL | Claygent | Backup data |
+| Fundraising Data | Enrichment | Context |
+
+### Clay Table 2: People at Fortune 500
+
+| Column | Source | Purpose |
+|--------|--------|---------|
+| Person Name | Find People | Contact |
+| Job Title | Find People | Targeting |
+| Department | AI Classification | Personalization |
+| LinkedIn Profile | Enrich Person | Data |
+| Example Docs | AI Generation | Personalization |
+| Custom Use Cases | AI (ClickUp features + company context) | Email copy |
+| Work Email | Waterfall | Outreach |
+| Custom First Line | AI (based on intent signals) | Email copy |
+
+### Email Copy Structure
+```
+FIRST LINE (intent-based):
+- If +10% growth: "Congrats on {{company}}'s recent growth..."
+- If acquisition: "I saw {{company}} recently acquired {{acquired_company}}..."
+- Else: Generic but personalized line
+
+VALUE PROP:
+"Have you ever wished you could create a bot out of {{company}}'s
+{{department}} docs and ask a question whenever you had one?"
+
+USE CASES:
+"For example, at {{company}} you could use ClickUp Brain to:
+{{custom_use_cases_based_on_their_docs}}"
+
+SOCIAL PROOF + CTA
+```
+
+### Key Takeaways
+1. **Multi-signal intent:** Stack headcount growth + acquisition news
+2. **Department-based personalization:** Different docs for different roles
+3. **AI-generated use cases:** Based on company description + ClickUp features
+4. **Formula-based email assembly:** Merge all pieces cleanly
+
+## Inbound Example — Triggery + Google Reviews
+
+### Workflow
+```
+LinkedIn Post Engagement (Triggery webhook)
+          ↓
+    Clay Table
+          ↓
+    Enrich Company
+          ↓
+    Match to Service Offering
+          ↓
+    Find Google Reviews
+          ↓
+    Extract Reviewer Name + Review Content
+          ↓
+    Generate Custom Message
+          ↓
+    Push to SmartLead
+```
+
+### Email Example
+```
+Hey {{first_name}},
+
+Saw you engaged with our post about {{post_summary}}.
+
+I noticed on Google that {{reviewer_name}} left a great review
+about how {{company}} helped them with {{review_summary}}.
+
+We help {{industry}} companies like yours with exactly that.
+For example, {{matched_case_study}}.
+
+Would you be open to a quick chat?
+```
+
+### Power Moves
+1. **Reviewer name in email** = Proves you actually researched
+2. **Industry-specific case study** = Relevant social proof
+3. **Post reference** = Warm intro (they engaged first)
+4. **Local business focus** = Google Maps data where LinkedIn fails

--- a/skills/alex-vacca/cold-email-strategist/references/cold-email-mastery.md
+++ b/skills/alex-vacca/cold-email-strategist/references/cold-email-mastery.md
@@ -1,0 +1,150 @@
+# Cold Email Mastery — 25 Lessons from 10M+ Emails
+
+*Source: Growth Engine X — 1.5-2M emails/month for 40-50 clients*
+
+## Email Infrastructure
+
+**Volume per inbox:**
+- 30 emails max per inbox
+- Scale horizontally (more inboxes, not more volume per inbox)
+
+**Open rate targets:**
+- 40-60% = good
+- <30% = deliverability problem
+- Solution: new domains, warm up 3 weeks, restart
+
+**Don't waste time:**
+- If <1% reply rate → no need for seed tests or Glock apps
+- Result will always be: new domains + new copy + restart
+
+**Max 3 emails per sequence:**
+- Email 1 = always best performance
+- Email 2 & 3 = diminishing returns
+- More than 3 = you annoy and get marked as spam
+
+## TAM Reuse
+
+**Golden rule:** Reuse your list every 3 months
+- People don't remember your email from 20 minutes ago
+- Their priorities/business change
+- Calculate: how many emails/day to recycle the TAM in 3 months
+
+## Filtering & Golden ICP
+
+**The problem:**
+- Director of Marketing at a 20-person bank ≠ Director of Marketing at a 500-person bank
+- Generic filters (20-500 employees) don't work
+
+**Solution — Golden ICP:**
+Stack signals with Clay:
+
+| Level | Signal | Example |
+|-------|--------|---------|
+| 1 | Recently founded | < 2 years |
+| 2 | Funded | Raised money |
+| 3 | CEO first-time | Never been CEO before |
+
+**Waterfall the signals:**
+- Run the most important signal FIRST
+- Conditional formulas to not enrich if signal #1 fails
+- Change messaging based on how many signals are true
+
+## Best Triggers
+
+**2023: Recently Joined Company**
+- "Hey congrats on the new role, as you're taking over..."
+- Still reliable but somewhat overused now
+
+**2024+: Social Signals (THE BEST)**
+- LinkedIn posts
+- Content engagement
+- Posts about certain keywords
+
+*Real example:* Offshore staffing company — the "LinkedIn post" trigger beat all other "logical" triggers (new hire, funded, international hiring, etc.)
+
+## The 3-Email Framework
+
+### Email 1: Introduce the Offer
+```
+Line 1: Why you, why now (why I'm reaching out now)
+Line 2: Your offer clearly explained (short!)
+Line 3: Social proof (you're not their first client)
+Line 4: CTA (Would you want to chat next Thursday?)
+```
+
+### Email 2: Add Context
+- Everything you had to cut from email 1
+- It's threaded, they can scroll to see email 1
+- Still short but more details
+
+### Email 3: Lower the Friction
+- They didn't respond twice → they're not convinced
+- Free lead magnet
+- Custom Loom audit
+- Less demanding CTA
+
+**Delay between emails:** 3-5 days (1 day = too short)
+
+## Breakup Emails = STOP
+
+**What doesn't work:**
+- "You must be getting chased by an alligator..."
+- Begging for a response
+
+**What works:**
+- "Am I reaching the right person?"
+- "Is there someone else in the company who handles this?"
+- Bonus with Clay: automatically name other people in the department
+
+## Changing Value Props
+
+**Between emails:**
+- Email 1: Save money
+- Email 2: Make money
+- Email 3: Save time
+
+**The "So What":**
+- "We help you save 3 hours/month" → not enough
+- "We help you save 3 hours/month so your SDRs can spend more time actually selling" → BETTER
+
+## Using AI Correctly
+
+**Show your work:**
+- Bad: "I see you get 50,000 visitors/month"
+- Good: "According to SimilarWeb, you get 50,000 visitors/month"
+- If it's wrong, SimilarWeb is wrong, not you
+
+**Client case studies:**
+- Claygent can scrape their site's case studies
+- "I noticed you worked with Intercom and helped them with XYZ"
+- PS line: "Even if we never connect, saw the case study... really impressive, kudos"
+
+**Don't have AI write the entire email:**
+- Control the messaging for split-testing
+- Use AI for ONE specific part
+- The rest = static text
+
+## Small TAM Strategy (<20,000 people)
+
+**Omni-channel (actually):**
+1. Cold email everyone
+2. Cold call everyone
+3. LinkedIn message everyone
+4. Direct mail the rest
+
+**NO complex threading:**
+- Email day 1 → Call day 3 → DM day 5 = too much stress
+- Do one channel at a time, exhaustively
+- Same results, less complexity
+
+## Performance Benchmarks
+
+**2X Levers (metrics you can realistically double):**
+- Cold email reply rate: 0.5-1.0%
+- Email open rate: 20-40%
+- Email click rate: 2-5%
+
+**Signal-based benchmarks:**
+- Cold outreach: 6-8% reply rate
+- Signal-based: 18-22% reply rate
+- Multi-signal stacked: 35-40% reply rate

--- a/skills/alex-vacca/cold-email-strategist/references/copywriting-ecom-playbook.md
+++ b/skills/alex-vacca/cold-email-strategist/references/copywriting-ecom-playbook.md
@@ -1,0 +1,138 @@
+# Outbound to E-Commerce Brands — The Playbook
+
+Specific playbook for selling services to e-commerce brands via cold email.
+
+---
+
+## The E-Com Reality Check
+
+E-commerce founders and marketing heads are flooded:
+- 100+ cold emails per day hitting their inbox
+- Ignoring most messages by default
+- Extremely jaded by overhyped case studies
+- Trust at rock-bottom
+- They've heard every "Klaviyo audit," "2x ROAS," and "$50k/mo email marketing" pitch ten thousand times
+
+**The question:** If the entire market is saturated and skeptical, how do you break through?
+
+**The answer:** You have to OFFER MORE and DO MORE than every other agency. Your offer is the only thing that will break the pattern.
+
+---
+
+## Why Most Agency Offers Fail
+
+These offers are dead:
+- "Free Klaviyo audit"
+- "2x ROAS in 90 days"
+- "Add $50k/mo with email marketing"
+
+E-com brands have seen them for a decade. Nothing feels new, safe, or worth replying to.
+
+---
+
+## What Actually Works: Low-Risk, High-Value, Easy-Yes Offers
+
+Offers that convert because they do the work upfront:
+
+### Free Work Offers
+
+- Free welcome flow for their newsletter
+- Free cart-abandonment flow
+- Free product page rewrite
+- Free ad creative example
+- Free TikTok concept storyboard
+- Free UGC script
+- Free CRO audit (with screenshots)
+- Free checkout page mock-up
+
+**Why these work:**
+- Give value before money is discussed
+- Require zero commitment
+- Prove your skills without bragging
+- Feel specific, not generic
+
+### Lead Magnet Ideas
+
+- "How we grew Brand X's AOV by 27% with simple checkout tweaks"
+- "5 TikTok Shop optimizations that boosted 14% conversion overnight"
+- "Why 92% of Shopify brands waste money on Meta ads"
+- "3 hooks dominating TikTok ads this quarter"
+
+### Trends to Watch (Offer Angles)
+
+- TikTok Shop setup/optimization
+- Influencer-driven creative
+- Micro-UGC bundles
+- Onsite CRO quick wins
+- Top-of-funnel TikTok ad concepts
+- Checkout optimization
+
+---
+
+## E-Com List Building (Keep It Simple)
+
+### Step 1: Broad List in Apollo
+
+- Industry Keywords: Apparel, Beauty, Health & Wellness, Jewelry, Outdoor, Supplements
+- Technology filters: Shopify, WooCommerce, Klaviyo
+- 10K–50K rows at a time is normal
+
+### Step 2: Qualification in Clay
+
+- Confirm it's actually an e-com brand
+- Optional: check if they run Meta/TikTok ads
+- Add revenue or traffic estimates if helpful
+
+### Step 3: Waterfall Enrichment
+
+- Apollo → LeadMagic → Prospeo → Findymail (or your preferred stack)
+
+**Why this works:** You don't need fancy data tools. You need reach, relevance, and speed. Apollo + Clay covers that.
+
+---
+
+## E-Com Messaging Rules
+
+E-com founders don't want to read essays.
+
+1. **15–30 words max**
+2. Emphasize the offer, not the agency
+3. Only include case studies if the brand is well-known
+4. Always offer a lead magnet
+5. Keep the tone casual and value-first
+6. No paragraphs longer than one line
+
+---
+
+## Proven E-Com Frameworks
+
+### Email A: Free Work Offer
+
+> {{FIRST_NAME}}, interested in {{FREE WORK}} for {{COMPANY}}?
+>
+> We recently helped {{CLIENT}} with {{RELEVANT PROJECT}} achieve {{RESULT}}, figured this might help. Thoughts?
+
+### Email B: Lead Magnet Offer
+
+> {{FIRST_NAME}}, created {{LEAD MAGNET}} showing how we generated {{RESULT}} for {{CLIENT}} using {{UNIQUE STRATEGY}}. Want me to send it?
+
+---
+
+## Key Takeaways
+
+Winning in e-com outbound is NOT about:
+- Being louder
+- Sending more emails
+- Having a bigger case study deck
+
+It IS about:
+- Being more relevant
+- Delivering more value upfront
+- Crafting an offer that feels new and safe
+- Respecting the founder's time
+
+When everyone else sends the same tired "audit" email, you send something that actually helps. That's how you break through.
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/copywriting-frameworks.md
+++ b/skills/alex-vacca/cold-email-strategist/references/copywriting-frameworks.md
@@ -1,0 +1,333 @@
+# Cold Email Copywriting — Frameworks
+
+Named frameworks with templates and examples. Each framework is battle-tested and credited to its creator.
+
+---
+
+## Quick Reference
+
+| Framework | Best For | Creator |
+|---|---|---|
+| Do the Math | Quantifiable ROI, clear business case | Thibaut Souyris |
+| Short Trigger | Quick, trigger-based outreach | Guillermo Blanco |
+| Challenge of Similar Companies | Industry-wide pain points | Patrick Trümpi |
+| Neutral Insight | Sharing third-party content | Chelsea Castle |
+| Leader Responsibilities | Role-specific curiosity | Vin Matano |
+| Ask Before Pitch / Pattern Interrupt | Flipping the script | Will Allred |
+| Not Too Different Persona | Peer similarity | BowTiedSalesGuy |
+| Upfront Value | Leading with free value | Jordan Crawford |
+| Leverage Content in Outbound | Using lead magnets | Ethan Parker |
+| "Why Are You Paying?" | Analogy-based persuasion | Leif Bisping |
+| Write a Good Cold Email | Problem-first structure | Josh Braun |
+| HOT Outreach | Peak interest → value → CTA | — |
+| Manual Email Style | Casual, human, low-pressure | Josh Braun (Henry's email) |
+
+---
+
+## Do the Math
+
+**By Thibaut Souyris** — Best when you can put numbers to the problem.
+
+**Template:**
+1. **Trigger:** The reason for reaching out. Better with a number.
+2. **Quick pitch:** Short explanation of the qualified impact.
+3. **Calculation:** Back-of-napkin math.
+4. **CTA:** Ask for interest.
+
+**Example:**
+
+> Mary, noticed you have over 50 open positions on your job portal.
+>
+> We help tech scale-ups reduce their new employee churn from 30% to 10% or less.
+>
+> With a typical cost of mis-hire around $30,000 per employee, this would mean going from 15 mis-hires to 5, resulting in $300,000 saved.
+>
+> Worth a chat?
+
+---
+
+## Short Trigger-Based Outreach
+
+**By Guillermo Blanco** — Best for quick, punchy, under-30-word emails.
+
+**Template:**
+1. Relevant trigger (personalization)
+2. Validation + value prop
+3. CTA
+
+**Example:**
+
+> G, saw that Reach's latest blog post doesn't include a Meta tag which can affect its online visibility.
+>
+> {{client}} improved theirs by creating meta tags using ChatGPT.
+>
+> Can I share how?
+
+---
+
+## Challenge of Similar Companies
+
+**By Patrick Trümpi** — Best when the industry has a known, widespread pain point.
+
+**Template:**
+1. Personalization (if available)
+2. Challenge others in the industry face
+3. Solution
+4. CTA
+5. P.S. with something funny or personalized
+
+**Example:**
+
+> Hey Patrick,
+>
+> We are working with a lot of security officers at banks who faced losses of $9K per hour due to ransomware and had phishing victims every 11 seconds.
+>
+> We have a global team of experts available 24/7 to respond to and contain cyber incidents and can react in hours not days. When is the last time you tested your plan?
+>
+> Cheers,
+> P.
+>
+> PS: I would attach a link but we both work in security 😅
+
+---
+
+## Neutral Insight
+
+**By Chelsea Castle** — Best when you have a relevant third-party resource to share.
+
+**Template:**
+1. **Reference a third-party resource** — bring a trusted publication to the discussion
+2. **Explain why they should read it** — tie to their context
+3. **Explain why you're sharing it** — connect to their business needs
+4. **Optional:** Soft ask and nod back to original CTA
+
+**Example:**
+
+> George, do you read Outreach's blog?
+>
+> Given you're likely ramping reps, I thought you'd find it interesting.
+>
+> The VP of Sales Dev at Segment wrote about how she scaled her team to a $3.2B acquisition.
+>
+> They did it without using canned templates. (and using Lavender!)
+>
+> Check it out
+>
+> Will
+>
+> P.S. Any thoughts on my last note?
+
+---
+
+## Leader Responsibilities
+
+**By Vin Matano** — Best for reaching role-specific leaders with curiosity.
+
+**Template:**
+
+> {{First Name}} as a {{role}} leader, curious how {{responsibility}}
+>
+> Either way, {{personalize}}!
+
+**Example:**
+
+> Armand, as a Sales leader, curious how your reps prioritize which accounts to reach out to?
+>
+> If I can create a list for your team of Accounts researching competitors like Salesforce would it be worth a conversation?
+>
+> Either way, congrats on recently being named Top Sales Coach!
+
+---
+
+## Ask Before Pitch / Pattern Interrupt
+
+**By Will Allred** — Flips the typical cold email by leading with a question.
+
+**Template:**
+
+> Hey {{first_name}}, [open-ended question as CTA]
+>
+> You're [trigger/observation]. [Potential problem from observation]
+>
+> [How product solves problem]
+>
+> PS — Relevant because _____
+
+**Example:**
+
+> Hey Will, think this would help George & Anne?
+>
+> You're hiring new sellers. Despite the same templates, some reps get results and others don't.
+>
+> Lavender gives you a clearer picture on why things work. We've even seen it identify clear personalization plays for the team to use.
+>
+> Figured that'd be relevant with the new focus upmarket.
+>
+> Let me know.
+
+---
+
+## Not Too Different Persona
+
+**Seen on BowTiedSalesGuy** — Best when you can reference peers with the same problem.
+
+**Template:**
+
+> I work with [ICP similar to target]
+>
+> They tell me they struggle with [...]
+
+**Key idea:** Position yourself as someone who already understands their world because you work with people just like them.
+
+---
+
+## Upfront Value
+
+**By Jordan Crawford** — Lead with free value, no pitch.
+
+**Template:**
+
+> [here is "value offering"] hope it was helpful
+
+**Example:**
+
+> Here's a list of every founder at every company that just implemented HubSpot... I hope it was helpful.
+
+---
+
+## Leverage Content in Outbound
+
+**By Ethan Parker** — Use a lead magnet as the entry point.
+
+**Template:**
+
+> Hi {{first_name}}, [name of content] [how it helps].
+>
+> Can I send it over to you?
+>
+> PS — Thought this was relevant because _____
+
+**Example:**
+
+> Hey Jason — we've compiled a cheat sheet on how folks like [social proof] are getting their AEs self-sourcing more than 30% of their own pipeline.
+>
+> Can I send it over to you?
+>
+> Ethan
+>
+> PS — Thought this was relevant because I saw you recently decreased your SDR headcount and are hiring 3 more AEs right now.
+
+---
+
+## "Why Are You Paying?"
+
+**By Leif Bisping** — Analogy-based persuasion.
+
+**Tips:**
+1. Set the stage by describing a typical life situation
+2. Describe an obvious choice given several options
+3. Compare it to a "choice" the prospect is making relating to your solution
+
+**Key idea:** Make the prospect realize they're overpaying or overworking for something that should be simple — through a relatable analogy, not a pitch.
+
+---
+
+## Write a Good Cold Email
+
+**By Josh Braun** — Problem-first framework.
+
+**Framework (thinking process before writing):**
+1. Who are you targeting?
+2. What problem are you trying to solve?
+3. What are they currently doing to solve it?
+4. What's the problem with their current solution (and other solutions)?
+5. How does your solution solve it differently?
+
+**Rules:**
+1. Follow the structure
+2. Be crispy or specific
+3. Stay away from generic words ("optimize," "streamline," "save time," "save money")
+4. Focus on what sucks about how they currently get the job done — not your value prop. Solutions have no value without a problem people can relate to.
+
+**Example (for CaptivateIQ):**
+
+> James, honestly now — did you spend your youth dreaming about someday hard-pasting entire Excel pages into Google Sheets and then manually making adjustments, one sheet at a time to determine payouts?
+
+---
+
+## Manual Email Style
+
+**Josh Braun — Henry's cold email** — Casual, human, low-pressure.
+
+**Example:**
+
+> Hey Josh — Subscribed to your email list a few weeks ago. I've been doing digital marketing for eight years — have a few unconventional ideas that might goose sales of your Badass Guide without offering discounts.
+>
+> I don't get paid unless you make more.
+>
+> Worth batting around a few ideas? Henry.
+>
+> P.S. Not sure it's a fit for you, but several course creators I'm working with are seeing a 10-12% MoM boost in sales.
+
+**Why it works:**
+- "Subscribed" — personalization
+- "Don't get paid unless you make more" — lowers zone of resistance (ZOR)
+- "Not sure it's a fit" — also lowers ZOR, sounds curious not pushy
+- "10-12% increase" — plausible and exciting social proof
+- "A few unconventional ideas" — piques curiosity
+- "I don't get paid unless you make more" — we're in this together, not a hit-and-run
+- Casual writing — feels more relatable
+
+---
+
+## HOT Outreach Template
+
+Three-section structure for maximum impact.
+
+### Section 1: Peak Interest (the problem you found)
+
+Three options:
+1. **Say the problem you found** — "Your website is slow," "Your podcast clips are edited poorly," "Your current funnel is flawed"
+2. **Mention something not obvious** — "I listened to what you said in X," "You have a TikTok account but no TikTok shop," "You're not using email automations"
+3. **Anything related / connection** — "I also love X place," "X UFC fight was amazing yesterday"
+
+### Section 2: The Value (what makes you an expert)
+
+**Give them the answer. Whatever you want them to pay you for, give them something right now.**
+
+Examples:
+- "If you change your email to long form, you will easily get a 20% open rate difference"
+- "I re-edited a video of yours — it's here and why I did XYZ"
+- "I looked at your engagement, website traffic, etc. and think a TikTok shop would sell around 2K orders a month"
+
+### Section 3: About You and CTA
+
+- I am X from Y
+- I have done Z
+- I think I can help you here
+- **Always end with a question**
+
+**Don't:** "Let me know," "Let's get a call"
+**Do:** "What do you think of your short form content?" "Have you bought anything from TikTok shop?"
+
+---
+
+## Frontal Sequence Base (Quick Reference)
+
+Trigger-based message with soft CTA. Pick your trigger:
+
+| Trigger Type | Template Pattern |
+|---|---|
+| Case study | [One-line case study] — already done so for {{company X}} |
+| Observation | [Observation] — see you're doing X |
+| Hiring | Hiring for {{job_title}} who can {{job_summary}} |
+| Growth | Growing headcount across {{department}} |
+| Tech stack | Using {{software}} for {{topic}} |
+| Ads | Running ads on {{platform}} |
+| Pain/KPI | [Common problem] we see is X which leads to Y. Does that resonate? |
+| Give ideas | Have a problem? Here's an idea to solve it |
+| Break-up | Timing is off, priority soon? |
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/copywriting-principles.md
+++ b/skills/alex-vacca/cold-email-strategist/references/copywriting-principles.md
@@ -1,0 +1,265 @@
+# Cold Email Copywriting — Principles
+
+Core philosophy, rules, components, tips, and spam avoidance for writing cold emails that actually get replies.
+
+For named frameworks, see [copywriting-frameworks.md](copywriting-frameworks.md).
+For sequence structures (Email 1–3 variations), see [copywriting-sequences.md](copywriting-sequences.md).
+For e-commerce specific playbook, see [copywriting-ecom-playbook.md](copywriting-ecom-playbook.md).
+
+---
+
+## The Core Philosophy
+
+If you want your emails to draw attention, you need to make the reader think:
+
+**"There's no way this email was for anyone else but me."**
+
+Three things make a cold email NOT boring:
+1. **Personal** — feels written for that one person
+2. **Short** — gets the point across in as few lines as possible
+3. **Valuable** — gives something worth their time
+
+### What Makes Cold Emails Boring
+
+- Impersonal or irrelevant (or both) — "industry leaders like yourself" sent to 10,000 people
+- Unnecessarily long — nobody reads essays from strangers
+- Generic value props — "optimize," "streamline," "save time"
+
+---
+
+## The Rules
+
+**Bend these at your discretion — copywriting is more art than science. But these are the defaults:**
+
+1. **Under 100 words** (ideally 60–90)
+2. **More about them than you**
+3. **Benefits over features**
+4. **Solve a problem they actually have**
+5. **Personalize or make it hyper-relevant**
+6. **Pick your offer wisely**
+7. **Provide value before asking for anything**
+
+---
+
+## Main Components of a Cold Email
+
+Every email should have most of these:
+
+### 1. Observation (Opener)
+
+What you noticed about them. This is your hook — it must be relevant.
+
+**Two types:**
+- **Trigger-based** — a relevant event (hiring, funding, product launch, tech change)
+- **Recency-based** — something recent (news, blog post, LinkedIn activity)
+
+**Good observations tie to the problem you solve:**
+- Change in their industry likely to impact their business
+- Hiring trends / headcount growth or reduction
+- Opening of new office locations
+- Appointment of a new C-level
+- Launch of a new product
+- Increase in ad spend
+- Merger / acquisition
+- Recent fundraising
+- Bad Glassdoor reviews (if selling HR/culture tools)
+- Remote-first setup (if selling remote collaboration tools)
+- Average employee tenure (if selling retention tools)
+
+**The observation becomes your opener:**
+- "Hey, I was looking at {{company}} on LinkedIn, and I noticed the average tenure is below 6 months"
+- "Saw that Reach's latest blog post doesn't include a Meta tag which can affect its online visibility"
+- "Noticed you have over 50 open positions on your job portal"
+
+### 2. Value Proposition
+
+What you actually do, stated in terms of outcomes:
+- **Make money** — increase revenue, pipeline, conversions
+- **Save money** — reduce costs, prevent waste
+- **Save time** — automate, simplify, eliminate manual work
+
+**Be specific, not generic:**
+- Bad: "We help companies optimize their sales process"
+- Good: "We help tech scale-ups reduce new employee churn from 30% to 10% or less"
+
+### 3. Social Proof
+
+Quantifiable results from real companies:
+- "Companies like Uptech & Metadata increased average goal achievement by 40%"
+- "LinkedIn, Netflix, and Indeed save 100s of hours weekly using our tool"
+- "We recently helped {{client}} achieve {{result}} in {{timeframe}}"
+
+**Rules for social proof:**
+- Use numbers (%, $, time saved)
+- Name real companies (if they're recognizable)
+- Keep it to one sentence max
+
+### 4. Call to Action (CTA)
+
+**Soft CTA** (lower commitment — usually performs better):
+- "Would this be something you're looking to solve?"
+- "Worth exploring?"
+- "Can I share how?"
+- "Sound relevant?"
+- "What do you think?"
+
+**Hard CTA** (direct ask):
+- "Worth a chat?"
+- "Open for a quick call this week?"
+
+**Avoid:** "Let me know" and "Let's get a call" (too vague or too pushy).
+
+**Always end with a question** — it invites a reply.
+
+### 5. P.S. Line (Bonus)
+
+A great spot for:
+- A personalized joke or observation
+- A second social proof point
+- A cheeky line that shows personality
+- "P.S: Let me know if someone else would be the right person to talk to about this"
+
+---
+
+## Research & Segmentation
+
+Before writing the email, ask: **Who should I go after? Who is struggling the most with the problem I solve?**
+
+### Finding Buying Signals
+
+If you have existing clients, ask:
+- What made them want to reach out?
+- What made them buy?
+- What patterns do they share?
+
+### Examples of Buying Signals
+
+| Signal | What It Means | Example Use |
+|---|---|---|
+| Bad Glassdoor reviews | High churn, unhappy employees | Selling HR/culture/retention tools |
+| Remote-first company | Harder to monitor wellbeing | Selling remote collaboration/engagement |
+| Short average tenure (<6mo) | Active retention problem | Selling employee engagement platforms |
+| Hiring for specific roles | Budget allocated, active need | Selling tools that serve those roles |
+| Recent funding | Fresh capital to spend | Any B2B solution |
+| Increasing ad spend | Growing acquisition efforts | Selling marketing/creative services |
+| Tech stack changes | Open to new vendors | Selling competing/complementary tools |
+
+**The signal becomes the opener. The opener draws attention because you're highlighting an issue they know they have.**
+
+---
+
+## Tips from the Best
+
+### Ask Yourself Before Sending (Eric Nowoslawski)
+1. How can I make this email worth this person's time?
+2. How can I say it like a human would say it?
+3. What can you say in a cold email that your competitors can't say?
+
+### Be Cheeky (Josh Braun)
+People don't lose their sense of humor when they go to work. When you make a prospect smile, their brain says "Hey, that made me feel good; I'm going to respond."
+
+**Funny sign-off examples:**
+- "Awaiting your fair but stern reply."
+- "Awaiting your profanity-filled response."
+
+### Be Specific / Crispy (Josh Braun)
+The more specific you are, the more credible you are.
+
+**Don't say this → Say this instead:**
+
+| Don't | Do |
+|---|---|
+| "Lose 50 pounds in 2 weeks" | "Are you open to a different perspective for losing weight without dieting?" |
+| "Build a $1M portfolio in 60 days" | "How are you protecting your portfolio against market downturns?" |
+| "Increase sign-ups by 10X" | "Have you considered using finfluencers on TikTok to reach young customers?" |
+| "We reduce shipping costs" | "We're seeing e-com companies in the pet space overpaying for shipping by 10-15%. One reason is the weight and dimensions of boxes for pet products. Worth exploring for Animal Pharm?" |
+
+### Write with an Eraser (Josh Braun)
+Cut ruthlessly. Every word must earn its place.
+
+### Use Loss Aversion
+Frame what they're losing by NOT acting, not just what they'd gain.
+
+### Offer Rules
+Don't make the offer too good to be true (even if it is). Plausible > grandiose.
+
+### Subject Lines
+- 1–3 words on the subject matter
+- Add a space or two before the subject to create a pattern interrupt
+- Keep it casual and curiosity-driven
+
+---
+
+## Personalization: Dos and Don'ts
+
+### Don't
+- Generic AI compliments ("Loved your post about leadership!")
+- Sound the same as what the prospect already gets
+- One bit of irrelevant info about their school or hobby
+
+### Do
+- Custom prompts that reference real, relevant data
+- Interests/facts that prospects consistently care about
+- Observations tied to the problem you solve
+
+**Example:** Personalizing based on when the business was founded — founders are immensely proud of their longevity.
+
+---
+
+## Spam Word Avoidance
+
+### Why It Matters
+
+Email providers scan content for spam patterns. Too many trigger words = higher spam score = junk folder.
+
+### Common Spam Word Categories
+
+| Category | Examples to Avoid |
+|---|---|
+| Urgency & Pressure | "Act now," "Limited time," "Urgent," "Don't miss out," "Expires soon" |
+| Money & Offers | "Free," "Discount," "Cash," "Save big," "Double your," "Earn $," "100% free" |
+| Too Good to Be True | "Guarantee," "No obligation," "Risk-free," "Winner," "Congratulations" |
+| Salesy Language | "Buy now," "Order today," "Click here," "Call now," "Subscribe" |
+| Suspicious | "This isn't spam," "You've been selected," "Dear friend," "As seen on" |
+
+### Generic Words to Avoid in B2B Copy
+
+"Optimize," "streamline," "save time," "save money," "leverage," "synergy," "cutting-edge," "best-in-class" — everyone uses them, so they don't stand out.
+
+### Spam Checker Tools
+
+- **Frontal Email Spam Checker** — https://frontal.so/free-tools/email-spam-checker
+- **Salesforge Spam Checker** — https://www.salesforge.ai/tools/email-spam-checker
+- **Mailmeteor Spam Checker** — https://mailmeteor.com/spam-checker
+- **Instantly built-in checker** — available in the sequence editor
+
+**Best practice:** Run every campaign through a spam checker before sending. If it flags issues, rewrite with more natural, conversational language.
+
+---
+
+## Resources & People to Follow
+
+### People
+- **Michel Lieben** — AI & sales software recommendations
+- **Alex Vacca** — AI sales SaaS landscape & B2B outbound systems
+- **Louis van Wyk** — Clay templates & outbound automations
+- **Ivan Falco** — GTM/growth funnels, ABM and ads
+- **Monika Grycz** — Copywriting pro tips & sales software
+- **Josh Braun** — Cold email philosophy, before/after rewrites
+- **Thibaut Souyris** — "Do the Math" framework
+- **Jordan Crawford** — Upfront value approach
+- **Will Allred** — Pattern interrupt / ask before pitch
+- **Ethan Parker** — Leverage content in outbound
+
+### Videos
+- [How to Write Less Boring Cold Emails](https://www.youtube.com/watch?v=XCj3hVchj9U)
+- [How to write cold emails that get responses (45.8% reply rate)](https://www.youtube.com/watch?v=a3E7Mcvhbms)
+
+### Articles
+- [Josh Braun — Before/After Cold Emails](https://joshbraun.com/before-after-cold-emails/)
+- [Josh Braun — Let's Write a Good Cold Email](https://joshbraun.com/lets-write-a-good-cold-email-4/)
+- [Josh Braun — Lowering Resistance](https://joshbraun.com/readmind/)
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/copywriting-sequences.md
+++ b/skills/alex-vacca/cold-email-strategist/references/copywriting-sequences.md
@@ -1,0 +1,270 @@
+# Cold Email Copywriting — Sequences
+
+How to structure a full email sequence: Email 1 variations, follow-ups, timing, and structure.
+
+---
+
+## Sequence Structure Overview
+
+| Email | Timing | Goal | Notes |
+|---|---|---|---|
+| **Email 1** | Day 0 | Get the reply | 80% of positive replies come here. Test 3–4 variations. |
+| **Email 2** | Day 3 (same thread) | Add value / follow up | Lead magnet, social proof, different angle |
+| **Email 3** | Day 17 (new subject line) | Final attempt | New angle, very soft CTA, break-up |
+
+If no reply after Email 3 → wait 3 months, then re-engage with a fresh sequence.
+
+---
+
+## Email 1 — Variations
+
+80% of positive replies come from Email 1. Test 3–4 different variations of your value proposition and CTA.
+
+### v1: Observation + Solution + Social Proof + CTA
+
+**Template:**
+> Hey {{first_name}},
+>
+> {{observation — poke the bear question}}
+>
+> Solution
+>
+> Social Proof
+>
+> CTA
+
+**Example:**
+> Hey John,
+>
+> Saw you are the head of people and culture of a 50+ people company — I was wondering how you ensure every employee is engaged & productive?
+>
+> We developed an AI copilot that gives you a data-backed understanding of each employee, generates OKRs, summarizes performance reviews, and monitors engagement & burnout.
+>
+> Companies like Uptech & Metadata increased their average goal achievement by 40% and identified 3 at-risk employees.
+>
+> Would you like to try it?
+
+---
+
+### v2: Observation + Problem + Solution & Social Proof + CTA + P.S.
+
+**Template:**
+> Hey {{first_name}},
+>
+> {{observation — poke the bear question}}
+>
+> {{problem}}
+>
+> Solution & social proof
+>
+> CTA
+>
+> PS: Social proof
+
+**Example:**
+> Hey G,
+>
+> Saw that there are more than 80 people at Lemlist — do you have any software upgrades or rollouts coming up?
+>
+> As tech-stacks get more complex, documenting SOPs takes hours and employees ignore training videos & documentation.
+>
+> Tango captures processes as you do them, and once your process is captured, our AI screen overlay guides viewers through step-by-step.
+>
+> Could I send over our demo?
+>
+> PS: LinkedIn, Netflix, and Indeed are also big fans of Tango and save 100s of hours weekly using our tool :)
+
+---
+
+### v3: First Line + Poke the Bear + Similar Companies + CTA
+
+**Template:**
+> Hey {{first_name}} — {{relevant first line}}
+>
+> {{poke the bear question}}
+>
+> We're helping companies like {{company_name}} achieve {{outcome}} in {{timeframe}} without {{no good rotten thing}}.
+>
+> Would this be something you're looking to solve as well?
+
+**Example:**
+> Hey Fivos,
+>
+> Are you manually creating proposals for every new deal?
+>
+> We're helping agencies like Digital Reach and Frontal to replace PowerPoint & PandaDoc and impress with visuals, without needing a designer.
+>
+> Would this be something you're looking to solve as well?
+
+---
+
+### v4: Trigger + Problem + Solution + Calculation + CTA
+
+**Template:**
+> {{first_name}}, {{personalized trigger}}
+>
+> {{problem}}
+>
+> {{solution}}
+>
+> {{calculation}}
+>
+> CTA
+
+**Example:**
+> Mary, noticed you have over 50 open positions on your job portal.
+>
+> We help tech scale-ups reduce their new employee churn from 30% to 10% or less.
+>
+> With a typical cost of mis-hire around $30,000 per employee, this would mean going from 15 mis-hires to 5, resulting in $300,000 saved.
+>
+> Worth a chat?
+
+---
+
+### v5: Recency + Stat + Question + Problem Link + Value CTA
+
+**Template:**
+> Hi {{first_name}} — recency waterfall
+>
+> Stat
+>
+> Question
+>
+> Link to the problem you solve
+>
+> Value CTA
+
+**Example:**
+> Hi {{first_name}},
+>
+> 53% of founders say their emails don't get enough replies.
+>
+> How many meetings does {{company_name}} need each week to hit revenue targets?
+>
+> Whether it's 4 or 40, it's frustrating when your emails stop working.
+>
+> Could I share a cold email template that brings us 50+ meetings per week?
+
+---
+
+### v6: Trigger + Social Proof Achievement + CTA
+
+**Template:**
+> {{first_name}} — relevant trigger
+>
+> Social proof — achievement
+>
+> CTA
+
+**Example:**
+> Fivos, saw that Reach's latest blog post doesn't include a Meta tag which can affect its online visibility.
+>
+> {{client}} improved theirs by creating meta tags using ChatGPT.
+>
+> Can I share how?
+
+---
+
+### v7: Poke the Bear (Job Frustration) + Steps + Solution + CTA
+
+**Template:**
+> Hey {{first_name}},
+>
+> What {{title}} hate about their job is {{main problem with how they currently do their job}}.
+>
+> Stuff like [step 1], [step 2], [step 3], etc.
+>
+> Our tech enables you to {{solution}}
+>
+> [Answer to the most likely follow-up question]
+>
+> Soft CTA
+
+**Example:**
+> Hey {{first_name}},
+>
+> What IT Managers in healthcare hate about their job is maintaining data security and system efficiency.
+>
+> Issues like system downtimes, patient data protection, and regulatory compliance can be overwhelming.
+>
+> Our tech enables robust IT security solutions tailored for healthcare, ensuring data protection and compliance.
+>
+> Totally compatible with your existing system.
+>
+> Sound relevant?
+
+---
+
+## Email 2 — Follow-Up (Day 3, Same Thread)
+
+**Template:**
+> {{first_name}}, here's the {{lead magnet}}
+>
+> Social proof
+>
+> Value proposition
+>
+> CTA
+
+**Key rules:**
+- Same thread as Email 1 (reply to your own email)
+- Lead with value (lead magnet, resource, case study)
+- Keep it even shorter than Email 1
+- Don't repeat the same pitch — add a new angle
+
+---
+
+## Email 3 — New Subject Line (Day 17)
+
+**Key rules:**
+- **New subject line** (fresh thread)
+- Choose a different Email 1 variation than you used originally
+- Very soft CTA
+- We're aiming for ANY kind of answer
+- If no reply → wait 3 months before re-engaging
+
+**Template:**
+> Hook
+>
+> Statement
+>
+> Consequence
+>
+> Consequence
+>
+> Consequence
+>
+> CTA
+
+**Example:**
+> {{first_name}},
+>
+> Most sales leaders I speak to are a *little* embarrassed by the presentation of the proposals going out to prospects.
+>
+> Qwilr helps you stand out from the crowd when going head-to-head with other agencies.
+>
+> Web-based personalized proposals without needing a designer.
+>
+> With analytics on how much time your prospect spent reviewing each page.
+>
+> Curious to see how it works?
+>
+> PS: Let me know if someone else would be the right person to talk to about this :)
+
+---
+
+## Sequence Design Rules
+
+1. **Email 1 gets 80% of replies** — invest most effort here
+2. **Test 3–4 variations** of Email 1 simultaneously (A/B/C/D test)
+3. **Same thread for Email 2** — reply to yourself
+4. **New subject line for Email 3** — fresh start
+5. **Include soft CTA like "Would {{other_colleague}} be a better person to chat about this?"** in Email 3
+6. **If no reply after 3 emails** — wait 3 months, then re-engage
+7. **Never more than 3 emails in a sequence** without a significant pause
+8. **Every email should provide standalone value** — don't write "just following up"
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/copywriting.md
+++ b/skills/alex-vacca/cold-email-strategist/references/copywriting.md
@@ -1,0 +1,65 @@
+# Cold Email Copywriting
+
+You help users write effective cold emails using proven frameworks, principles, and sequence structures.
+
+## Reference
+
+Read these resources based on the user's question:
+
+- **13 named frameworks with templates and examples** → Read `copywriting-frameworks.md`
+- **Core philosophy, rules, and email components** → Read `copywriting-principles.md`
+- **Sequence structure, variations, timing, and performance metrics** → Read `copywriting-sequences.md`
+- **E-commerce vertical cold email playbook** → Read `copywriting-ecom-playbook.md`
+- **Frontal operational playbook: value prop styles, preview patterns, ready-to-deploy sequences, 250K+ email insights** → Read `frontal-playbook.md`
+
+## 13 Named Frameworks
+
+| Framework | Best For | Creator |
+|---|---|---|
+| Do the Math | Quantifiable ROI | Thibaut Souyris |
+| Short Trigger | Quick, under-30-word emails | Guillermo Blanco |
+| Challenge of Similar Companies | Industry-wide pain points | Patrick Trumpi |
+| Neutral Insight | Sharing third-party resources | Chelsea Castle |
+| Leader Responsibilities | Role-specific curiosity | Vin Matano |
+| Ask Before Pitch / Pattern Interrupt | Flipping script with questions | Will Allred |
+| Not Too Different Persona | Peer similarity | BowTiedSalesGuy |
+| Upfront Value | Leading with free value | Jordan Crawford |
+| Leverage Content in Outbound | Lead magnets as entry point | Ethan Parker |
+| "Why Are You Paying?" | Analogy-based persuasion | Leif Bisping |
+| Write a Good Cold Email | Problem-first structure | Josh Braun |
+| HOT Outreach | Peak interest + value + CTA | — |
+| Manual Email Style | Casual, human, low-pressure | Josh Braun |
+
+## Core Rules
+
+1. Under 100 words (ideally 50-75)
+2. More about them than you
+3. Benefits over features
+4. Solve a problem they actually have
+5. Personalize or make it hyper-relevant
+6. Pick your offer wisely
+7. Provide value before asking
+
+## Sequence Structure
+
+| Email | Timing | Goal | Performance |
+|---|---|---|---|
+| Email 1 | Day 0 | Get the reply | 80% of positive replies |
+| Email 2 | Day 3 (same thread) | Add value/follow up | Lead magnet, different angle |
+| Email 3 | Day 17 (new subject) | Final attempt | Very soft CTA, break-up |
+
+## Examples
+
+**Example 1:** "Give me a framework for emailing a CFO about cost savings"
+→ Load copywriting-frameworks.md. Recommend "Do the Math" framework. Calculate specific savings.
+
+**Example 2:** "How should I structure my 3-email sequence?"
+→ Load copywriting-sequences.md. Provide Email 1 variations, Email 2 value-add, Email 3 soft CTA pattern.
+
+**Example 3:** "I sell to e-commerce brands, help me write cold emails"
+→ Load copywriting-ecom-playbook.md. Use low-risk free work offers, 15-30 word emails, casual tone.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/deliverability-guide.md
+++ b/skills/alex-vacca/cold-email-strategist/references/deliverability-guide.md
@@ -1,0 +1,358 @@
+# Cold Email Deliverability & Compliance Guide
+
+## 1. Email Authentication
+
+### SPF (Sender Policy Framework)
+
+**What it does:** Tells receiving servers which IP addresses/servers are authorized to send email for your domain.
+
+**Setup:**
+1. Go to your DNS provider
+2. Add a TXT record:
+```
+Host: @
+Type: TXT
+Value: v=spf1 include:_spf.google.com ~all
+```
+
+**For multiple providers:**
+```
+v=spf1 include:_spf.google.com include:spf.protection.outlook.com include:sendgrid.net -all
+```
+
+**Common mistakes:**
+- Multiple SPF records (only ONE allowed per domain — merge them)
+- Using `+all` instead of `~all` or `-all`
+- Exceeding 10 DNS lookups (each `include:` counts as one)
+
+### DKIM (DomainKeys Identified Mail)
+
+**What it does:** Adds a digital signature to outgoing emails proving they haven't been tampered with.
+
+**Setup (Google Workspace):**
+1. Google Admin Console → Apps → Gmail → Authenticate Email
+2. Generate DKIM key (2048-bit recommended)
+3. Add TXT record to DNS:
+```
+Host: google._domainkey
+Type: TXT
+Value: v=DKIM1; k=rsa; p=[your-public-key]
+```
+4. Back in Google Admin, click "Start Authentication"
+
+**Verification:** Send test email, check headers for `dkim=pass`.
+
+### DMARC (Domain-based Message Authentication)
+
+**What it does:** Tells receiving servers what to do when SPF or DKIM fails, and where to send reports.
+
+**Progressive setup:**
+```
+# Week 1-2: Monitor only (no blocking)
+v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com
+
+# Week 3-4: Quarantine failures
+v=DMARC1; p=quarantine; pct=50; rua=mailto:dmarc@yourdomain.com
+
+# Week 5+: Reject failures (full protection)
+v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com
+```
+
+Add as TXT record:
+```
+Host: _dmarc
+Type: TXT
+Value: v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com
+```
+
+### Verification Checklist
+- [ ] SPF: `dig TXT yourdomain.com` shows `v=spf1`
+- [ ] DKIM: Email headers show `dkim=pass`
+- [ ] DMARC: `dig TXT _dmarc.yourdomain.com` shows policy
+- [ ] Use mail-tester.com or MXToolbox for full check
+
+## 2. Domain Warmup
+
+### New Domain Warmup Schedule
+
+| Week | Daily Cold Emails | Warmup Emails | Total | Notes |
+|------|------------------|---------------|-------|-------|
+| **1** | 0 | 5-10 | 5-10 | Warmup tool only, no cold |
+| **2** | 0 | 10-20 | 10-20 | Warmup tool, send/receive internally |
+| **3** | 5-10 | 15-25 | 20-35 | Begin mixing cold cautiously |
+| **4** | 10-20 | 20-30 | 30-50 | Monitor bounces and complaints |
+| **5-6** | 20-30 | 20-30 | 40-60 | Gradual increase |
+| **7-8** | 30-40 | 15-20 | 45-60 | Approaching steady state |
+| **9+** | 30-50 | 10-20 | 40-70 | Full operations, keep warmup running |
+
+### Warmup Tools
+
+| Tool | Price | Method | Notes |
+|------|-------|--------|-------|
+| **Instantly** (built-in) | Included | Peer network warmup | Opens, replies, marks as important |
+| **Lemwarm** (Lemlist) | Included with Lemlist | Similar peer network | Auto-adjusts volume |
+| **Mailreach** | $25/mo per mailbox | Large warmup network | Detailed reports |
+| **Warmbox** | $19/mo per mailbox | AI-powered warmup | Good standalone option |
+
+### Key Rules
+- **Never stop warmup** — keep 10-20/day even during active campaigns
+- Warmup emails should come from real-looking domains
+- Ensure replies and "move to primary" actions happen
+- Monitor sender score throughout
+
+### Domain Age Requirements
+
+| Age | Status | Recommendation |
+|-----|--------|----------------|
+| 0-2 weeks | Brand new | No email. Set up DNS, create mailboxes, join warmup. |
+| 2-4 weeks | Fresh | Warmup only. No cold email. |
+| 4-8 weeks | Warming | Begin mixing cold (follow schedule above). |
+| 8-12 weeks | Establishing | Moderate cold volume (30-50/mailbox/day). |
+| 12+ weeks | Established | Full operations. Monitor ongoing. |
+| 6+ months | Mature | Can push slightly higher volumes if reputation supports. |
+
+**Minimum before first cold email: 4 weeks** (2 weeks aging + 2 weeks warmup)
+**Ideal: 6-8 weeks** (2-4 weeks aging + 4 weeks warmup)
+
+## 3. Inbox Placement
+
+### Plain Text vs HTML
+
+| Factor | Plain Text | HTML |
+|--------|-----------|------|
+| Deliverability | Better | Worse (more spam signals) |
+| Trust signal | Feels personal | Feels like marketing |
+| Tracking | Limited (no pixel) | Open tracking possible |
+| Rendering | Universal | Can break across clients |
+| Cold email best practice | **Preferred** | Avoid for cold |
+
+**Rule: Use plain text for cold email. Always.**
+
+### Sending Time Optimization
+- Send during **business hours in recipient's timezone** (9 AM - 5 PM)
+- Peak windows: **8-10 AM** and **1-3 PM** (Tuesday-Thursday)
+- Random delays between emails: 30-120 seconds
+- Vary sending times slightly day-to-day (not always at 9:00 AM)
+
+### Reply Rate Impact on Deliverability
+
+Reply rate is the **single most powerful positive signal**:
+
+| Reply Rate | Status |
+|-----------|--------|
+| >15% | Excellent — strong positive reputation |
+| >10% | Good — inbox placement stable |
+| >5% | Minimum acceptable for sustained sending |
+| <3% | Danger zone — deliverability will degrade |
+
+**How replies help:** Creates a "conversation" (trust signal), recipients who reply rarely mark as spam, high replies offset occasional complaints.
+
+## 4. Compliance
+
+### CAN-SPAM (United States)
+
+**Requirements:**
+1. Accurate "From" and "Reply-To" headers
+2. Non-deceptive subject lines
+3. Identify as advertisement (flexibility on this)
+4. Include valid physical postal address
+5. Clear opt-out explanation
+6. Honor opt-outs within 10 business days
+7. Monitor compliance of third parties
+
+**Penalties:** Up to $51,744 per email in violation.
+
+**Key:** CAN-SPAM does NOT require prior consent. B2B cold email is compliant with unsubscribe + physical address.
+
+### GDPR (EU/EEA/UK)
+
+**Legal bases for B2B cold email:**
+
+1. **Legitimate Interest (Article 6(1)(f))** — most common:
+   - Conduct Legitimate Interest Assessment (LIA)
+   - Email must be relevant to professional role
+   - Easy opt-out required
+   - Data sourced lawfully
+
+2. **Consent (Article 6(1)(a))** — required in some countries (notably Germany)
+
+**Country-specific:**
+| Country | B2B Cold Email |
+|---------|---------------|
+| UK | Generally permitted (legitimate interest) |
+| France | Permitted if relevant to professional role |
+| Germany | Very restrictive — consent generally required |
+| Netherlands | Permitted with legitimate interest |
+| Nordic | Generally permit with legitimate interest |
+
+**Requirements:** Lawful basis, transparency, right to object, data minimization, right to erasure, record keeping, privacy notice, data source disclosure.
+
+**Compliant footer:**
+```
+You're receiving this because of your role as [Role] at [Company].
+To opt out, reply "unsubscribe" or click here: [link]
+Privacy policy: [link]
+```
+
+**Penalties:** Up to 4% of global annual revenue or EUR 20M.
+
+### RFC 8058: One-Click Unsubscribe
+
+**Required since February 2024** for bulk senders (5,000+/day to Gmail/Yahoo).
+
+```
+List-Unsubscribe: <https://yourdomain.com/unsubscribe?id=token>, <mailto:unsubscribe@yourdomain.com>
+List-Unsubscribe-Post: List-Unsubscribe=One-Click
+```
+
+Most cold email tools (Instantly, Smartlead, Lemlist) add these automatically.
+
+## 5. Blacklist Monitoring
+
+### Major Blacklists
+
+| Blacklist | Severity | Impact |
+|-----------|----------|--------|
+| **Spamhaus ZEN** | Critical | Used by ~80% of ISPs |
+| **Spamhaus DBL** | Critical | Domain-based |
+| **Barracuda BRBL** | High | Corporate email gateways |
+| **SpamCop** | Medium-High | Auto-expires 24-48 hrs |
+| **SORBS** | Medium | Multiple lists |
+| **URIBL / SURBL** | High | Checks domains in email body |
+
+### How to Check
+
+1. **MXToolbox**: mxtoolbox.com/blacklists.aspx (100+ blacklists)
+2. **MultiRBL**: multirbl.valli.org (300+ blacklists)
+3. **Google Postmaster Tools**: domain/IP reputation with Gmail
+4. **Microsoft SNDS**: reputation with Outlook/Hotmail
+
+**Frequency:** Daily during warmup, weekly during campaigns.
+
+### Removal Process
+
+| Blacklist | Process | Timeline |
+|-----------|---------|----------|
+| Spamhaus | Submit removal at spamhaus.org | 24-48 hrs |
+| Barracuda | Self-service at barracudacentral.org | 12-24 hrs |
+| SpamCop | Auto-expires (no manual removal) | 24-48 hrs |
+| SORBS | Self-service at sorbs.net | Varies |
+
+## 6. Infrastructure Best Practices
+
+### Multiple Domains Strategy
+
+```
+Primary domain (NEVER for cold email):
+  yourcompany.com → Website, support, team email
+
+Cold outreach domains (3-5+):
+  yourcompany.co
+  getyourcompany.com
+  tryyourcompany.com
+  yourcompanyhq.com
+  withyourcompany.com
+```
+
+**Rules:**
+- 2-5 domains per SDR for rotation
+- 2-3 mailboxes per domain
+- Domain naming: clearly related to your brand
+- Let domains age 2-4 weeks before warmup
+
+### Sending Limits per Provider
+
+| Provider | Technical Limit | Safe Cold Email Limit |
+|----------|----------------|----------------------|
+| **Google Workspace** | 2,000/day | 30-50/day per mailbox |
+| **Google (new account)** | 500/day first 24h | 5-10/day during warmup |
+| **Microsoft 365** | 10,000/day | 30-50/day per mailbox |
+| **Gmail (free)** | 500/day | NOT recommended |
+
+### Custom Tracking Domains
+
+Always use a subdomain of your sending domain:
+```
+Type: CNAME
+Host: track
+Value: [provided by your email tool]
+```
+
+### Complete DNS Checklist
+
+```
+1. MX Records       → Points to email provider
+2. SPF (TXT)        → v=spf1 include:[providers] -all
+3. DKIM (TXT/CNAME) → [selector]._domainkey → public key
+4. DMARC (TXT)      → _dmarc → v=DMARC1; p=reject; rua=mailto:...
+5. Tracking CNAME    → track.[domain] → [tool's tracking server]
+6. Return-Path CNAME → If required by sending tool
+7. A Record          → Web server (landing/unsubscribe pages)
+```
+
+## 7. Bounce Management
+
+### Hard vs Soft Bounces
+
+| Type | Definition | Action |
+|------|-----------|--------|
+| **Hard Bounce** (5xx) | Permanent failure — address invalid | Remove immediately, never retry |
+| **Soft Bounce** (4xx) | Temporary failure — server issue | Retry 2-3 times over 24-72 hrs |
+
+### Acceptable Bounce Rates
+
+| Rate | Status | Action |
+|------|--------|--------|
+| <1% | Excellent | Maintain practices |
+| 1-2% | Acceptable | Monitor closely |
+| 2-3% | Warning | Run verification |
+| 3-5% | Dangerous | Pause campaigns, clean list |
+| >5% | Critical | Stop immediately |
+
+### Email Verification Tools
+
+| Tool | Cost | Accuracy | Best For |
+|------|------|----------|----------|
+| **ZeroBounce** | $0.008/email | 98%+ | Comprehensive verification |
+| **NeverBounce** | $0.008/email | 97%+ | Platform integrations |
+| **Findymail** | ~$0.01/email | 99%+ B2B | Find + verify combined |
+| **MillionVerifier** | $0.0005/email | 95%+ | Budget large lists |
+| **Bouncer** | $0.008/email | 97%+ | EU-based (GDPR) |
+
+### Verification Best Practices
+
+1. **Verify 100% of emails before any campaign.** No exceptions.
+2. **Re-verify lists older than 30 days.**
+3. **Remove "unknown" and "catch-all" results** or treat with extreme caution.
+4. **Remove role-based emails** (info@, admin@, sales@).
+5. **Remove free email providers** for B2B outreach.
+6. **Budget rule:** Verification costs ($0.005-0.01/email) are trivial vs damaged reputation.
+
+## Pre-Launch Checklist
+
+- [ ] 3-5 outreach domains purchased (not primary domain)
+- [ ] Domains aged 2+ weeks
+- [ ] Google Workspace or Microsoft 365 on each domain
+- [ ] 2-3 mailboxes per domain
+- [ ] SPF, DKIM, DMARC configured for each domain
+- [ ] Custom tracking domain (CNAME) per domain
+- [ ] Warmup running on every mailbox (2-4 weeks)
+- [ ] 100% email verification before loading campaigns
+- [ ] Blacklist monitoring alerts set up
+- [ ] Compliant templates (physical address, unsubscribe)
+- [ ] Legitimate interest assessment (if emailing EU)
+
+## Active Campaign Monitoring
+
+- [ ] Cold email volume: 30-50/mailbox/day
+- [ ] Warmup tool running (10-20/day per mailbox)
+- [ ] Bounce rate <2%
+- [ ] Spam complaint rate <0.1%
+- [ ] Reply rate >5%
+- [ ] Blacklists checked weekly
+- [ ] Google Postmaster + Microsoft SNDS reviewed weekly
+- [ ] Plain text emails (no HTML/images)
+- [ ] Sending during business hours in recipient's timezone
+- [ ] Unsubscribes processed within 24 hours
+- [ ] Mailbox rotation across campaigns
+- [ ] Re-verify lists older than 30 days

--- a/skills/alex-vacca/cold-email-strategist/references/email-infra-guide.md
+++ b/skills/alex-vacca/cold-email-strategist/references/email-infra-guide.md
@@ -1,0 +1,353 @@
+# Cold Email Infrastructure
+
+Complete guide to setting up and maintaining cold email sending infrastructure — from zero to live campaigns.
+
+## The Redline (Follow In Order)
+
+1. **Calculate** infrastructure needs
+2. **Acquire** secondary domains
+3. **Create** workspaces & mailboxes
+4. **Configure** DNS (SPF, DKIM, DMARC)
+5. **Connect** to sending platform (Instantly)
+6. **Warm up** mailboxes (2–3 weeks minimum)
+7. **Go live** with conservative limits
+8. **Monitor** and maintain ongoing
+
+For detailed walkthroughs of each step, see [email-infra-step-by-step.md](email-infra-step-by-step.md).
+For DNS issues and deliverability problems, see [email-infra-troubleshooting.md](email-infra-troubleshooting.md).
+
+---
+
+## Critical Rules (Never Break These)
+
+1. **Never use a primary domain for cold outreach.** Always use secondary domains.
+2. **Maximum 2 mailboxes per domain.** Limits blast radius if a domain gets burned.
+3. **One domain = one workspace/tenant.** Never add multiple domains to one Google Workspace or Microsoft 365 account.
+4. **Use multiple registrars.** No single point of failure.
+5. **Warm up for 2–3 weeks minimum** before sending any campaigns.
+6. **Never disable warm-up** once campaigns are running.
+7. **Start conservative, scale gradually.** Easier to add capacity than recover from deliverability damage.
+
+---
+
+## Infrastructure Sizing
+
+### Core Formula
+
+Work backwards: **Monthly goal → Daily volume → Mailboxes → Domains**
+
+### Send Limits Per Provider
+
+| Provider | Safe Daily Limit per Mailbox |
+|---|---|
+| Google Workspace | 15–25 emails/day |
+| Microsoft 365 | 10–15 emails/day |
+
+### Sizing Calculator
+
+| Monthly Goal | Daily Volume | Mailboxes Needed (with 50% buffer) | Domains Needed |
+|---|---|---|---|
+| 3,000 | 150 | 10–12 | 5–6 |
+| 7,500 | 375 | 18–23 | 9–12 |
+| 15,000 | 750 | 38–45 | 19–23 |
+| 30,000 | 1,500 | 75–90 | 38–45 |
+
+### Sizing Steps
+
+1. Define monthly email goal
+2. Divide by 20 working days = daily volume
+3. Divide daily volume by 20 (conservative) or 25 (aggressive) = mailboxes
+4. Multiply by 1.5 = mailboxes with buffer
+5. Divide mailboxes by 2 = domains needed
+
+### Provider Split
+
+| Provider | Allocation | Why |
+|---|---|---|
+| Google Workspace | 60% | Higher send limits, good deliverability |
+| Microsoft 365 | 40% | Different infrastructure, risk diversification |
+
+**Practical minimum: 15 mailboxes** (~375 emails/day capacity).
+
+---
+
+## Domain Acquisition
+
+### Naming Patterns (Good)
+
+For primary domain `acme.com`:
+- acmehq.com, getacme.com, tryacme.com, goacme.com
+- teamacme.com, hiacme.com, meetacme.com, acmeco.com
+
+### Naming Patterns (Bad)
+
+- Random strings, misspellings, spammy words (deals, offers)
+- Numbers, excessive hyphens
+
+### TLD Rules
+
+- **.com is king** — best deliverability and trust
+- **.org** acceptable as secondary
+- **Avoid** .io, .ai, .co for cold email
+
+### Recommended Registrars
+
+Spread purchases across multiple:
+- **Cloudflare** — no markup, great DNS management
+- **Namecheap** — affordable, good for bulk
+- **GoDaddy** — widely used
+- **Squarespace** (ex–Google Domains) — reliable
+- **Porkbun** — cheap, good reputation
+
+### Per-Domain Checklist
+
+- [ ] Domain registered
+- [ ] Auto-renew enabled
+- [ ] Whois privacy enabled
+- [ ] Logged in tracking spreadsheet
+
+---
+
+## Workspace & Mailbox Setup
+
+### Google Workspace (~$6/user/month, Business Starter)
+
+1. Create new workspace at workspace.google.com
+2. Add secondary domain → verify ownership via TXT record
+3. Create mailboxes (max 2 per domain, real names)
+4. DNS records configured during this step (see DNS section)
+
+### Microsoft 365 (~$6/user/month, Business Basic)
+
+1. Purchase plan at microsoft.com/microsoft-365/business
+2. Add secondary domain → verify ownership via TXT record
+3. Create mailboxes (max 2 per domain, real names)
+4. **Critical: Enable SMTP & IMAP** in Admin Center → Users → Active Users → Mail → Manage email apps
+5. **Wait 1 hour** after enabling SMTP before connecting to Instantly
+
+### Mailbox Naming
+
+**Good:** Real first names — alex@, sarah@, michael@, james@, emma@, david@
+**Bad:** sales@, info@, noreply@, hello@, outreach@
+
+**Pro tip:** Keep names consistent across domains (alex@ on all your domains).
+
+### Profile Pictures
+
+Add a professional headshot to every mailbox. This improves deliverability and reply rates. Do not skip.
+
+---
+
+## DNS Configuration
+
+Every domain needs **all four records**. Missing one can tank deliverability.
+
+| Record | Purpose |
+|---|---|
+| **MX** | Routes incoming email to your provider |
+| **SPF** | Declares which servers can send for your domain |
+| **DKIM** | Digital signature proving email authenticity |
+| **DMARC** | Policy for handling SPF/DKIM failures |
+
+### SPF Records
+
+- Google: `v=spf1 include:_spf.google.com ~all`
+- Microsoft: `v=spf1 include:spf.protection.outlook.com ~all`
+- **Only ONE SPF record per domain** (most common mistake)
+
+### DMARC Record
+
+| Field | Value |
+|---|---|
+| Type | TXT |
+| Host | _dmarc |
+| Value | `v=DMARC1;p=none;sp=none;pct=100;rua=mailto:you@domain.com;ri=86400;aspf=r;adkim=r;fo=1` |
+
+### Domain Forwarding
+
+Redirect secondary domains → main website (301 permanent redirect). Makes domains look legitimate when prospects check.
+
+### Custom Tracking Domain (Recommended)
+
+CNAME record: `inst` → `prox.itrackly.com` (TTL 300)
+Then configure in Instantly → Settings → Custom Tracking Domain.
+**Cloudflare users:** proxy must be OFF (grey cloud).
+
+### Testing DNS
+
+1. **Instantly:** Email Accounts → Test domain setup (easiest)
+2. **MXToolbox:** mxtoolbox.com — MX, SPF, DMARC, blacklist
+3. **Mail-Tester:** mail-tester.com — deliverability score (aim 8+/10)
+4. **Google Postmaster Tools:** postmaster.google.com — Gmail reputation
+
+For DNS troubleshooting, see [troubleshooting.md](troubleshooting.md).
+
+---
+
+## Connecting to Instantly
+
+### Google Accounts (OAuth — Recommended)
+
+1. Email Accounts → Add New → Google → OAuth
+2. Copy Client ID → Google Workspace Admin → Security → API Controls → Manage App Access
+3. Configure new app → paste Client ID → select "Instantly OAuth Email v1"
+4. Scope: All users, Access: Trusted
+5. Return to Instantly → Login to complete
+
+### Microsoft Accounts (One-by-One Only)
+
+1. Email Accounts → Add New → Microsoft
+2. Confirm SMTP is enabled → sign in
+3. **Check "Consent on behalf of your organization"**
+4. Accept permissions
+
+**Microsoft cannot be bulk imported.** Plan time accordingly.
+
+### Post-Connection Settings
+
+- **Daily send limits:** Google 15–25, Microsoft 10–15
+- **Custom tracking domain:** Enable per account
+- **Account tags:** Organize by client / domain / provider
+- **Slow ramp:** Enable — starts at 2/day, increases by 2/day
+
+---
+
+## Warm-Up
+
+### Timeline
+
+| Period | What Happens | Can Send Campaigns? |
+|---|---|---|
+| Week 1 | Foundation — low volume warm-up starts | No |
+| Week 2 | Building — volume increases, health scores appear | No |
+| Week 3 | Ready — health scores 70%+ (ideally 90%+) | Yes, conservatively |
+
+**Minimum: 2 weeks. Recommended: 3 weeks.**
+
+### Recommended Warm-Up Settings
+
+| Setting | Value |
+|---|---|
+| Daily warmup limit | 10–15 |
+| Reply rate | 30–40% |
+| Increase by day | Enabled |
+| Read emulation | Enabled |
+| Open rate | 80–90% |
+| Spam protection | 100% |
+| Mark important | 30–50% |
+
+### Warm-Up Pools
+
+| Pool | Flame Color | Quality |
+|---|---|---|
+| Premium | Blue | Best — aged Google/Outlook accounts |
+| Standard | Green | Good — default for all accounts |
+| Basic | Orange | Lower — mostly SMTP |
+| Disabled | Red | Needs reactivation (DNS issue likely) |
+
+### Red Flame Recovery
+
+1. Fix DNS (run "Test domain setup" in Instantly)
+2. Click red flame → Request Reactivation Code
+3. Check inbox for code → enter in Instantly
+
+---
+
+## Going Live
+
+### Ramp Schedule
+
+| Provider | Week 1 | Week 2–3 | Week 4+ |
+|---|---|---|---|
+| Google | 10–15/day | 15–20/day | 20–25/day |
+| Microsoft | 5–10/day | 10–12/day | 12–15/day |
+
+### Deliverability Settings (Instantly)
+
+- **Text-only first email** — reduces spam filter triggers
+- **Disable open tracking** — improves inbox placement (Frontal default)
+- **ESP matching** — Google sends to Gmail, Microsoft sends to Outlook
+- **Limit emails per company** — 2–3 per company per day (workspace-wide)
+- **Slow ramp** — enable for new accounts only
+
+### First Campaign
+
+- Start with **50–100 leads**
+- Monitor 2–3 days before scaling
+- Scale by adding mailboxes, not pushing limits higher
+
+### Healthy Metrics
+
+| Metric | Healthy | Warning | Stop |
+|---|---|---|---|
+| Open rate | 50%+ | 30–50% | Below 30% |
+| Reply rate | 2%+ | 1–2% | Below 1% |
+| Bounce rate | Below 3% | 3–5% | Above 5% |
+| Spam complaints | 0 | Any | Multiple |
+
+---
+
+## Ongoing Monitoring
+
+### Daily (5 min)
+
+- Check bounce rates (<5%), reply rates, spam complaints
+- Spot-check 2–3 warm-up emails
+- Watch for blacklist alerts
+
+### Weekly (15 min)
+
+- Google Postmaster Tools + Microsoft SNDS
+- MXToolbox blacklist check
+- Compare week-over-week trends
+
+### Monthly (30 min)
+
+- Update suppression list, audit bounces
+- Review domain reputation, clean old leads
+- Rotate warm-up email content
+
+### Quarterly (1 hour)
+
+- Full DNS audit across all domains
+- Infrastructure cost review
+- Strategic capacity planning
+
+### Scaling Rule
+
+- Increase volume by max **20% per week**
+- Add new domains instead of pushing existing ones
+- Stagger new domain launches (1 per week max)
+- New domains go through full warm-up cycle
+
+For detailed recovery protocols, see [email-infra-troubleshooting.md](email-infra-troubleshooting.md).
+
+---
+
+## Infrastructure Tracking Spreadsheet
+
+Maintain a spreadsheet with:
+
+| Domain | Registrar | Provider | Mailbox 1 | Mailbox 2 | Admin Email | Status |
+|---|---|---|---|---|---|---|
+| acmehq.com | Cloudflare | Google | alex@acmehq.com | sarah@acmehq.com | admin@you.com | Active |
+| getacme.com | Namecheap | Microsoft | alex@getacme.com | sarah@getacme.com | admin@you.com | Warming |
+
+Track: domain, registrar, provider, mailboxes, admin email, warm-up status, health score.
+
+---
+
+## Seasonal Expectations
+
+| Period | Expected Impact |
+|---|---|
+| December holidays | 20–30% engagement drop, recovers mid-January |
+| July–August | 10–20% drop (vacation season) |
+| End of quarter | Lower response rates (prospects closing deals) |
+| Industry conferences | 15–25% drop during event week |
+
+Don't panic during seasonal dips. Investigate only if the drop exceeds norms or doesn't recover.
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/email-infra-step-by-step.md
+++ b/skills/alex-vacca/cold-email-strategist/references/email-infra-step-by-step.md
@@ -1,0 +1,364 @@
+# Email Infrastructure — Detailed Reference
+
+Step-by-step walkthroughs for each phase of the setup. The SKILL.md has the quick reference; this file has the full detail.
+
+---
+
+## Step 1: Calculate Infrastructure Needs
+
+### The Process
+
+1. **Define monthly email goal** — how many cold emails per month?
+2. **Calculate daily volume** — divide by 20 working days
+3. **Calculate mailboxes** — divide daily volume by 20 (conservative) or 25 (aggressive)
+4. **Add 50% buffer** — multiply by 1.5 for rotation, warm-up, and account issues
+5. **Calculate domains** — divide total mailboxes by 2
+6. **Decide provider split** — 60% Google Workspace, 40% Microsoft 365
+
+### Write Down Your Numbers
+
+- Monthly email goal: ___
+- Daily volume: ___
+- Mailboxes needed (with buffer): ___
+- Domains needed: ___
+- Google mailboxes (60%): ___
+- Microsoft mailboxes (40%): ___
+
+---
+
+## Step 2: Domain Acquisition — Full Walkthrough
+
+### Planning Your Domain Names
+
+Brainstorm **2x the number you need** — some won't be available.
+
+For primary domain `acme.com`, good patterns:
+- Prefix: getacme.com, tryacme.com, goacme.com, hiacme.com, meetacme.com
+- Suffix: acmehq.com, acmeco.com, acmegroup.com
+- Team: teamacme.com, acme-team.com
+
+### Purchasing Process
+
+1. **Spread across registrars** — example split for 10 domains:
+   - 3 from Cloudflare
+   - 3 from Namecheap
+   - 2 from GoDaddy
+   - 2 from Squarespace
+2. **Stick to .com** (.org acceptable as backup)
+3. **Enable auto-renew** on every domain immediately
+4. **Enable Whois privacy** (usually free)
+5. **Start your tracking spreadsheet** — log every domain, registrar, and status
+
+### Why Multiple Registrars Matter
+
+If one registrar flags your account, has an outage, or changes policy — you lose only 25% of capacity instead of 100%. No single point of failure.
+
+---
+
+## Step 3: Google Workspace Setup — Full Walkthrough
+
+### Per Domain (Repeat for Each)
+
+1. Go to workspace.google.com → Get Started
+2. Enter real business details
+3. Add your secondary domain
+4. Verify domain ownership (TXT record in DNS)
+5. Create first user (e.g., alex@yourdomain.com)
+6. Create second user (e.g., sarah@yourdomain.com)
+7. Choose Business Starter plan (~$6/user/month)
+
+### Video Tutorials by Registrar
+
+- **Google Domain → Google Workspace:** https://www.loom.com/share/a230d197ed24480095ce2ccdeaeca3e6 (9 min)
+- **Namecheap → Google Workspace:** https://www.loom.com/share/8aa8eb5e98904b6f91ca8797a0fd82d1 (11 min)
+- **GoDaddy → Google Workspace:** https://www.loom.com/share/4c61ea43a89846be92f835ca0850f296 (7 min)
+
+### What the Videos Cover
+
+- Domain forwarding setup
+- Domain verification (TXT record)
+- MX record configuration
+- SPF record creation
+- DKIM generation and setup
+- DMARC manual setup
+- User account creation
+
+---
+
+## Step 4: Microsoft 365 Setup — Full Walkthrough
+
+### Per Domain (Repeat for Each)
+
+1. Go to microsoft.com/microsoft-365/business
+2. Choose Business Basic (~$6/user/month)
+3. Create admin account
+4. Add secondary domain → verify with TXT record
+5. Create users (max 2 per domain)
+6. **Enable SMTP & IMAP:**
+   - Admin Center (admin.microsoft.com) → Users → Active Users
+   - Select user → Mail → Manage email apps
+   - Check **IMAP** and **Authenticated SMTP** → Save
+7. **Wait 1 hour** before connecting to Instantly
+
+### Video Tutorials by Registrar
+
+- **GoDaddy → Microsoft 365:** https://www.loom.com/share/b5dea267f88b4bdb864e08d8d3f96aaf (12 min)
+- **Namecheap → Microsoft 365:** https://www.loom.com/share/cf362a64841a4bdaa6f1a9e5b8c517d0 (10 min)
+
+### Common Mistake
+
+Trying to connect Microsoft accounts to Instantly before the 1-hour SMTP propagation window. Set a timer.
+
+---
+
+## Step 5: DNS Configuration — Full Walkthrough
+
+### Record-by-Record Setup
+
+**MX Records** — configured automatically during workspace setup (via videos above).
+
+**SPF Record:**
+
+| Provider | TXT Record Value |
+|---|---|
+| Google | `v=spf1 include:_spf.google.com ~all` |
+| Microsoft | `v=spf1 include:spf.protection.outlook.com ~all` |
+
+**Only one SPF record per domain.** If you see duplicates (common with GoDaddy), delete the extras.
+
+**DKIM Record:**
+- Google: Generate in Google Workspace Admin → Apps → Gmail → Authenticate Email
+- Microsoft: Two CNAME records (selector1._domainkey, selector2._domainkey)
+- Copy the EXACT value — no extra spaces, all characters
+
+**DMARC Record:**
+
+| Field | Value |
+|---|---|
+| Type | TXT |
+| Host/Name | _dmarc |
+| Value | `v=DMARC1;p=none;sp=none;pct=100;rua=mailto:you@domain.com;ri=86400;aspf=r;adkim=r;fo=1` |
+
+DMARC is never added automatically — you must add it manually every time.
+
+### Domain Forwarding Setup
+
+Redirect secondary domains to your main website:
+- Redirect type: Permanent (301)
+- Forward path: No (root domain only)
+- SSL: On
+
+**Registrar-specific guides:**
+- GoDaddy: Set up in domain settings → Forwarding
+- Namecheap: Set up in domain settings → Redirect Domain
+- Google Domains/Squarespace: Domain settings → Website → Forwarding
+
+### Custom Tracking Domain Setup
+
+1. Add CNAME record: `inst` → `prox.itrackly.com` (TTL 300)
+2. Cloudflare: ensure proxy is OFF (grey cloud, not orange)
+3. Instantly → Settings → Custom Tracking Domain → enter `inst.yourdomain.com`
+4. Click Verify → Enable
+5. Wait 15–30 min for propagation
+
+### DNS Propagation Timeline
+
+| Record Type | Typical | Maximum |
+|---|---|---|
+| MX, SPF, DKIM | 15 min – 4 hours | 48 hours |
+| DMARC | 15 min – 4 hours | 48 hours |
+| CNAME (tracking) | 15–30 min | 4 hours |
+
+**Pro tip:** Set TTL to 300 seconds before making changes (speeds up propagation). Increase to 3600 after confirmed working.
+
+---
+
+## Step 6: Connecting to Instantly — Full Walkthrough
+
+### Google OAuth (Recommended)
+
+1. Instantly → Email Accounts → Add New → Connect existing accounts → Google
+2. Choose Option 1: OAuth
+3. Copy the Client ID
+4. Google Workspace Admin Console → Security → API Controls → Manage App Access
+5. Configure new app → paste Client ID
+6. Select "Instantly OAuth Email v1" from results
+7. Scope: All users, Access: Trusted
+8. Return to Instantly → Login
+
+### Google App Password (Backup Method)
+
+1. Enable 2FA on the Google account
+2. Google Account → Security → App Passwords → generate for "Mail"
+3. In Instantly: Option 2: App Password → enter email + generated password
+
+### Google Bulk Import (10+ accounts)
+
+1. Generate app passwords for each account
+2. Download Instantly's CSV template
+3. Fill in: email, app password, host settings
+4. IMAP: imap.gmail.com:993 | SMTP: smtp.gmail.com:587
+5. Upload via Add New → Any Provider → Bulk Import from CSV
+
+### Microsoft (One-by-One Only)
+
+1. Instantly → Email Accounts → Add New → Microsoft
+2. Confirm SMTP enabled → Yes
+3. Sign in with Microsoft account
+4. **Check "Consent on behalf of your organization"**
+5. Accept permissions
+
+Microsoft accounts **cannot** be bulk imported.
+
+### Post-Connection Checklist (Per Account)
+
+- [ ] Set daily send limits (Google: 15–25, Microsoft: 10–15)
+- [ ] Enable custom tracking domain (if set up)
+- [ ] Add account tags (client, domain, provider)
+- [ ] Enable slow ramp (starts at 2/day, +2/day)
+- [ ] Run "Test domain setup" — all green
+
+---
+
+## Step 7: Warm-Up — Full Walkthrough
+
+### Enabling Warm-Up
+
+**Individual:** Email Accounts → click flame icon next to account
+**Bulk:** Select accounts with checkbox → three dots → Enable warmup
+
+### Settings Configuration
+
+Navigate to: Account → Settings → Warm-up settings
+
+| Setting | New Accounts | Established Accounts |
+|---|---|---|
+| Daily warmup limit | 10–15 | 20–30 |
+| Reply rate | 30–40% | 30–40% |
+| Increase by day | On | Optional |
+| Read emulation | On | On |
+| Open rate | 80–90% | 80–90% |
+| Spam protection | 100% | 100% |
+| Mark important | 30–50% | 30–50% |
+
+### Email Filters (Keep Inbox Clean)
+
+**Gmail:**
+1. Find warm-up filter tag in Instantly (Account Settings → Warmup filter tag)
+2. Gmail → Settings → Filters → Create filter with tag in Subject/Has words
+3. Actions: Skip inbox, Apply label "Warmup"
+
+**Outlook:**
+1. Copy filter tag from Instantly
+2. Outlook → Rules → Create rule: Subject/body contains [tag]
+3. Actions: Mark as read, Move to "Warmup" folder
+
+### Monitoring During Warm-Up
+
+Check daily:
+- Health score (aim 90%+, minimum 70%)
+- Flame color (green/blue = good, red = problem)
+- Sent AND received counts (both should increase)
+
+---
+
+## Step 8: Going Live — Full Walkthrough
+
+### Pre-Launch Checklist
+
+- [ ] All accounts warmed 2–3 weeks
+- [ ] Health scores 70%+ (ideally 90%+)
+- [ ] No red flames
+- [ ] DNS test all green
+- [ ] Custom tracking domain enabled
+- [ ] Lead list verified (email verification tool)
+- [ ] Email copy written and reviewed
+- [ ] Unsubscribe/opt-out included
+
+### Deliverability Settings in Instantly
+
+Navigate to: Campaign → Settings → Advanced Deliverability
+
+1. **Text-only first email:** Enable "Always send first email as text-only"
+2. **Disable open tracking:** Enable (Frontal default — tracking ≠ success metric)
+3. **ESP matching:** Enable (Google sends to Gmail, Microsoft sends to Outlook)
+4. **Limit emails per company:** Set 2–3/day, workspace-wide
+
+### Slow Ramp Guidance
+
+- **New accounts:** Enable slow ramp (starts at 2, +2/day until max)
+- **Established accounts already sending:** Do NOT enable — it resets them to 2/day
+- **New accounts added to existing campaigns:** Enable for those specific accounts only
+
+### First Campaign Launch
+
+1. Start with 50–100 leads
+2. Set 3–8 minute random delays between emails
+3. Send Tuesday–Thursday, 8–11am recipient timezone (B2B default)
+4. Monitor for 2–3 days
+5. If metrics healthy, scale up gradually
+6. **Scale by adding mailboxes, not by pushing limits higher**
+
+### Inbox Rotation
+
+Add all healthy accounts to campaign rotation. More accounts = lower volume per account = better deliverability.
+
+---
+
+## Step 9: Monitoring — Full Walkthrough
+
+### Daily Routine (5 min — morning coffee check)
+
+- [ ] Bounce rates <5%
+- [ ] Reply rates consistent
+- [ ] No spam complaint notifications
+- [ ] No blacklist alerts
+- [ ] Spot-check 2–3 warm-up emails
+
+### Weekly Deep Dive (15 min)
+
+- [ ] Google Postmaster Tools check
+- [ ] Microsoft SNDS scores
+- [ ] MXToolbox blacklist status
+- [ ] Week-over-week open/reply rate comparison
+- [ ] Bounce rate trending
+
+### Monthly Audit (30 min)
+
+- [ ] Update suppression list
+- [ ] Audit bounce patterns
+- [ ] Review domain reputation trends
+- [ ] Clean old unresponsive leads
+- [ ] Rotate warm-up email content
+- [ ] Review infrastructure costs
+
+### Quarterly Review (1 hour)
+
+- [ ] Full DNS audit (all records still correct across all domains)
+- [ ] Sender reputation deep dive
+- [ ] Warm-up service effectiveness review
+- [ ] Strategic capacity planning
+- [ ] Document lessons learned
+
+### Scaling Protocol
+
+- Max 20% volume increase per week
+- Stagger new domain launches (1 per week max)
+- New domains go through full warm-up cycle
+- Never add volume AND change copy simultaneously
+
+### Monitoring Tools
+
+**Free:**
+- Google Postmaster Tools — Gmail reputation
+- Microsoft SNDS — Outlook reputation
+- MXToolbox — blacklist checking
+- Mail-Tester — periodic email scoring
+
+**Already Included:**
+- Instantly analytics — primary monitoring
+- Warm-up dashboards — daily health
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/email-infra-troubleshooting.md
+++ b/skills/alex-vacca/cold-email-strategist/references/email-infra-troubleshooting.md
@@ -1,0 +1,251 @@
+# Email Infrastructure — Troubleshooting
+
+Diagnosis and recovery protocols for common email infrastructure problems.
+
+---
+
+## DNS Issues
+
+### "DNS Records Not Found"
+
+**Cause:** Records haven't propagated or weren't saved correctly.
+
+**Fix:**
+1. Wait — propagation takes 15 min to 48 hours
+2. Check registrar DNS panel — verify records are actually saved
+3. Flush DNS cache: `sudo dscacheutil -flushcache` (Mac) or `ipconfig /flushdns` (Windows)
+4. Lower TTL to 300 seconds for faster propagation
+5. Verify you're editing the correct domain in the correct registrar
+
+### "Multiple SPF Records Detected"
+
+**Cause:** More than one SPF TXT record exists. Only ONE is allowed per domain.
+
+**Fix:**
+1. Go to registrar DNS panel
+2. Find all TXT records starting with `v=spf1`
+3. Delete duplicates — keep only the correct one:
+   - Google: `v=spf1 include:_spf.google.com ~all`
+   - Microsoft: `v=spf1 include:spf.protection.outlook.com ~all`
+4. Save and wait for propagation
+
+**Note:** This is especially common with GoDaddy, which sometimes auto-creates SPF records.
+
+### "DKIM Authentication Failed"
+
+**Cause:** DKIM record not added, incorrect value, or hasn't propagated.
+
+**Fix:**
+1. Re-generate the DKIM key in Google Workspace or Microsoft 365 admin
+2. Copy the EXACT value — including all characters, no extra spaces
+3. Verify the host/name field:
+   - Google: `google._domainkey`
+   - Microsoft: `selector1._domainkey` and `selector2._domainkey`
+4. Wait 24 hours (DKIM can take longer to propagate)
+5. Re-start authentication in workspace admin panel
+
+### "DMARC Record Missing"
+
+**Cause:** DMARC is never auto-configured. You must add it manually.
+
+**Fix:** Add TXT record:
+- Host: `_dmarc`
+- Value: `v=DMARC1;p=none;sp=none;pct=100;rua=mailto:you@domain.com;ri=86400;aspf=r;adkim=r;fo=1`
+
+### "Custom Tracking Domain Not Working"
+
+**Cause:** CNAME record incorrect, Cloudflare proxy enabled, or not configured in Instantly.
+
+**Fix:**
+1. Verify CNAME: host `inst` → points to `prox.itrackly.com` (type CNAME)
+2. Cloudflare: click orange cloud to make it grey (proxy OFF)
+3. Instantly: Settings → Custom Tracking Domain → enter `inst.yourdomain.com` → Verify
+4. Wait 15–30 min for propagation
+5. Test: `nslookup inst.yourdomain.com` — should point to tracking server
+
+### DNS Gotchas Checklist
+
+- [ ] Did you save after adding records?
+- [ ] Are you editing the correct domain?
+- [ ] Is the host field exactly right? (@ vs blank vs _dmarc)
+- [ ] Did you paste the entire value with no extra spaces?
+- [ ] Is Cloudflare proxy disabled for CNAME records?
+- [ ] Is there only ONE SPF record?
+
+---
+
+## Connection Issues
+
+### "Account already added"
+
+Account is connected to another Instantly workspace. Remove it from the other workspace first.
+
+### Google OAuth Fails
+
+- Verify you're admin of the Google Workspace
+- Check API Controls are configured: Security → API Controls → Manage App Access
+- Try from incognito browser
+
+### Microsoft Won't Connect
+
+- Verify SMTP AND IMAP are both enabled in Admin Center
+- Wait the full 1 hour after enabling
+- Try from incognito browser
+- Ensure you're signing in with the correct Microsoft account
+
+### "Invalid Credentials"
+
+- Double-check app password (regenerate if needed)
+- Verify 2FA is still enabled on the account
+
+### Connection Keeps Dropping
+
+- Check if 2FA was disabled — re-enable and generate new app password
+- Verify DNS records haven't changed
+
+---
+
+## Warm-Up Issues
+
+### Red Flame (Warm-Up Disabled)
+
+**Cause:** High bounce rate on warm-up emails. Usually a DNS problem.
+
+**Recovery:**
+1. Run "Test domain setup" in Instantly — fix any red items
+2. Verify DKIM, SPF, DMARC are all correct
+3. Check if domain/IP is blacklisted (MXToolbox)
+4. Click red flame → Request Reactivation Code
+5. Check inbox for code → enter in Instantly
+6. Warm-up re-enables
+
+### Low Health Score (Below 70%)
+
+**Cause:** Warm-up emails landing in spam.
+
+**Fix:**
+1. Verify all DNS records (SPF, DKIM, DMARC)
+2. Check domain age — very new domains need more time
+3. Reduce warm-up volume temporarily
+4. Check if on any blacklists
+
+### No Emails Sending
+
+Account likely disconnected. Reconnect in Instantly.
+
+### No Emails Receiving
+
+Warm-up not enabled. Click the flame icon to enable.
+
+---
+
+## Deliverability Issues
+
+### Emails Going to Spam
+
+**Investigation checklist:**
+1. All 4 DNS records present? (MX, SPF, DKIM, DMARC)
+2. Domain forwarding set up?
+3. Mailboxes properly warmed (2–3 weeks)?
+4. Sending volume within limits (max 25/day Google, 15/day Microsoft)?
+5. Email content spammy? (check for trigger words, too many links, HTML)
+6. On any blacklists? (MXToolbox check)
+7. Custom tracking domain enabled?
+8. Profile pictures on all mailboxes?
+
+### Bounce Rate Spike (Above 5%)
+
+**Immediate response:**
+1. Pause campaigns immediately
+2. Identify source: bad list? domain issue? DNS problem?
+3. Clean list — remove all bounced emails
+4. Resume at 50% volume for 3 days
+5. Day 5–7: increase to 75%
+6. Day 8+: return to 100%
+
+### Blacklisted
+
+**Critical:** Stop all sending from affected domain immediately.
+
+**Recovery:**
+1. Identify which blacklist (MXToolbox → Blacklist Check)
+2. Follow that blacklist's specific removal process:
+   - **Spamhaus** — most critical, affects major ISPs
+   - **SORBS** — less critical but still matters
+   - **Barracuda** — affects corporate email filters
+3. Fix the root cause before resuming
+4. If multiple listings, consider the domain burned — set up new domain
+
+### Engagement Drop
+
+**Investigation:**
+1. What changed? (list, copy, volume, timing, CTA)
+2. When did it start? (pinpoint date)
+3. Which domains affected? (all or specific)
+4. Any external factors? (holidays, industry events)
+
+**Recovery:**
+- Revert to previous working approach
+- Run A/B test to isolate the problem
+- Change only ONE variable at a time
+
+---
+
+## Recovery Protocols
+
+### Default Recovery Process
+
+```
+Day 1:  Pause affected campaigns
+Day 2:  Fix the identified issue
+Day 3–5: Resume at 50% volume
+Day 6–8: Monitor, increase to 75%
+Day 9–11: Monitor, increase to 100%
+Day 12+: Full volume with continued monitoring
+```
+
+### Healthy Metrics Reference
+
+| Metric | Healthy | Warning | Action Required |
+|---|---|---|---|
+| Bounce rate | <2% | 2–5% | >5% |
+| Spam rate | <0.1% | 0.1–0.3% | >0.3% |
+| Open rate | 40–60% | 30–40% | <30% |
+| Reply rate | 2%+ | 1–2% | <1% |
+| Deliverability score | >95% | 90–95% | <90% |
+
+### Investigation Framework
+
+When something goes wrong, ask:
+1. **What changed?** (list, copy, volume, timing)
+2. **When did it start?** (pinpoint date/time)
+3. **Which domains affected?** (all or specific)
+4. **What do metrics show?** (bounce, spam, open rates)
+5. **External factors?** (holidays, news, industry events)
+
+---
+
+## Seasonal Factors (Don't Panic)
+
+| Period | Normal Drop | Recovery |
+|---|---|---|
+| December holidays | 20–30% | Mid-January |
+| July–August | 10–20% | September |
+| End of quarter | 10–15% | First 2 weeks of new quarter |
+| Industry conferences | 15–25% | 1 week post-event |
+
+**Investigate** only if dips exceed these norms or don't recover on schedule.
+
+---
+
+## Where to Get Help
+
+1. Re-watch the Step 4 setup videos (most issues are missed steps)
+2. Contact registrar support (they can verify records are saved)
+3. MXToolbox "Check DNS" feature (shows exactly what's missing)
+4. Frontal community (share screenshots, hide sensitive values)
+5. Tag @Louis or @Nik for urgent issues
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/cold-email-strategist/references/email-infra.md
+++ b/skills/alex-vacca/cold-email-strategist/references/email-infra.md
@@ -1,0 +1,75 @@
+# Email Infrastructure
+
+You help users set up, configure, and troubleshoot cold email infrastructure from zero to live campaigns.
+
+## Reference
+
+Read these resources based on the user's question:
+
+- **Complete setup guide: domains, DNS, warmup, monitoring** → Read `email-infra-guide.md`
+- **Step-by-step walkthroughs with video tutorials** → Read `email-infra-step-by-step.md`
+- **Diagnosis and recovery for DNS, connection, warmup, deliverability issues** → Read `email-infra-troubleshooting.md`
+
+## Critical Rules (Never Break)
+
+1. Never use primary domain for cold outreach
+2. Max 2 mailboxes per domain
+3. One domain = one workspace (never mix)
+4. Use multiple registrars (no single point of failure)
+5. Warm up 2-3 weeks minimum before sending
+6. Never disable warm-up once campaigns running
+7. Start conservative, scale gradually
+
+## Infrastructure Sizing Formula
+
+- Monthly goal / 20 working days = daily volume
+- Daily volume / 20-25 per mailbox = mailboxes needed
+- Mailboxes x 1.5 (buffer) / 2 = domains needed
+- Provider split: 60% Google Workspace, 40% Microsoft 365
+
+## DNS (All 4 Records Required)
+
+| Record | Purpose |
+|--------|---------|
+| MX | Routes incoming email |
+| SPF | Declares sending servers |
+| DKIM | Digital signature authentication |
+| DMARC | Policy for SPF/DKIM failures |
+
+## Warmup Timeline
+
+- Week 1: Foundation (no campaigns)
+- Week 2: Building (no campaigns)
+- Week 3: Ready (health scores 70%+, ideally 90%+)
+
+## Going Live Ramp Schedule
+
+| Week | Google | Microsoft |
+|------|--------|-----------|
+| 1 | 10-15/day | 5-10/day |
+| 2-3 | 15-20/day | 10-12/day |
+| 4+ | 20-25/day | 12-15/day |
+
+## Healthy Metrics
+
+- Open rate: 50%+
+- Reply rate: 2%+
+- Bounce rate: <3% (target <2%)
+- Spam rate: <0.1%
+- Deliverability score: >95%
+
+## Examples
+
+**Example 1:** "I want to send 3,000 emails per month, how many domains do I need?"
+→ Read email-infra-guide.md. Calculate: 150/day → 10-12 mailboxes → 5-6 domains. Split 60/40 Google/Microsoft.
+
+**Example 2:** "My warm-up shows a red flame in Instantly"
+→ Read email-infra-troubleshooting.md. Run "Test domain setup", verify all 4 DNS records, check domain age, request reactivation.
+
+**Example 3:** "Walk me through setting up a new domain from scratch"
+→ Read email-infra-step-by-step.md. Follow 9-step process: calculate needs → buy domain → Google/Microsoft setup → DNS → connect Instantly → warmup → go live → monitor.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/email-templates-library.md
+++ b/skills/alex-vacca/cold-email-strategist/references/email-templates-library.md
@@ -1,0 +1,319 @@
+# Complete Cold Email Templates Library (34 Templates)
+
+## First Touch Templates (23 Templates)
+
+### #1 Observation Question Framework
+```
+Subject: {{trigger_topic}}
+
+Observation question about their situation?
+
+Solution statement with social proof.
+
+Soft CTA question.
+```
+
+### #2 Analogy Email
+- Uses metaphor to simplify complex value prop
+- Makes abstract benefits concrete
+- Example: "Hiring an SDR is like buying a treadmill..." (for outsourced sales)
+
+### #3 Hiring "End Users" Template
+- Target: Companies hiring roles that align with your product
+- Trigger: Job posting for relevant position
+- Logic: If they're hiring for X, they need tools that support X
+
+```
+Noticed you're hiring {{role}}.
+
+Most companies at your stage struggle with {{problem}} during onboarding.
+
+We helped {{similar_company}} cut ramp time by {{%}}.
+
+Worth a quick look?
+```
+
+### #4 NCAA Games Hook (>10% reply rate)
+```
+Subject: march madness
+
+{{firstName}}, quick question—
+
+Do you have your bracket filled out yet?
+
+Also curious: how are you currently handling {{problem}}?
+
+[Name]
+```
+
+### #5 Work Anniversary Trigger
+```
+Subject: {{years}} years
+
+Congrats on {{years}} years at {{company}}.
+
+Quick q: Has {{pain_point}} gotten easier or harder since you started?
+```
+
+### #6 Visual Email Template
+- Include screenshot/gif showing their problem
+- Personalized Loom showing their website/tool
+- Works because: Pattern interrupt + proof you researched
+
+### #13 Snowflake Style
+```
+Subject: {{metric}} at {{company}}
+
+Noticed {{company}} is {{trigger}}.
+
+Companies doing this typically see {{problem}}.
+
+We helped {{customer}} achieve {{result}} in {{timeframe}}.
+
+Open to seeing how?
+```
+
+### #16 Content Teams Template
+- Hook: Identify a challenge they're facing
+- Offer: Solution with success story
+- Works for: Marketing/content-focused ICPs
+
+### #17 Account-Based Framework
+```
+I noticed {{company}} is {{trigger}}.
+
+Been chatting with a few folks on the {{department}} team about {{topic}}.
+
+{{Name}} mentioned you'd be the right person to talk to about {{specific_initiative}}.
+
+Worth connecting?
+```
+
+### #18 Podcast Guest Spot
+- Addresses content gaps in their marketing
+- Provides tangible value (exposure)
+- Non-salesy opener
+
+### #19 Customer Reconnect
+```
+Subject: {{company}} → {{new_company}}
+
+{{firstName}}, saw you moved from {{old_company}} to {{new_company}}.
+
+At {{old_company}} you used us for {{use_case}}.
+
+Does {{new_company}} have something similar in place?
+```
+
+### #20 New Exec Template (First 90 Days)
+```
+Subject: first 90
+
+{{firstName}}, congrats on the {{title}} role.
+
+Most new {{title}}s I talk to are focused on {{common_priority}}.
+
+Happy to share what {{similar_company}} did in their first quarter.
+
+Interested?
+```
+
+### #21 Job Change (Beanworks Style)
+- References career shift context
+- Acknowledges transition period
+
+### #22 Do the Math Template
+```
+Subject: {{number}} potential leads
+
+{{firstName}}, quick math:
+
+{{company}} has {{X}} people who {{trigger}}.
+
+If even {{%}} convert, that's {{Y}} opportunities.
+
+We helped {{customer}} capture {{result}} from similar math.
+
+Want to see the breakdown?
+```
+
+### #23-25 CastorDoc ROI Series
+- ROI calculations for specific costs
+- Data warehouse costs
+- Onboarding time calculations
+
+---
+
+## Follow-Up Templates (4 Templates)
+
+### #27 Nooks SDR Breakdown (7 Steps)
+1. Reference previous email
+2. Acknowledge no response (no guilt)
+3. Add new information/angle
+4. Keep it shorter than email 1
+5. Different CTA style
+6. Same thread (no new subject)
+7. Send 3-5 days after email 1
+
+### #28 Robot Follow Up (Humor-Based)
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+This is an automated follow-up because you didn't respond to my last email.
+
+Just kidding. I'm a real person.
+
+But seriously—did {{topic}} resonate at all?
+
+[Name]
+```
+
+### #29 3rd Party Content
+- Educational follow-up
+- Share podcast/content recommendations
+- Non-promotional touchpoint
+
+### #30 LinkedIn + Video
+- Personalized video showing profile research
+- Multi-channel coordination
+
+---
+
+## Re-Engagement Templates (4 Templates)
+
+### #31 No-Oriented Question (Rebooking Demos)
+```
+Subject: quick question
+
+{{firstName}},
+
+Would it be crazy to reconnect?
+
+I know we talked {{timeframe}} ago about {{topic}}.
+
+{{New_information}} has changed since then.
+
+Still relevant?
+```
+
+### #32 Reactivating Closed Lost
+```
+Subject: since we last talked
+
+{{firstName}},
+
+When we talked in {{month}}, you mentioned {{objection}}.
+
+Since then, we've {{improvement}}.
+
+Worth another look?
+```
+
+### #33-34 Ramp Re-Engagement Examples
+- Different angle from original outreach
+- New trigger or information
+- Very soft CTA asking for right person
+
+---
+
+## 7 Email 1 Variations (Frontal Core Framework)
+
+### Variation 1: Observation → Solution → Proof → CTA
+```
+[Observation question about their situation?]
+
+[Solution statement.] [Social proof with specific number.]
+
+[Soft CTA question?]
+```
+
+### Variation 2: Question → Problem → Solution + Proof → CTA + PS
+```
+[Observation question?]
+
+[Problem statement they likely face.]
+
+[Solution + social proof combined.]
+
+[CTA]
+
+PS - [Additional social proof]
+```
+
+### Variation 3: First Line → Poke Bear → Value Prop → CTA
+```
+[Relevant personalized first line]
+
+[Poke the bear question about their pain?]
+
+We help companies like {{similar_company}} achieve {{result}} without {{obstacle}}.
+
+[CTA]
+```
+
+### Variation 4: Trigger → Problem → Solution → Calculation → CTA
+```
+[Personalized trigger reference]
+
+[Problem statement]
+
+[Solution]
+
+[Specific calculation showing impact]
+
+[CTA]
+```
+
+### Variation 5: Stat → Question → Value CTA
+```
+[Industry statistic]
+
+[Question linking stat to their specific problem?]
+
+[Value-based CTA offering resource/insight]
+```
+
+### Variation 6: Trigger → Achievement → CTA
+```
+[Relevant trigger observation]
+
+[Social proof achievement we delivered for similar company]
+
+[Direct CTA]
+```
+
+### Variation 7: Role Pain → Solution → Answer Objection → Soft CTA
+```
+What {{title}}s hate about their job: [common pain]
+
+[How we solve it]
+
+[Pre-answer their likely question]
+
+[Very soft CTA]
+```
+
+### Email 2 Template (Send 3 Days Later)
+```
+Subject: RE: (same thread)
+
+[Lead magnet offer]
+
+[Social proof]
+
+[Value prop restated differently]
+
+[CTA]
+```
+
+### Email 3 Template (Send 14 Days Later — New Subject)
+```
+Subject: [New subject line]
+
+[New Email 1 variation - different angle]
+
+[Very soft CTA asking for right person]
+"If this isn't you, who should I be talking to about {{topic}}?"
+```

--- a/skills/alex-vacca/cold-email-strategist/references/first-touch.md
+++ b/skills/alex-vacca/cold-email-strategist/references/first-touch.md
@@ -1,0 +1,90 @@
+# First Touch Email Writing
+
+You write high-performing first cold emails for B2B outbound. Every email must be 60-90 words, plain text, one CTA, and lead with pain over features.
+
+## Process
+
+1. **Clarify ICP** -- Ask: Who is the target? (title, company size, industry). ATL or BTL?
+2. **Identify trigger** -- What signal or reason justifies reaching out NOW?
+3. **Select framework** -- Pick from the 8 allowed frameworks below
+4. **Draft email** -- 60-90 words, one soft CTA, specific social proof
+
+## Reference
+
+Read `writing-frameworks.md` for all 8 frameworks and Josh Braun principles.
+Read `email-templates-library.md` for 23 first-touch templates and the 7 Frontal Email 1 variations.
+Read `frontal-playbook.md` for 3 value prop styles (Show Cost, Peer Proof, Specific Outcome), 3 preview/first line patterns (Observation, Pain, Industry), and Frontal benchmarks from 250K+ emails.
+
+## 8 Allowed Frameworks
+
+1. **Before/After** -- Show current state vs. desired state
+2. **Pattern Interrupt** -- Break expectations to earn attention
+3. **Ask Before Pitch** -- Open-ended question before any selling
+4. **Upfront Value** -- Give something useful before asking
+5. **Do the Math** -- Trigger + pitch + calculation + CTA
+6. **Challenge of Similar Companies** -- "Companies doing X in Y often struggle with Z"
+7. **Neutral Insight** -- Share third-party resource, build trust first
+8. **Typical Problems by Role** -- Role-specific pain that prompts reflection
+
+## Structure Checklist
+
+```
+Opening (trigger/observation) + Assumption + Social proof with numbers + Open-ended question
+```
+
+- 60-90 words max
+- No bullets in cold emails
+- One CTA only -- soft ask ("Worth a quick look?" not "Book a 30-min demo")
+- Specific social proof ("47% increase" not "significant improvement")
+- Lead with pain, not features
+- Plain text only
+
+## Examples
+
+**Example 1: Do the Math framework for a hiring platform**
+```
+Subject: 12 open roles
+
+{{firstName}}, quick math:
+
+{{company}} has 12 engineering roles open averaging 45 days to fill.
+
+At $500/day in lost productivity, that's $270K sitting on the table.
+
+We helped {{similar_company}} cut time-to-fill by 38%.
+
+Want to see the breakdown?
+```
+
+**Example 2: Ask Before Pitch for an analytics tool**
+```
+Subject: marketing data
+
+{{firstName}}, curious --
+
+How much time does your team spend pulling reports from different platforms each week?
+
+Most marketing ops leads I talk to say 6-8 hours.
+
+We helped {{similar_company}} get that to under 1 hour.
+
+Worth a quick look?
+```
+
+**Example 3: Challenge of Similar Companies for cybersecurity**
+```
+Subject: {{company}} security
+
+{{firstName}},
+
+Companies doing $10-50M in SaaS typically discover 3x more vulnerabilities when they switch from periodic pen tests to continuous scanning.
+
+{{similar_company}} found 47 critical issues in their first week.
+
+Open to seeing how that compares to your setup?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/follow-up.md
+++ b/skills/alex-vacca/cold-email-strategist/references/follow-up.md
@@ -1,0 +1,94 @@
+# Follow-Up Email Writing
+
+You write follow-up emails (Email 2 and Email 3) for B2B cold sequences. The 3-email framework is the standard -- more than 3 annoys and triggers spam flags.
+
+## Process
+
+1. **Review Email 1** -- What framework, value prop, and CTA were used?
+2. **Change the angle** -- Each email MUST use a different value prop
+3. **Draft follow-up** -- Shorter than Email 1, same thread (Email 2) or new subject (Email 3)
+
+## Reference
+
+Read `email-templates-library.md` for follow-up templates (#27-30) and Frontal Email 2/3 structures.
+Read `cold-email-mastery.md` for the 3-email framework, value prop rotation, and breakup strategy.
+
+## The 3-Email Framework
+
+### Email 2: Add Context (send 3-5 days after Email 1)
+- Same thread (RE: original subject)
+- Everything you cut from Email 1
+- Different value prop angle
+- Shorter than Email 1
+- New CTA style
+
+### Email 3: Lower the Friction (send ~17 days after Email 1)
+- New subject line, fresh thread
+- They said no twice -- lower the ask
+- Offer a lead magnet, custom Loom audit, or resource
+- Very soft CTA: "If this isn't you, who should I be talking to?"
+
+## Value Prop Rotation
+
+Rotate between emails -- never repeat the same angle:
+- **Email 1:** Save money
+- **Email 2:** Make money
+- **Email 3:** Save time
+
+Always add the "So What": "Save 3 hours/month" is weak. "Save 3 hours/month so your SDRs spend more time actually selling" is strong.
+
+## Breakup Emails -- What Works
+
+- "Am I reaching the right person?"
+- "Is there someone else who handles this?"
+- Name other people in their department (use Clay enrichment)
+
+What does NOT work: Guilt trips, begging, "you must be getting chased by an alligator" humor.
+
+## Examples
+
+**Example 1: Email 2 -- Add Context**
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+Quick follow-up -- wanted to share one thing I left out.
+
+{{similar_company}} was losing $40K/quarter on manual reconciliation before switching. Their ops team now saves 12 hours/week.
+
+Would a 2-minute walkthrough be useful?
+```
+
+**Example 2: Email 3 -- Lower Friction**
+```
+Subject: quick resource
+
+{{firstName}},
+
+Put together a benchmark report on {{industry}} conversion rates -- thought it might be useful regardless of whether we connect.
+
+[link]
+
+If improving {{metric}} is a priority, happy to walk through what we're seeing. If not, no worries at all.
+
+Is there someone else on the team I should reach out to?
+```
+
+**Example 3: Humor-Based Follow-Up (Robot)**
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+This is an automated follow-up because you didn't respond to my last email.
+
+Just kidding. I'm a real person.
+
+But seriously -- did {{topic}} resonate at all?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/frontal-playbook.md
+++ b/skills/alex-vacca/cold-email-strategist/references/frontal-playbook.md
@@ -1,0 +1,155 @@
+# Frontal Cold Email Playbook
+
+Operational insights from 250K+ emails sent and 73 prospect calls.
+
+## Preview / First Line Patterns
+
+3 types of openers. Match to your campaign type:
+
+### Type 1: Observation (General Triggers)
+Call out something you noticed about them, without reason. Works because it could mean: potential customer, question, or research.
+```
+Hey John, saw you offer a free audit on your site.
+```
+
+### Type 2: Pain (Specific Triggers)
+Reference a pain point you're confident they have. Connect the trigger to the "why."
+```
+Bad: "Noticed you're hiring a BDR."
+Better: "Hey John, here is a top of funnel outbound playbook. With {{company}} hiring for a BDR I assume generating top of funnel is a priority."
+```
+
+### Type 3: Industry (Enterprise & Traditional)
+Hot topic they've seen, been impacted by, or regulation change.
+```
+Subject: tariffs
+Preview: Hey John, with cost rising on imports from China, are you considering your options?
+```
+```
+Subject: NIS2 regulations
+Preview: Hey John, with the new NIS2 regulations it's now mandatory to back up your Okta tenant.
+```
+
+---
+
+## 3 Value Proposition Styles
+
+### Style 1: Show Them the Cost of the Problem
+Framework: [Observation/Pain] → [Here's what that's actually costing you] → [Specific number]
+```
+Hey John, most businesses at the 5-year mark are leaving $50K-$200K in available
+capital on the table. Typically because they don't know what they qualify for.
+Based on your revenue range, {{company}} likely qualifies for more than you'd expect.
+Would you be open to hearing more?
+```
+
+### Style 2: Peer Proof ("Others Like You Are Doing X")
+Framework: [Observation/Pain] → [Other companies like you are doing X] → [Result they're getting]
+```
+Hey John, congrats on crossing the 5-year mark. A lot of businesses at your stage
+are using growth capital to fund expansion without touching their cash reserves.
+One owner in {{industry}} locked in $150K at terms that let him keep full ownership.
+Would something like that be useful for {{company}}?
+```
+
+### Style 3: Show a Specific Outcome
+Framework: [Observation/Pain] → [Here's the specific outcome] → [Want to see if it applies?]
+```
+Hey John, since you just opened a second location, I'd imagine managing cash flow
+across both is a priority. We recently helped a {{industry}} business secure $200K
+in growth capital in under 2 weeks with no equity or collateral.
+Would it make sense to see what {{company}} qualifies for?
+```
+
+---
+
+## CTA Patterns
+
+### Interest-Based (Safest at Scale)
+- "Think this could help your team?"
+- "Interested to learn more about this?"
+- "Worth exploring?"
+
+### Value-First / Resource
+- "Want me to send over a quick breakdown?"
+- "I put together a comparison for businesses your size — want me to share it?"
+
+### Routing / Right Person
+- "Are you the right person that handles {{responsibility}} at {{company}}?"
+- "Would this sit with you or someone else on the team?"
+
+---
+
+## Ready-to-Deploy Sequences
+
+### Referral Ceiling Founder Sequence (7 Touches)
+
+| Day | Channel | Touch | Strategy |
+|-----|---------|-------|----------|
+| 1 | Email | "The Mirror" | Names exact situation without pitch |
+| 2 | LinkedIn | Connection request | No pitch, just connect |
+| 4 | Email | "The Benchmark" | Introduces "1 in 300" benchmark |
+| 8 | LinkedIn | Engage/Soft DM | Comment on their content, soft message |
+| 11 | Email | "The Proof" | Social proof with case study |
+| 17 | LinkedIn | Value-Add DM | Share useful resource |
+| 22 | Email | "The Breakup" | Final low-pressure touch |
+
+### Lead Magnet Engager Sequence (2 Emails)
+
+| Email | Strategy |
+|-------|----------|
+| Email 1 | Position the system behind the lead magnet |
+| Email 2 | Webinar invite as secondary CTA |
+
+---
+
+## Frontal Principles (from 250K+ Emails)
+
+1. **Write for the 97%** — Optimize for the majority who won't reply, not the 3% who will
+2. **70-90 words optimal** — Keep it tight
+3. **2-step sequences work best** — Don't over-sequence
+4. **13X gap** between worst and best email variants — testing matters enormously
+5. **Subject + Preview = Complete thought** — They work together
+6. **Position yourself as a potential customer** in the subject line
+7. **Soft CTAs > time asks** — "Think this could help?" beats "Got 15 min?"
+8. **Segment > Individual personalization** at scale — effort-to-output ratio is better
+9. **Preview line IS the first line** — First 50 characters appear in inbox
+
+### Benchmarks
+
+| Metric | Target |
+|--------|--------|
+| Open rate | 50%+ |
+| Positive reply rate | 5-8% |
+| Meeting book rate | 2-4% |
+| Emails per inbox/day | 50-100 max |
+
+---
+
+## Frontal Pain-Point Angles (from 73 Prospect Calls)
+
+Use these proven angles when selling outbound/GTM services:
+
+1. **Referral Ceiling** — "How do you generate pipeline beyond referrals?"
+2. **Failed DIY Outbound** — "You tried outbound, it didn't work"
+3. **System vs. Leads** — "You need a system, not just more leads"
+4. **Scale Without Headcount** — "Grow pipeline without hiring more reps"
+
+---
+
+## Common Mistakes
+
+- Too long subject lines (7+ words)
+- Misleading clickbait
+- Same copy for every persona
+- All caps or spammy words ("FREE", "OFFER")
+- Making it about YOU not them
+- "Helping {{company}} with growth" — too obviously a pitch
+- "Quick call?" — overused, screams cold email
+
+## A/B Testing Rules
+
+- Test 3 subject lines per campaign
+- Track reply rate to meeting rate, not just opens
+- Match inbox type to prospect (Gmail to Gmail, Outlook to Outlook)
+- Run the "So What?" test on every signal: Is it recent? Does it connect to my offer? Would they care?

--- a/skills/alex-vacca/cold-email-strategist/references/personalization-prompts.md
+++ b/skills/alex-vacca/cold-email-strategist/references/personalization-prompts.md
@@ -1,0 +1,188 @@
+# Personalization Prompts & Best Practices
+
+## 6 Buckets of Personalization (Flip The Script)
+
+### Bucket 1: Self-Authored Content
+Content the prospect has created themselves:
+1. Speaking Engagements
+2. Webinars
+3. Articles
+4. Posts
+
+**Usage:** Highest value personalization. Reference their thought leadership directly.
+
+### Bucket 2: Engaged Content
+Content the prospect has interacted with:
+1. Commented On
+2. Shared
+3. Liked Comments
+4. Liked Posts
+
+**Usage:** Shows what topics interest them. Reference shared interests.
+
+### Bucket 3: Self-Identified Traits
+How the prospect describes themselves:
+1. Profile Line ("About me" Section)
+2. Company Line (Role, Specialization & Achievements Description)
+3. Headline (Below Profile Picture)
+
+**Usage:** Use their own words to frame relevance.
+
+### Bucket 4: Junk Drawer
+Personal details from their profile:
+1. Personal Interests
+2. Volunteer Experience: Personal (Charity)
+3. Languages Spoken
+4. Schools Attended
+5. Interested In/Following
+
+**Usage:** Build rapport but don't overdo it. Use sparingly.
+
+### Bucket 5: Background Centric
+Professional history and credentials:
+1. Tenure at Company
+2. Professional Trajectory (Movement Between Companies)
+3. Recommendations Given/Received
+4. Boards They're On
+5. Volunteer Experience: Professional (Mentorship)
+6. Awards Received
+7. Certifications
+8. Mutual Connections
+9. Skill Endorsements
+
+**Usage:** Reference career achievements and professional credibility.
+
+### Bucket 6: Company Level
+Company-wide information (24 data points):
+- Company Website Language, Posts, Blog Entries
+- News Mentions, IPO, Funding, Financial Reports
+- M&A Activity (Acquired, Were Acquired, Merged)
+- Growth, Hiring, Key Hires
+- HQ Moves, New Locations
+- Products, Features, Integrations releases
+- Marketing Moves, Competitor Moves
+- Negative/Positive Outputs, Midputs, Inputs
+
+**Usage:** Trigger-based personalization at scale.
+
+## 5 Types of Core-Static Relevance
+
+Fallback relevance when personalization isn't possible:
+1. **Demographic:** Buyer Persona
+2. **Firmographic:** Company Segment
+3. **Firmographic:** Company Industry Vertical
+4. **Firmographic:** Company Market Geos
+5. **Technographic:** Tech Stack
+
+## Personalization Hooks
+
+**Strong Hook (Verbatim Tie):**
+- Direct quote or reference from their content
+- Example: "In your recent post about X, you mentioned Y..."
+
+**Lite Hook (Conceptual Tie):**
+- Reference the theme/topic without direct quote
+- Example: "I noticed you're focused on X..."
+
+## Personalization Playbook by Category
+
+**INBOUND:**
+- First Line: Trigger-Based Relevance ONLY
+- Second Line: CTA to Book Time (Optional: Core-Static Relevance)
+
+**POSTBOUND/BRIDGEBOUND:**
+- First Line: Trigger-Based Relevance + ("but more importantly") Personalization
+- Second Line: Personalization "Hook" + Core-Static Relevance
+
+**OUTBOUND:**
+- First Line: Personalization Title or Summary + Personalization Excerpt
+- Second Line: Personalization "Hook" + Core-Static Relevance
+
+## No Personalization Playbook (Automated Templates)
+
+**INBOUND:** Trigger-Based Relevance → CTA
+**POSTBOUND/BRIDGEBOUND:** Trigger-Based Relevance → Core-Static Relevance
+**OUTBOUND:** Core-Static Relevance (Pattern Interrupt) → Core-Static ("We work with...")
+
+## Personalization Best Practices
+
+**DO:**
+- Custom prompts based on research
+- Facts prospects consistently care about
+- Time business was founded (owners proud of longevity)
+- Recent company news/changes
+- Tech stack signals
+
+**DON'T:**
+- Generic AI compliments ("Love your work!")
+- Content that sounds same as what they already have
+- Over-personalization that feels creepy
+- Complimenting LinkedIn posts without substance
+
+---
+
+## AI Personalization Prompts (lemlist Style)
+
+### ICP Identification Prompt
+```
+Find the top 3 most likely ICPs this person is prospecting based on {{companyDomain}}.
+If unavailable, use {{companyDescription}}.
+
+Rules:
+- Keep ICPs to just job titles (max 3)
+- Use shorter, abbreviated alternatives (CEO not Chief Executive Officer)
+- Always use "and" before the last example
+- Never end with a full stop
+```
+
+### Short Company Description Prompt
+```
+Describe the company in one concise sentence based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- Don't mention company name or ICP
+- Maximum 8 words
+- Keep tone neutral, all lower case
+- No quotes in output
+- Use main value prop from website
+
+Output must fit in: "Getting people interested in [insert] isn't the easiest thing in the world."
+```
+
+### Similar Product/Service Prompt
+```
+Categorize the product/service type based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- Maximum 6 words, neutral tone, all lower case
+- Keep it singular, avoid vagueness
+- Can use abbreviations
+
+Output must fit in: "We work with a similar [output]."
+```
+
+### Top 3 Problems Prompt
+```
+Identify top 3 problems of the main ICP based on {{companyDomain}} or {{companyDescription}}.
+
+Requirements:
+- Problems directly linked to lagging indicators
+- Rank 1-3 with 1 being biggest
+- Each problem max 10 words
+- Don't capitalize, no full stop at end
+- Add "and" before problem 3
+
+Format: [Problem 1], [Problem 2], and [Problem 3]
+```
+
+### Subject Line Prompt
+```
+Write a two-word email subject line based on {{companyDomain}} or {{companyDescription}}.
+
+Rules:
+- MUST be exactly 2 words
+- All lower case
+- Relevant to user's business
+- No sales/spam/buzz words
+- Should flow into email naturally
+```

--- a/skills/alex-vacca/cold-email-strategist/references/personalization.md
+++ b/skills/alex-vacca/cold-email-strategist/references/personalization.md
@@ -1,0 +1,84 @@
+# Personalization at Scale
+
+You build personalization strategies that make cold emails feel 1-to-1 even at high volume. You know the 6 data buckets, how to write AI prompts for Clay/enrichment tools, and the difference between strong and lite hooks.
+
+## Process
+
+1. **Assess data available** -- What enrichment tools and data sources does the user have?
+2. **Pick personalization tier** -- Strong hook (verbatim tie) or Lite hook (conceptual tie)?
+3. **Build the prompt or strategy** -- Provide AI prompts for Clay, data bucket selection, and hook templates
+
+## Reference
+
+Read `personalization-prompts.md` for the 6 buckets, hook types, playbook by category (inbound/outbound/postbound), and AI prompt templates.
+Read `campaign-playbooks.md` for advanced personalization playbooks (AI video, DynaPictures, lookalike, LinkedIn followers, job opening intent, ad scraping).
+
+## 6 Data Buckets (Ranked by Value)
+
+1. **Self-Authored Content** -- Posts, articles, webinars, speaking engagements (HIGHEST value)
+2. **Engaged Content** -- What they commented on, shared, liked
+3. **Self-Identified Traits** -- LinkedIn headline, about section, company line
+4. **Junk Drawer** -- Personal interests, volunteer work, languages, schools
+5. **Background Centric** -- Tenure, career trajectory, awards, certifications, mutual connections
+6. **Company Level** -- News, funding, hiring, product launches, M&A (24 data points)
+
+## Hook Types
+
+**Strong Hook (Verbatim Tie):**
+Direct quote or reference from their content. Example: "In your recent post about X, you mentioned Y..."
+
+**Lite Hook (Conceptual Tie):**
+Reference the theme without quoting. Example: "I noticed you're focused on X..."
+
+## AI Prompt Principles
+
+- Use AI for ONE specific part of the email, not the entire thing
+- Control messaging for split-testing -- static text + dynamic personalization
+- Show your work: "According to SimilarWeb, you get 50K visitors/month" (source attribution protects you if data is wrong)
+- Never use generic AI compliments ("Love your work!")
+
+## Fallback: Core-Static Relevance (No Personalization)
+
+When personalization data is unavailable, use these 5 fallbacks:
+1. Demographic (buyer persona)
+2. Firmographic (company segment)
+3. Firmographic (industry vertical)
+4. Firmographic (market geos)
+5. Technographic (tech stack)
+
+## Examples
+
+**Example 1: Clay prompt for custom first line (Bucket 1 -- Self-Authored)**
+```
+Find the most recent LinkedIn post by {{firstName}} {{lastName}} at {{company}}.
+Summarize the post's main argument in one sentence.
+Rules: Max 15 words, no generic compliments, reference a specific claim they made.
+Output format: "Your recent take on [topic] -- specifically [specific claim] -- caught my attention."
+```
+
+**Example 2: Lite hook using company-level data (Bucket 6)**
+```
+Noticed {{company}} just raised a Series B -- congrats.
+
+Most teams at this stage realize their outbound process that worked at seed doesn't scale past 50 reps.
+
+We helped {{similar_company}} rebuild theirs in 3 weeks.
+
+Worth a look?
+```
+
+**Example 3: Advanced playbook -- Job Opening Intent**
+```
+Saw {{company}} is hiring a {{role}}.
+
+In our experience, companies hiring for that role are usually dealing with {{problem}}.
+
+We helped {{similar_company}} solve that before their new hire even started -- saved 6 weeks of ramp time.
+
+Open to a quick chat?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/re-engagement.md
+++ b/skills/alex-vacca/cold-email-strategist/references/re-engagement.md
@@ -1,0 +1,82 @@
+# Re-Engagement Email Writing
+
+You write emails that revive cold leads, closed-lost deals, and prospects who went dark. These are NOT follow-ups within an active sequence -- these target leads from weeks or months ago.
+
+## Process
+
+1. **Understand the history** -- When was last contact? What was discussed? Why did they go cold?
+2. **Identify the new angle** -- What has changed since then? (new feature, new data, new trigger)
+3. **Draft re-engagement** -- No-oriented question, very soft CTA, acknowledge the gap
+
+## Reference
+
+Read `email-templates-library.md` for re-engagement templates (#31-34): no-oriented questions, closed-lost reactivation, and ramp re-engagement.
+
+## Re-Engagement Types
+
+### 1. No-Oriented Question (Rebook Demos)
+For prospects who booked but did not convert. Use "no-oriented" questions that are easy to say no to (which paradoxically gets more replies).
+
+### 2. Closed-Lost Reactivation
+For deals that were lost. Reference the original objection and what has changed since.
+
+### 3. Ramp Re-Engagement
+For leads from old sequences. New angle, new trigger, very soft ask for the right person.
+
+## Key Principles
+
+- **Acknowledge the gap** -- Do not pretend the previous interaction did not happen
+- **Lead with what changed** -- New feature, new data, new case study, market shift
+- **No-oriented questions work** -- "Would it be crazy to reconnect?" gets more replies than "Want to chat?"
+- **Reference their words** -- If they gave an objection, name it: "You mentioned X was the blocker"
+- **Very soft CTAs** -- "Still relevant?" or "Worth another look?" not "Book a call"
+
+## Examples
+
+**Example 1: No-Oriented Question (Rebook)**
+```
+Subject: quick question
+
+{{firstName}},
+
+Would it be crazy to reconnect?
+
+I know we talked {{timeframe}} ago about {{topic}}.
+
+We've since launched {{new_feature}} which directly addresses the {{objection}} concern.
+
+Still relevant?
+```
+
+**Example 2: Closed-Lost Reactivation**
+```
+Subject: since we last talked
+
+{{firstName}},
+
+When we talked in {{month}}, you mentioned {{objection}} was the blocker.
+
+Since then, we've {{specific_improvement}} -- {{similar_company}} saw {{result}} after making the switch.
+
+Worth another look?
+```
+
+**Example 3: Ramp Re-Engagement (New Angle)**
+```
+Subject: different angle
+
+{{firstName}},
+
+Reached out a while back about {{original_topic}} -- different reason this time.
+
+Just published a report on {{new_topic}} showing {{industry}} companies are {{insight}}.
+
+Thought of {{company}} given {{trigger}}.
+
+If this isn't you, who handles {{topic}} on your team?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/sequencing-tools.md
+++ b/skills/alex-vacca/cold-email-strategist/references/sequencing-tools.md
@@ -1,0 +1,88 @@
+# Sequencing Tool Recommendations
+
+## Email Sequencing (Automated Outbound)
+
+| Tool | Best For | Volume |
+|------|----------|--------|
+| **SmartLead** | High volume, AI warmup | 1000s/day |
+| **Instantly** | Ease of use, good deliverability | 1000s/day |
+| **Lemlist** | Multi-channel, images | Medium |
+| **Apollo** | All-in-one (data + sending) | Medium |
+
+## LinkedIn Sequencing
+
+| Tool | Best For |
+|------|----------|
+| **HeyReach** | Automated LinkedIn outreach |
+| **Expandi** | LinkedIn automation |
+| **Dripify** | LinkedIn sequences |
+
+## Multi-Channel Sequencing
+
+| Tool | Channels |
+|------|----------|
+| **LaGrowthMachine** | Email + LinkedIn + Twitter |
+| **Lemlist** | Email + LinkedIn |
+| **Reply.io** | Email + LinkedIn + Calls |
+
+## Integration Pattern with Clay
+
+```
+Clay Table
+    ↓
+[Add to SmartLead Campaign]
+    ↓
+Map variables:
+- first_name → {{First Name}}
+- last_name → {{Last Name}}
+- email → {{Work Email}}
+- first_line → {{AI First Line}}
+- company → {{Company Name}}
+- custom_1 → {{Use Case}}
+```
+
+## Cold Call Script (1 Minute — 5 Steps)
+
+```
+1. Pattern Interrupt Opening:
+   "Hey {{firstName}}, this is [Name] from [Company]—
+   I know I'm catching you out of the blue."
+
+2. Permission-Based Transition:
+   "Mind if I take 30 seconds to tell you why I called?
+   Then you can decide if it's worth continuing."
+
+3. Problem Statement:
+   "I work with [ICP] who are struggling with [problem]."
+
+4. Social Proof:
+   "We just helped [similar company] achieve [result]."
+
+5. CTA:
+   "Is that something you're dealing with right now?"
+```
+
+## No-Show Phone Script
+
+```
+"Hey {{firstName}}, it's [Name] from [Company].
+
+We had a call scheduled for [time]—
+wanted to make sure everything's okay.
+
+No worries if something came up.
+Would [alternative time] work better?"
+```
+
+## Tone by Channel
+
+**Agency Services:** Consultative, Strategic, Calm
+**Accelerator:** Slang professional, Friendly, Curious
+**Outbound Cold:** Pattern interrupt, Short, Clear
+
+## Definition of Success
+- Reply
+- Conversation started
+- Meeting booked
+
+**NOT:** Long messages, Clever wording, Over-explaining, Sounding impressive

--- a/skills/alex-vacca/cold-email-strategist/references/subject-lines.md
+++ b/skills/alex-vacca/cold-email-strategist/references/subject-lines.md
@@ -1,0 +1,90 @@
+# Subject Line Writing
+
+You write high-performing subject lines for B2B cold emails. Subject lines should feel like an internal email from a colleague, not marketing.
+
+## Process
+
+1. **Understand the email** -- What framework and value prop is the email using?
+2. **Draft 3-5 options** -- Mix personalized, curiosity, and direct approaches
+3. **Recommend A/B test** -- Pick 2 contrasting styles to test against each other
+
+## Reference
+
+Read `writing-frameworks.md` for CTA rules and writing principles that apply to subject lines.
+Read `personalization-prompts.md` for the AI subject line prompt (2-word formula) and personalization hooks.
+
+## Rules
+
+- **2-4 words ideal** -- Shorter subject lines outperform in cold email
+- **All lowercase** -- Feels casual and personal, not promotional
+- **No spam trigger words** -- Avoid "free", "guarantee", "limited time", "act now"
+- **No punctuation overkill** -- No exclamation marks, no ALL CAPS
+- **Relevant to the email body** -- Deceptive subject lines destroy trust and trigger spam
+- **Same thread for follow-ups** -- Email 2 uses RE: (same subject), Email 3 gets a new subject
+
+## Subject Line Formulas
+
+### 1. Personalized (highest open rate)
+```
+{{trigger_topic}}
+{{metric}} at {{company}}
+{{years}} years
+```
+
+### 2. Curiosity Gap
+```
+quick question
+one thing about {{topic}}
+{{company}} -> {{outcome}}
+```
+
+### 3. Direct Value
+```
+3 hours back
+{{number}} potential leads
+Q1 revenue efficiency
+```
+
+### 4. Two-Word Formula (AI-generated)
+```
+Rules: Exactly 2 words, all lowercase, relevant to their business, no sales/buzz words.
+Example: "marketing data", "hiring speed", "pipeline math"
+```
+
+## A/B Testing Guidelines
+
+- Test 2 subject lines at a time (not more)
+- Minimum 100 sends per variant before judging
+- Measure open rate AND reply rate (high opens with low replies = clickbait)
+- Test contrasting styles: personalized vs. curiosity, short vs. slightly longer
+
+## Examples
+
+**Example 1: For a hiring platform email**
+```
+Option A: "12 open roles" (personalized + specific)
+Option B: "hiring speed" (two-word formula)
+Option C: "quick question" (curiosity)
+Recommendation: A/B test Option A vs Option C
+```
+
+**Example 2: For a cybersecurity email**
+```
+Option A: "{{company}} security" (personalized)
+Option B: "quick math" (curiosity + direct)
+Option C: "vulnerability scan" (two-word formula)
+Recommendation: A/B test Option A vs Option B
+```
+
+**Example 3: For a re-engagement email**
+```
+Option A: "since we last talked" (acknowledges history)
+Option B: "different angle" (curiosity)
+Option C: "quick question" (universal opener)
+Recommendation: A/B test Option A vs Option B
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-strategist/references/writing-frameworks.md
+++ b/skills/alex-vacca/cold-email-strategist/references/writing-frameworks.md
@@ -1,0 +1,104 @@
+# Email Writing Frameworks
+
+## Core Frameworks
+
+### Do the Maths Framework
+- Trigger + pitch + calculation + CTA
+- Example: "Saw [trigger]. Companies like yours typically [problem costing X]. We helped [similar company] reduce this by [%]. Worth a quick call?"
+
+### Short-Trigger Based Outreach
+- 3-4 sentences maximum
+- Lead with observation, not pitch
+- One clear CTA
+
+### Challenge of Similar Companies
+- Reference industry-specific pain
+- Position as pattern you've seen
+- "Companies doing [X revenue] in [industry] often struggle with [problem]"
+
+### Neutral Insight Framework
+- Share third-party resource (not your content)
+- Build trust before pitching
+- "Came across this [resource] that addresses [their problem]"
+
+### Leader Responsibilities
+- Role-specific questions that prompt reflection
+- "As [title], how are you currently handling [challenge]?"
+
+### Ask Before Pitch (Will Allred)
+```
+Open-ended question → Trigger/observation → How product solves → PS relevance
+```
+
+### Not Too Different Persona
+```
+"I work with [similar ICP], they struggle with [problem]..."
+```
+
+### Upfront Value (Jordan Crawford)
+```
+"Here's [value offering], hope it was helpful..."
+```
+
+### Leverage Content in Outbound (Ethan Parker)
+```
+"We've compiled [content] on [how it helps]. Can I send it over? PS - Relevant because [trigger]"
+```
+
+### "Why Are You Paying?" (Leif Bisping)
+```
+Set stage with life situation → Obvious choice → Compare to prospect's current solution
+```
+
+## Josh Braun Writing Principles
+
+1. **Write with an eraser** — Remove every unnecessary word
+2. **Be cheeky** — Personality matters, make them smile
+3. **Be specific** — Credibility comes through precision
+4. **Don't say "we reduce costs"** — Say "e-commerce companies doing $5k/month overpaying 10-15%"
+5. **Use loss aversion** — Frame around what they're losing, not gaining
+
+## 8 Allowed Messaging Frameworks
+
+1. Before/After
+2. Pattern Interrupt
+3. Ask Before Pitch
+4. Upfront Value
+5. Do the Math
+6. Challenge of Similar Companies
+7. Neutral Insight
+8. Typical Problems by Role
+
+## Email Structure Checklist
+
+```
+Opening (trigger) + Assumption + Social proof with numbers + Open-ended question
+```
+
+- **BTL emails:** 3-4 sentences
+- **ATL emails:** 2-3 sentences
+
+## Outbound Writing Rules
+
+```
+Emails: 60-90 words maximum
+No bullets in cold emails
+One CTA only
+
+CTA Rules:
+- Clear and direct
+- Respectful of their time
+- Scheduling-oriented when possible
+```
+
+## Key Template Principles
+
+1. **Lead with pain not features**
+2. **Keep qualification simple** (deeper on calls)
+3. **Personalize to person not just company**
+4. **Use specific social proof numbers** ("47% increase" not "significant improvement")
+5. **Soft CTAs work better** ("worth a look?" vs "book a call")
+6. **Multi-channel coordination** (email + LinkedIn + ads)
+7. **Humor reduces tension**
+8. **Timing matters** (new role signals peak at days 14-45)
+9. **Value-first before asking**

--- a/skills/alex-vacca/cold-email-templates-34/SKILL.md
+++ b/skills/alex-vacca/cold-email-templates-34/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: cold-email-templates-34
+title: Cold email templates
+description: |
+  Use this skill when building email campaigns, looking for proven cold email templates, or expanding
+  an outreach playbook. A library of 34 templates — 23 first touch, 4 follow-up, 4 re-engagement —
+  with reply-rate data, top performers, and key template principles.
+category: Outreach
+---
+
+# Cold Email Templates Library (34 Templates)
+
+Quick reference for cold email templates. For full templates, see reference files below.
+
+## Template Categories
+
+| Category | Count | Details |
+|----------|-------|---------|
+| First Touch | 23 | [references/first-touch.md](references/first-touch.md) |
+| Follow-Up | 4 | [references/follow-up.md](references/follow-up.md) |
+| Re-Engagement | 4 | [references/re-engagement.md](references/re-engagement.md) |
+
+## Key Template Principles
+
+1. **Lead with pain not features**
+2. **Keep qualification simple** (deeper on calls)
+3. **Personalize to person not just company**
+4. **Use specific social proof numbers** ("47% increase" not "significant improvement")
+5. **Soft CTAs work better** ("worth a look?" vs "book a call")
+6. **Multi-channel coordination** (email + LinkedIn + ads)
+7. **Humor reduces tension**
+8. **Timing matters** (new role signals peak at days 14-45)
+9. **Value-first before asking**
+
+## Top Performing Templates
+
+| Template | Use Case | Reply Rate |
+|----------|----------|------------|
+| #4 NCAA Games Hook | Sports timing | >10% |
+| #20 New Exec | First 90 days | 8-12% |
+| #22 Do the Math | ROI-focused | 8-10% |
+| #27 Nooks SDR | Follow-up | 6-8% |
+| #31 No-Oriented | Re-engagement | 10-15% |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Plug templates into sequence structure |
+| `personalization-hooks` | Add hooks to any template |
+| `email-writing-frameworks` | Understand framework behind each template |
+| `buying-signals-6` | Match template to signal |
+
+## Example prompts
+
+```
+Give me 3 templates for following up with website visitors.
+```
+
+```
+Which template works best for prospects who just got funding?
+```
+
+```
+Adapt template #20 (New Exec) for a CMO at a fintech company.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/cold-email-templates-34/references/first-touch.md
+++ b/skills/alex-vacca/cold-email-templates-34/references/first-touch.md
@@ -1,0 +1,284 @@
+# First Touch Templates (23)
+
+## #1 Observation Question Framework
+```
+Subject: {{trigger_topic}}
+
+Observation question about their situation?
+
+Solution statement with social proof.
+
+Soft CTA question.
+```
+
+## #2 Analogy Email
+Uses metaphor to simplify complex value prop. Makes abstract benefits concrete.
+
+Example: "Hiring an SDR is like buying a treadmill..." (for outsourced sales)
+
+## #3 Hiring "End Users" Template
+Target companies hiring roles that align with your product.
+
+```
+Noticed you're hiring {{role}}.
+
+Most companies at your stage struggle with {{problem}} during onboarding.
+
+We helped {{similar_company}} cut ramp time by {{%}}.
+
+Worth a quick look?
+```
+
+## #4 NCAA Games Hook (>10% reply rate)
+```
+Subject: march madness
+
+{{firstName}}, quick question—
+
+Do you have your bracket filled out yet?
+
+Also curious: how are you currently handling {{problem}}?
+
+[Name]
+```
+
+## #5 Work Anniversary Trigger
+```
+Subject: {{years}} years
+
+Congrats on {{years}} years at {{company}}.
+
+Quick q: Has {{pain_point}} gotten easier or harder since you started?
+```
+
+## #6 Visual Email Template
+- Include screenshot/gif showing their problem
+- Personalized Loom showing their website/tool
+- Works because: Pattern interrupt + proof you researched
+
+## #7 Podcast Guest Template
+```
+Subject: {{podcast_name}}
+
+Listened to your episode on {{topic}}.
+
+Your point about {{insight}} stuck with me.
+
+We've been helping companies apply that thinking to {{related_area}}.
+
+Worth a chat?
+```
+
+## #8 Competitor Switch Template
+```
+Subject: {{competitor}}
+
+Noticed you're using {{competitor}}.
+
+Most teams I talk to hit a wall with {{common_limitation}}.
+
+We helped {{company}} solve that by {{solution}}.
+
+Worth exploring?
+```
+
+## #9 Content Engagement Template
+```
+Subject: your post
+
+Saw your post about {{topic}}.
+
+Especially the part about {{specific_point}}.
+
+We're working on something similar with {{similar_company}}.
+
+Curious if you're open to comparing notes?
+```
+
+## #10 Mutual Connection Template
+```
+Subject: {{mutual_name}}
+
+{{mutual_name}} suggested I reach out.
+
+They mentioned you're focused on {{priority}}.
+
+We just helped them with {{result}}.
+
+Worth a quick intro?
+```
+
+## #11 Industry Event Template
+```
+Subject: {{event_name}}
+
+Saw you attended {{event}}.
+
+The session on {{topic}} was interesting.
+
+We've been helping companies implement {{related_solution}}.
+
+Did any of that resonate for {{company}}?
+```
+
+## #12 Tech Stack Trigger
+```
+Subject: {{technology}}
+
+Noticed you're using {{tech}}.
+
+Most teams pair that with {{complementary_solution}} to solve {{problem}}.
+
+We just helped {{company}} do exactly that.
+
+Worth exploring?
+```
+
+## #13 Snowflake Style
+```
+Subject: {{metric}} at {{company}}
+
+Noticed {{company}} is {{trigger}}.
+
+Companies doing this typically see {{problem}}.
+
+We helped {{customer}} achieve {{result}} in {{timeframe}}.
+
+Open to seeing how?
+```
+
+## #14 Problem Agitation Template
+```
+Subject: {{pain_point}}
+
+{{firstName}}, quick question:
+
+How much time does your team spend on {{manual_task}}?
+
+Most {{role}}s I talk to say it's their biggest time drain.
+
+We helped {{company}} cut that by {{%}}.
+
+Worth a look?
+```
+
+## #15 Social Proof Stack
+```
+Subject: {{similar_company_1}}, {{similar_company_2}}
+
+{{firstName}},
+
+We helped:
+- {{company_1}} achieve {{result_1}}
+- {{company_2}} achieve {{result_2}}
+
+Both were dealing with {{common_problem}}.
+
+Is that on your radar at {{company}}?
+```
+
+## #16 Trigger + Timing Template
+```
+Subject: timing
+
+{{firstName}}, saw {{trigger}}.
+
+Usually means {{implication}}.
+
+We help companies at this stage with {{solution}}.
+
+Worth a quick chat while it's fresh?
+```
+
+## #17 Account-Based Framework
+```
+I noticed {{company}} is {{trigger}}.
+
+Been chatting with a few folks on the {{department}} team about {{topic}}.
+
+{{Name}} mentioned you'd be the right person to talk to about {{specific_initiative}}.
+
+Worth connecting?
+```
+
+## #18 Breakup Preview Template
+```
+Subject: last try
+
+{{firstName}},
+
+I've reached out a few times about {{topic}}.
+
+No response = no interest, and that's fine.
+
+But before I close the loop—is {{problem}} something you're dealing with?
+
+If not, I'll stop bugging you.
+```
+
+## #19 Customer Reconnect
+```
+Subject: {{company}} → {{new_company}}
+
+{{firstName}}, saw you moved from {{old_company}} to {{new_company}}.
+
+At {{old_company}} you used us for {{use_case}}.
+
+Does {{new_company}} have something similar in place?
+```
+
+## #20 New Exec Template (First 90 Days)
+```
+Subject: first 90
+
+{{firstName}}, congrats on the {{title}} role.
+
+Most new {{title}}s I talk to are focused on {{common_priority}}.
+
+Happy to share what {{similar_company}} did in their first quarter.
+
+Interested?
+```
+
+## #21 Case Study Offer
+```
+Subject: {{similar_company}} case study
+
+{{firstName}},
+
+We just published a case study on how {{similar_company}} achieved {{result}}.
+
+They were dealing with {{problem}} you might recognize.
+
+Want me to send it over?
+```
+
+## #22 Do the Math Template
+```
+Subject: {{number}} potential leads
+
+{{firstName}}, quick math:
+
+{{company}} has {{X}} people who {{trigger}}.
+
+If even {{%}} convert, that's {{Y}} opportunities.
+
+We helped {{customer}} capture {{result}} from similar math.
+
+Want to see the breakdown?
+```
+
+## #23 Pain + Authority Template
+```
+Subject: {{pain_point}}
+
+{{firstName}},
+
+{{Authority_source}} recently said {{relevant_quote}}.
+
+Most {{title}}s I talk to are feeling that pressure.
+
+We've been helping companies like {{similar_company}} with {{solution}}.
+
+Relevant?
+```

--- a/skills/alex-vacca/cold-email-templates-34/references/follow-up.md
+++ b/skills/alex-vacca/cold-email-templates-34/references/follow-up.md
@@ -1,0 +1,87 @@
+# Follow-Up Templates (4)
+
+## #27 Nooks SDR Breakdown (7 Steps)
+1. Reference previous email
+2. Acknowledge no response (no guilt)
+3. Add new information/angle
+4. Keep it shorter than email 1
+5. Different CTA style
+6. Same thread (no new subject)
+7. Send 3-5 days after email 1
+
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+Wanted to follow up on my note about {{topic}}.
+
+Just saw {{new_information}} which made me think of {{company}}.
+
+Still relevant?
+```
+
+## #28 Robot Follow Up (Humor-Based)
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+This is an automated follow-up because you didn't respond to my last email.
+
+Just kidding. I'm a real person.
+
+But seriously—did {{topic}} resonate at all?
+
+[Name]
+```
+
+## #29 3rd Party Content
+Educational follow-up with podcast/content recommendations. Non-promotional touchpoint.
+
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+Quick resource—this podcast episode on {{topic}} is worth 20 min.
+
+[Link]
+
+Thought of you given {{relevant_context}}.
+
+No pitch, just genuinely useful.
+```
+
+## #30 LinkedIn + Video
+Personalized video showing profile research. Multi-channel coordination.
+
+```
+Subject: RE: (same thread)
+
+{{firstName}},
+
+Recorded a quick 60-second video for you.
+
+[Loom link]
+
+Shows what I noticed about {{company}} and why I think {{solution}} could help.
+
+Worth a watch?
+```
+
+---
+
+## Follow-Up Best Practices
+
+| Timing | Email # | Subject | Key Change |
+|--------|---------|---------|------------|
+| Day 3-5 | Email 2 | Same thread | New angle, shorter |
+| Day 7-10 | Email 3 | Same thread | Different CTA |
+| Day 14+ | Email 4 | New subject | Fresh approach |
+
+**Rules:**
+- Each follow-up shorter than previous
+- Add new information, don't just "bump"
+- Different CTA style each time
+- No guilt or pressure

--- a/skills/alex-vacca/cold-email-templates-34/references/re-engagement.md
+++ b/skills/alex-vacca/cold-email-templates-34/references/re-engagement.md
@@ -1,0 +1,76 @@
+# Re-Engagement Templates (4)
+
+## #31 No-Oriented Question (Rebooking Demos)
+```
+Subject: quick question
+
+{{firstName}},
+
+Would it be crazy to reconnect?
+
+I know we talked {{timeframe}} ago about {{topic}}.
+
+{{New_information}} has changed since then.
+
+Still relevant?
+```
+
+**Why it works:** "Would it be crazy" invites "no" response, which is easier psychologically than committing to "yes"
+
+## #32 Reactivating Closed Lost
+```
+Subject: since we last talked
+
+{{firstName}},
+
+When we talked in {{month}}, you mentioned {{objection}}.
+
+Since then, we've {{improvement}}.
+
+Worth another look?
+```
+
+**Best timing:** 3-6 months after closed lost
+
+## #33 Ghosted Prospect Recovery
+```
+Subject: checking in
+
+{{firstName}},
+
+We were chatting about {{topic}} back in {{month}}.
+
+Things went quiet on your end (totally get it—priorities shift).
+
+Is this still on your radar, or should I close the loop?
+```
+
+**Why it works:** Offers easy exit, reduces pressure
+
+## #34 Renewal/Upsell Trigger
+```
+Subject: {{upcoming_date}}
+
+{{firstName}},
+
+Noticed your {{contract/subscription}} is coming up in {{timeframe}}.
+
+Before you renew, worth discussing {{improvement/expansion}}?
+
+Most companies at your stage are adding {{feature/service}}.
+
+Quick call this week?
+```
+
+---
+
+## Re-Engagement Timing Guide
+
+| Scenario | Wait Time | Best Approach |
+|----------|-----------|---------------|
+| Ghosted mid-conversation | 2-3 weeks | #33 Ghosted Recovery |
+| Closed lost | 3-6 months | #32 Reactivating |
+| Old demo, no close | 2-4 months | #31 No-Oriented |
+| Renewal coming | 30-60 days before | #34 Renewal Trigger |
+
+**Key Principle:** Always add new information or a reason to reconnect—never just "checking in" without value.

--- a/skills/alex-vacca/email-1-variations-7/SKILL.md
+++ b/skills/alex-vacca/email-1-variations-7/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: email-1-variations-7
+title: Email 1 variations
+description: |
+  Use this skill when crafting the first email in a sequence, testing different opening structures, or
+  building complete email cadences. Seven Email 1 variations from the Frontal core framework —
+  observation, question, poke-the-bear, trigger, stat, and role-pain openers — plus Email 2 and Email
+  3 templates.
+category: Outreach
+---
+
+# 7 Email 1 Variations (Frontal Core Framework)
+
+## Variation 1: Observation → Solution → Proof → CTA
+
+```
+[Observation question about their situation?]
+
+[Solution statement.] [Social proof with specific number.]
+
+[Soft CTA question?]
+```
+
+---
+
+## Variation 2: Question → Problem → Solution + Proof → CTA + PS
+
+```
+[Observation question?]
+
+[Problem statement they likely face.]
+
+[Solution + social proof combined.]
+
+[CTA]
+
+PS - [Additional social proof]
+```
+
+---
+
+## Variation 3: First Line → Poke Bear → Value Prop → CTA
+
+```
+[Relevant personalized first line]
+
+[Poke the bear question about their pain?]
+
+We help companies like {{similar_company}} achieve {{result}} without {{obstacle}}.
+
+[CTA]
+```
+
+---
+
+## Variation 4: Trigger → Problem → Solution → Calculation → CTA
+
+```
+[Personalized trigger reference]
+
+[Problem statement]
+
+[Solution]
+
+[Specific calculation showing impact]
+
+[CTA]
+```
+
+---
+
+## Variation 5: Stat → Question → Value CTA
+
+```
+[Industry statistic]
+
+[Question linking stat to their specific problem?]
+
+[Value-based CTA offering resource/insight]
+```
+
+---
+
+## Variation 6: Trigger → Achievement → CTA
+
+```
+[Relevant trigger observation]
+
+[Social proof achievement we delivered for similar company]
+
+[Direct CTA]
+```
+
+---
+
+## Variation 7: Role Pain → Solution → Answer Objection → Soft CTA
+
+```
+What {{title}}s hate about their job: [common pain]
+
+[How we solve it]
+
+[Pre-answer their likely question]
+
+[Very soft CTA]
+```
+
+---
+
+## Email 2 Template (Send 3 Days Later)
+
+```
+Subject: RE: (same thread)
+
+[Lead magnet offer]
+
+[Social proof]
+
+[Value prop restated differently]
+
+[CTA]
+```
+
+---
+
+## Email 3 Template (Send 14 Days Later - New Subject)
+
+```
+Subject: [New subject line]
+
+[New Email 1 variation - different angle]
+
+[Very soft CTA asking for right person]
+"If this isn't you, who should I be talking to about {{topic}}?"
+```
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Slot variations into Email 1 position |
+| `email-writing-frameworks` | Each variation uses different framework |
+| `personalization-hooks` | Add hooks to first line of each variation |
+| `atl-btl-messaging` | Adjust variation for seniority |
+
+## Example prompts
+
+```
+Write Email 1 using Variation 4 (Trigger → Problem → Solution → Calculation) for a hiring signal.
+```
+
+```
+Give me 3 variations of Email 1 for targeting CFOs at mid-market companies.
+```
+
+```
+Which variation should I use when I have strong social proof numbers?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/email-metrics-benchmarks/SKILL.md
+++ b/skills/alex-vacca/email-metrics-benchmarks/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: email-metrics-benchmarks
+title: Email metrics and benchmarks
+description: |
+  Use this skill when analyzing cold email campaign performance, setting benchmarks, diagnosing low
+  open or reply rates, or optimizing outreach metrics. Covers 2X levers, reply rates by outreach type,
+  deliverability thresholds, sequence performance, and quick diagnostics.
+category: Outreach
+---
+
+# Email Metrics & Benchmarks
+
+## Email Metrics to Track
+
+### 2X Levers (Metrics you can realistically double)
+
+| Metric | Current Baseline | Good | Great |
+|--------|------------------|------|-------|
+| Cold email reply rate | 0.5-1.0% | 2-3% | 5%+ |
+| Email open rate | 20-40% | 50% | 60%+ |
+| Email click rate | 2-5% | 5-8% | 10%+ |
+
+---
+
+## Performance by Outreach Type
+
+| Outreach Type | Reply Rate |
+|---------------|------------|
+| Cold outreach (no signal) | 6-8% |
+| Signal-based outreach | 18-22% |
+| Multi-signal stacked | 35-40% |
+| Website visitor follow-up | 25-30% |
+| Champion job change | 20-25% |
+
+---
+
+## Email Structure Checklist
+
+```
+Opening (trigger) + Assumption + Social proof with numbers + Open-ended question
+```
+
+### By Seniority
+
+| Target | Max Sentences | Max Words |
+|--------|---------------|-----------|
+| BTL (Managers, ICs) | 3-4 sentences | 90 words |
+| ATL (VPs, C-Level) | 2-3 sentences | 60 words |
+
+---
+
+## Deliverability Benchmarks
+
+| Metric | Target | Warning | Critical |
+|--------|--------|---------|----------|
+| Bounce rate | <2% | 2-5% | >5% |
+| Spam rate | <0.1% | 0.1-0.3% | >0.3% |
+| Unsubscribe rate | <0.5% | 0.5-1% | >1% |
+
+---
+
+## Sequence Performance
+
+### Email 1
+- Highest open rate
+- Sets the tone
+- Most important to optimize
+
+### Email 2 (Day 3)
+- 40-60% of Email 1 opens
+- Different angle
+- Shorter than Email 1
+
+### Email 3 (Day 14)
+- New subject line
+- Fresh approach
+- Delegation ask effective
+
+### Email 4 (Break-up)
+- Often highest reply rate
+- Creates urgency
+- Clean exit
+
+---
+
+## Optimization Priorities
+
+### If Open Rate Low (<30%)
+1. Test subject lines
+2. Check sender reputation
+3. Verify deliverability
+4. Test send times
+
+### If Reply Rate Low (<2%)
+1. Improve relevance/personalization
+2. Shorten message
+3. Strengthen CTA
+4. Add social proof
+5. Test different frameworks
+
+### If Meeting Rate Low (<20% of replies)
+1. Qualify better in message
+2. Improve CTA clarity
+3. Reduce friction to book
+4. Follow up faster
+
+---
+
+## Quick Diagnostics
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Low opens | Subject line or deliverability | A/B test subjects, check spam score |
+| Opens but no replies | Message relevance | More personalization, shorter copy |
+| Replies but no meetings | Weak CTA or poor qualification | Clearer ask, better targeting |
+| High unsubscribe | Too aggressive or wrong ICP | Reduce frequency, refine targeting |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Understand sequence metrics |
+| `sdr-outbound-rules` | Rules that improve metrics |
+| `list-building-tips` | Fix deliverability issues |
+| `buying-signals-6` | Improve reply rates with signals |
+
+## Example prompts
+
+```
+My reply rate is 0.8% - diagnose and suggest fixes.
+```
+
+```
+What benchmarks should I target for a signal-based campaign?
+```
+
+```
+My Email 2 has lower opens than Email 1 - is that normal?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/email-writing-frameworks/SKILL.md
+++ b/skills/alex-vacca/email-writing-frameworks/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: email-writing-frameworks
+title: Email writing frameworks
+description: |
+  Use this skill when writing cold emails, structuring outreach messages, or choosing the right
+  framework for an ICP. Five proven frameworks — Do the Maths, Short-Trigger, Challenge of Similar
+  Companies, Neutral Insight, and Leader Responsibilities — with structures and when to use each.
+category: Outreach
+---
+
+# Email Writing Frameworks
+
+## 1. Do the Maths Framework
+
+Trigger + pitch + calculation + CTA
+
+**Structure:**
+```
+Saw [trigger]. Companies like yours typically [problem costing X].
+We helped [similar company] reduce this by [%].
+Worth a quick call?
+```
+
+**When to use:** When you can quantify the problem or ROI
+
+---
+
+## 2. Short-Trigger Based Outreach
+
+**Rules:**
+- 3-4 sentences maximum
+- Lead with observation, not pitch
+- One clear CTA
+
+**Structure:**
+```
+[Observation about their situation]
+[Brief connection to pain point]
+[Soft CTA]
+```
+
+**When to use:** Default framework for most cold outreach
+
+---
+
+## 3. Challenge of Similar Companies
+
+Reference industry-specific pain and position as pattern you've seen.
+
+**Structure:**
+```
+Companies doing [X revenue] in [industry] often struggle with [problem].
+
+We've helped [similar companies] solve this by [solution].
+
+Is this on your radar?
+```
+
+**When to use:** When targeting a specific vertical or company profile
+
+---
+
+## 4. Neutral Insight Framework
+
+Share third-party resource (not your content) to build trust before pitching.
+
+**Structure:**
+```
+Came across this [resource] that addresses [their problem].
+
+Thought it might be useful given [observation about their situation].
+
+[Optional soft pitch]
+```
+
+**When to use:** For warming up cold prospects, building trust first
+
+---
+
+## 5. Leader Responsibilities
+
+Role-specific questions that prompt reflection.
+
+**Structure:**
+```
+As [title], how are you currently handling [challenge]?
+
+Most [titles] I talk to are dealing with [common problem].
+
+Worth comparing notes?
+```
+
+**When to use:** When targeting specific roles with known pain points
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Apply frameworks to each email in sequence |
+| `josh-braun-copywriting` | Polish copy after choosing framework |
+| `cold-email-templates-34` | See templates using each framework |
+| `personalization-hooks` | Add hooks to framework structure |
+
+## Example prompts
+
+```
+Write an email using the "Do the Maths" framework for HR software targeting 500+ employee companies.
+```
+
+```
+Which framework should I use for a prospect who just raised Series B?
+```
+
+```
+Create a "Challenge of Similar Companies" email for e-commerce brands doing $5-20M revenue.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/frontal-messaging-templates/SKILL.md
+++ b/skills/alex-vacca/frontal-messaging-templates/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: frontal-messaging-templates
+title: Frontal messaging templates
+description: |
+  Use this skill when creating outreach campaigns, A/B testing message structures, or choosing a
+  messaging approach. Six Frontal messaging templates — Ask Before Pitch, Not Too Different Persona,
+  Upfront Value, Leverage Content, Why Are You Paying, and Case Study Reference — with examples.
+category: Outreach
+---
+
+# Frontal Messaging Templates
+
+## 1. Ask Before Pitch (Will Allred)
+
+```
+Open-ended question → Trigger/observation → How product solves → PS relevance
+```
+
+**Example:**
+```
+How are you currently handling [challenge]?
+
+Noticed [trigger/observation about their company].
+
+We help companies like yours [solution].
+
+PS - Relevant because [specific trigger]
+```
+
+---
+
+## 2. Not Too Different Persona
+
+```
+"I work with [similar ICP], they struggle with [problem]..."
+```
+
+**Example:**
+```
+I work with B2B SaaS companies doing $2-5M ARR.
+
+They usually struggle with pipeline predictability.
+
+Is that something you're dealing with at {{company}}?
+```
+
+---
+
+## 3. Upfront Value (Jordan Crawford)
+
+```
+"Here's [value offering], hope it was helpful..."
+```
+
+**Example:**
+```
+Here's a quick breakdown of your top 3 competitors' outbound strategies.
+
+Hope it's useful.
+
+If you want, I can share how we'd approach it differently for {{company}}.
+```
+
+---
+
+## 4. Leverage Content in Outbound (Ethan Parker)
+
+```
+"We've compiled [content] on [how it helps]. Can I send it over?
+PS - Relevant because [trigger]"
+```
+
+**Example:**
+```
+We've compiled a playbook on signal-based outbound for B2B SaaS.
+
+Can I send it over?
+
+PS - Relevant because I saw you're hiring SDRs.
+```
+
+---
+
+## 5. "Why Are You Paying?" (Leif Bisping)
+
+```
+Set stage with life situation → Obvious choice → Compare to prospect's current solution
+```
+
+**Example:**
+```
+Imagine paying for a gym membership but only using the treadmill.
+
+That's what most companies do with their CRM - pay for 100 features, use 10.
+
+Why are you paying for {{competitor}} when you only need [core feature]?
+```
+
+---
+
+## 6. Case Study Reference
+
+```
+Our client [Lead Solution] used to prospect [ICP].
+
+They focused on:
+[Problem 1], [Problem 2], [Problem 3].
+
+Since you focus on {{summary}}, might work well if you combined [free resource].
+
+Could I share the outbound campaign they were using to book 35 meetings/month?
+```
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `cold-email-4-sequence` | Use templates as Email 1 variations |
+| `personalization-6-buckets` | Add personalization to templates |
+| `buying-signals-6` | Match template to signal type |
+| `ai-personalization-prompts` | Automate template personalization |
+
+## Example prompts
+
+```
+Write an "Ask Before Pitch" email for a SaaS company targeting RevOps managers.
+```
+
+```
+Create an "Upfront Value" email offering a competitor analysis for marketing agencies.
+```
+
+```
+Use the "Why Are You Paying" template for companies using Outreach.io.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/gtm-philosophy/SKILL.md
+++ b/skills/alex-vacca/gtm-philosophy/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: gtm-philosophy
+title: GTM philosophy
+description: |
+  Use this skill when defining outbound strategy, training sales teams, or establishing GTM
+  fundamentals. Core principles — scale what top performers do, signal-based outreach, lead with pain,
+  segment don't over-personalize — plus multi-channel coordination and key mindsets on
+  personalization, volume, timing, and messaging.
+category: Sales
+---
+
+# Core GTM Philosophy
+
+## Fundamental Principles
+
+1. **Scale what top performers do** - Study best reps, systematize their approach
+
+2. **Diagnose before prescribing** - BIPSY framework: Behaviors, Individual, Process, Skill, You
+
+3. **Signal-based outreach = 3-4x higher contract values**
+
+4. **You can't burn your TAM** - Re-engage with new angles
+
+5. **Lead with pain, not features** - HockeyStack approach: "Do you have problems tying brand awareness to revenue?"
+
+6. **Segment and convert, don't over-personalize** - Gorgias went from 200 sequences to 10 modular ones
+
+---
+
+## Multi-Channel Coordination
+
+**The Data:**
+- Email + ads + referrals = extra $2M ARR (case study)
+- ABM approach = 36% meeting rate vs 10% non-ABM
+- Warm before you touch principle
+
+**Coordination Strategy:**
+
+| Channel | Role | Timing |
+|---------|------|--------|
+| Ads | Warm up, build awareness | Before outreach |
+| Email | Primary outreach | Day 1 |
+| LinkedIn | Secondary touch | Day 2-3 |
+| Phone | High-intent follow-up | After engagement |
+| Referrals | Leverage network | Throughout |
+
+---
+
+## Key Mindsets
+
+### On Personalization
+- Personalize to the person, not just the company
+- Use specific numbers, not vague claims
+- Research should inform approach, not just first line
+
+### On Volume vs Quality
+- Quality signals beat high volume
+- 100 signal-based emails > 1000 cold emails
+- Stack signals for heat scoring (3+ signals = reach out same day)
+
+### On Timing
+- New role signals peak at days 14-45
+- Website visitors: act within 24-48 hours
+- Funding announcements: wait 2-4 weeks
+
+### On Messaging
+- Lead with pain, not features
+- Soft CTAs outperform hard asks
+- Humor reduces tension and increases response
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `buying-signals-6` | Implement signal-based philosophy |
+| `outreach-4-categories` | Categorize leads properly |
+| `sdr-outbound-rules` | Apply philosophy to daily execution |
+| `josh-braun-copywriting` | Write messages that lead with pain |
+
+## Example prompts
+
+```
+How should I structure multi-channel coordination for a $50K ACV deal?
+```
+
+```
+Explain the BIPSY framework for diagnosing my SDR team's issues.
+```
+
+```
+How do I balance volume vs quality for a mid-market SaaS product?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/gtm-plays-11/SKILL.md
+++ b/skills/alex-vacca/gtm-plays-11/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gtm-plays-11
+title: GTM signal plays
+description: |
+  Use this skill when building outbound campaigns, creating signal-based plays, or expanding a GTM
+  playbook. Eleven plays with execution details — new team members, skills-targeting, role-targeting,
+  leaving employees, bad reviews, website visitors, inbound followers, and more — with signals and
+  best timing.
+category: Signals
+---
+
+# 11 GTM Plays
+
+Quick reference for signal-based outbound plays. For templates, see [references/templates.md](references/templates.md).
+
+| Play | Signal | Best Timing |
+|------|--------|-------------|
+| 1. New Team Members | Company added team members | 2-4 weeks after hire |
+| 2. Skills-Targeting | LinkedIn skills match product | Ongoing |
+| 3. Role-Targeting | Uncommon job title exists | Ongoing |
+| 4. Industry Research | Create signal via surveys | Value-first |
+| 5. Resources for ICs | New SDRs starting roles | Evergreen |
+| 6. Leaving Employees | Team member departed | 1-2 weeks after |
+| 7. No Dedicated Role | Missing key title | Ongoing |
+| 8. Bad Reviews | Negative G2/Capterra review | Within days |
+| 9. AI-Generated Ideas | Personalized value via AI | Ongoing |
+| 10. ServiceBell Allbound | Website visitor activity | Real-time |
+| 11. Inbound Followers | New LinkedIn follower | 24-48 hours |
+
+## Play Details
+
+### 1. New Team Members
+Reference new hire by name. Shows attention to their growth.
+
+### 2. Skills-Targeting
+Target LinkedIn skills (not just titles). Clay extracts skills from profiles.
+- Salesforce skill → Salesforce add-ons
+- Python skill → Developer tools
+
+### 3. Role-Targeting
+Uncommon titles signal budget/priority.
+- "RevOps Manager" → RevOps is priority
+- "Growth Engineer" → Technical growth exists
+
+### 4. Industry-Level Research
+Survey ICP experts → opens value-first conversations.
+
+### 5. Resources for ICs (Evergreen)
+Automated campaign sending resources to new ICs. Long-term brand building.
+
+### 6. Leaving Employees
+Position around coverage gap after departure.
+
+### 7. No Dedicated Role
+No "Content Manager" + $5M+ revenue = content gap opportunity.
+
+### 8. Bad Reviews Targeting
+Scrape negative reviews, reference their pain, offer alternatives.
+
+### 9. AI-Generated Ideas
+Generate 2 relevant ideas + your offer as #3 (with humor).
+
+### 10. ServiceBell Allbound
+Visitor hits pricing → SDR calls in 2 min → email if no answer → LinkedIn next day.
+
+### 11. Inbound Followers
+Monitor daily, filter to ICP via Clay, outreach within 24-48h.
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `buying-signals-6` | Understand signal strength per play |
+| `clay-enrichment-9step` | Automate play execution in Clay |
+| `cold-email-templates-34` | Get templates for each play |
+| `bridgebound-in-market-20` | Deep-dive on in-market signals |
+
+## Example prompts
+
+```
+Create an outreach sequence for Play #1 (New Team Members) targeting Sales teams.
+```
+
+```
+How do I set up Play #8 (Bad Reviews) in Clay with G2 scraping?
+```
+
+```
+Which play should I prioritize for a $30K ACV product?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/gtm-plays-11/references/templates.md
+++ b/skills/alex-vacca/gtm-plays-11/references/templates.md
@@ -1,0 +1,90 @@
+# GTM Plays Templates
+
+## Play 1: New Team Members
+
+```
+Noticed {{company}} just added {{new_hire_name}} to the {{department}} team.
+
+Growing teams usually means [relevant challenge].
+
+We helped {{similar_company}} handle this by [solution].
+
+Worth a quick chat?
+```
+
+## Play 4: Industry-Level Research
+
+```
+Hey {{first_name}} — we're surveying {{role}} experts on {{topic}}.
+
+We have a page listing {{insight_type}} used at {{company_types}}.
+
+Want to contribute?
+[Link]
+
+You can add your links too (socials, projects, blog, website).
+We get ~XXk monthly visits so it's good exposure.
+```
+
+## Play 5: Resources for ICs
+
+```
+Hey {{first_name}}, congrats on the new role at {{company_name}}.
+
+We know how tough outreach can be, so we compiled our highest-converting cold email frameworks (used by 364 SDRs already!).
+
+Here they are: [Link]
+
+Good luck!
+```
+
+## Play 6: Leaving Employees
+
+```
+Saw {{former_employee}} recently left {{company}}.
+
+That usually creates a gap in {{function_area}}.
+
+We've been helping companies like {{similar_company}} cover that gap with [solution].
+
+Worth exploring?
+```
+
+## Play 8: Bad Reviews Targeting
+
+```
+Just saw your review of {{competitor}}...
+
+We researched and tested 3 alternatives (that don't suck).
+
+Shall I send the report to you?
+
+Cheers,
+[Name]
+```
+
+## Play 9: AI-Generated Ideas
+
+```
+Based on {{company_description}}, here are 3 ideas:
+
+[1] {{AI_generated_idea_1}}
+[2] {{AI_generated_idea_2}}
+[3] Hire a sales prospecting agency (like Frontal) to start generating leads on autopilot
+
+I'd probably give better ideas with more context.
+
+Want to chat?
+```
+
+## Play 11: Inbound Followers
+
+```
+Hey {{first_name}}, thanks for the follow.
+
+Noticed you're a {{title}} at {{company}}.
+
+Most {{title}}s I talk to are dealing with {{common_problem}}.
+
+Is that on your radar?
+```

--- a/skills/alex-vacca/inbound-triggers-30/SKILL.md
+++ b/skills/alex-vacca/inbound-triggers-30/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: inbound-triggers-30
+title: Inbound triggers
+description: |
+  Use this skill when building inbound follow-up sequences, categorizing marketing leads, or
+  prioritizing inbound response. Thirty inbound premises from Flip The Script — content and events,
+  product interest, social and intent, sponsored influencers — plus the inbound response framework and
+  priority order.
+category: Signals
+---
+
+# INBOUND Premises (30 Triggers)
+
+## Content & Events (9 Triggers)
+
+1. **Content Downloads** - Downloaded gated content
+2. **Webinar Registrants: Company Webinar** - Registered for your webinar
+3. **Webinar Attendees: Company Webinar** - Attended your webinar
+4. **Webinar Registrants: Sponsored Webinar** - Registered for sponsored webinar
+5. **Webinar Attendees: Sponsored Webinar** - Attended sponsored webinar
+6. **Event Registrants: Company Event** - Registered for your event
+7. **Event Attendees: Company Event** - Attended your event
+8. **Event Registrants: Sponsored Event** - Registered for sponsored event
+9. **Event Attendees: Sponsored Event** - Attended sponsored event
+
+---
+
+## Product Interest (6 Triggers)
+
+10. **Freemium Account Registrants** - Signed up for free tier
+11. **Free-Trial Registrants** - Started a free trial
+12. **Blog Subscribers** - Subscribed to blog
+13. **Newsletter Subscribers** - Subscribed to newsletter
+14. **Members of Company Community** - Joined your community
+15. **Members of Sponsored Community** - Joined sponsored community
+
+---
+
+## Social & Intent (8 Triggers)
+
+16. **Followers of Company Social Page** - Followed your social pages
+17. **Engaged with Company Social Page** - Liked/commented on your posts
+18. **"Buyer Intent" Prospects (G2 or TrustRadius)** - Showing intent on review sites
+19. **"Dark Funnel" Prospects (6Sense or Bombora)** - Intent data signals
+20. **Viewed Company Website** - Website visitor identified
+21. **Opened Marketing Emails (Aggressively)** - High email open rate
+22. **Clicked-Thru Marketing Emails (Aggressively)** - High email CTR
+
+---
+
+## Sponsored Influencers (8 Triggers)
+
+23. **Postbound Leads Sent from Sponsored Influencer** - Influencer referrals
+24. **Engaged with Sponsored Influencer's Personal Page** - Engaged with influencer
+25. **Followers of Sponsored Influencer's Personal Page** - Following influencer
+26. **Mutual Connections with Sponsored Influencer** - Shared network
+27. **Engaged with Sponsored Influencer's Company Page** - Company engagement
+28. **Followers of Sponsored Influencer's Company Page** - Company followers
+29. **To Postbound "Groundswell" for Info** - For ALL postbound actions
+30. **To DM Based on "Groundswell" Postbound** - For ALL postbound actions
+
+---
+
+## Inbound Response Framework
+
+**Messaging approach:** Trigger-Based Relevance ONLY
+
+```
+First Line: Trigger-Based Relevance ONLY
+Second Line: CTA to Book Time (Optional: Core-Static Relevance)
+```
+
+**Priority order:** Hand-raisers (demo requests) > High-intent (pricing page) > Content engagement > Social signals
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `outreach-4-categories` | Understand Inbound category |
+| `personalization-playbooks` | Get Inbound messaging playbook |
+| `cold-email-templates-34` | Find inbound follow-up templates |
+| `email-metrics-benchmarks` | Benchmark inbound performance |
+
+## Example prompts
+
+```
+Create a follow-up sequence for webinar attendees who didn't book a demo.
+```
+
+```
+Which inbound triggers should I prioritize for a high-velocity sales motion?
+```
+
+```
+Write an email for trigger #10 (Freemium Account Registrants) for a SaaS product.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/josh-braun-copywriting/SKILL.md
+++ b/skills/alex-vacca/josh-braun-copywriting/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: josh-braun-copywriting
+title: Josh Braun copywriting
+description: |
+  Use this skill when refining email copy, improving message quality, or reviewing outreach for common
+  mistakes. Josh Braun's five cold email principles — write with an eraser, be cheeky, be specific,
+  use loss aversion — plus personalization do's and don'ts.
+category: Outreach
+---
+
+# Josh Braun Writing Principles
+
+## The 5 Principles
+
+1. **Write with an eraser** - Remove every unnecessary word
+2. **Be cheeky** - Personality matters, make them smile
+3. **Be specific** - Credibility comes through precision
+4. **Don't say "we reduce costs"** - Say "e-commerce companies doing $5k/month overpaying 10-15%"
+5. **Use loss aversion** - Frame around what they're losing, not gaining
+
+---
+
+## Personalization Best Practices
+
+### DO:
+- Custom prompts based on research
+- Facts prospects consistently care about
+- Time business was founded (owners proud of longevity)
+- Recent company news/changes
+- Tech stack signals
+
+### DON'T:
+- Generic AI compliments ("Love your work!")
+- Content that sounds same as what they already have
+- Over-personalization that feels creepy
+- Complimenting LinkedIn posts without substance
+
+---
+
+## Key Takeaways
+
+- **Specificity = Credibility**: "47% increase" beats "significant improvement"
+- **Loss > Gain**: People act more to avoid loss than to gain
+- **Every word must earn its place**: If it doesn't add value, delete it
+- **Personality differentiates**: Be human, not corporate
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `email-writing-frameworks` | Apply principles to any framework |
+| `personalization-hooks` | Create hooks that don't feel generic |
+| `sdr-outbound-rules` | Quality checklist alignment |
+| `cold-email-templates-34` | Review templates against principles |
+
+## Example prompts
+
+```
+Review this email using Josh Braun's 5 principles and suggest improvements.
+```
+
+```
+Rewrite this email to be more specific and use loss aversion.
+```
+
+```
+Make this email "cheeky" without being unprofessional.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/lead-sources-guide/SKILL.md
+++ b/skills/alex-vacca/lead-sources-guide/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: lead-sources-guide
+title: Lead sources guide
+description: |
+  Use this skill when choosing lead sources, building prospecting workflows, or setting up data
+  enrichment. Lead sources by use case — Apollo, LinkedIn Sales Navigator, Clay, Ocean.io, Openmart,
+  local directories — with delivery-ready Clay templates and a source selection matrix.
+category: Prospecting
+---
+
+# Lead Sources & Clay Templates
+
+## Lead Sources by Use Case
+
+### Apollo.io
+- **Best for:** Broad targeting
+- **Use with:** LeadMagic scraper for enrichment
+- **Pros:** Good volume
+- **Cons:** Needs verification
+
+### LinkedIn Sales Navigator
+- **Best for:** Precise role/seniority targeting
+- **Use with:** Prospeo or Vayne scrapers
+- **Pros:** Higher quality
+- **Cons:** Lower volume
+
+### Clay Find People/Accounts
+- **Best for:** Quick lookups
+- **Use case:** Native database for enrichment workflows
+
+### Ocean.io
+- **Best for:** Lookalike accounts
+- **Use case:** Expanding TAM based on tech stack/ICP
+
+### Openmart
+- **Best for:** Local lead generation
+- **Use case:** SMB-focused targeting
+
+### Local Directories
+- **Best for:** Niche verticals
+- **Tool:** Instant Data Scraper
+- **Use case:** Specific industries
+
+---
+
+## Clay Templates (Delivery-Ready)
+
+### General High-Volume
+```
+Leadmagic → Apollo → Bouncebean → Import Template
+```
+
+### Segmented by Title/Industry
+```
+Leadmagic → Apollo Import → Persona Segment
+```
+
+### Email Enrichment
+```
+Leadmagic → Clay → Enrich Prospect Emails
+```
+
+### Standard Sales Nav Workflow
+```
+Prospeo → Sales Nav → Leads Import Template
+```
+
+### Alternative Sales Nav Flow
+```
+Vayne → Sales Nav → Import Template
+```
+
+---
+
+## List Building Pro Tips
+
+1. **Mix sources** - Don't rely on just one
+2. **Scraping = step 1** - Still need Clay enrichment
+3. **Templates are modular** - Adjust for campaign goals
+4. **Don't reinvent the wheel** - Start with template, tweak
+
+---
+
+## Source Selection Matrix
+
+| Need | Best Source | Backup |
+|------|-------------|--------|
+| Volume | Apollo | Clay Find |
+| Quality | Sales Navigator | Ocean.io |
+| Lookalikes | Ocean.io | Clay |
+| Local/SMB | Openmart | Directories |
+| Niche | Directories | Apollo filters |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `clay-enrichment-9step` | Enrich leads after sourcing |
+| `list-building-tips` | Apply quality principles |
+| `clay-buying-signals-5` | Add signals to sourced leads |
+| `buying-signals-6` | Prioritize by signal strength |
+
+## Example prompts
+
+```
+Which source should I use for targeting VP Engineering at Series B startups?
+```
+
+```
+Set up a Clay template for Apollo → enrichment → email verification.
+```
+
+```
+How do I find lookalike companies to my best customers?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/linkedin-campaign-complete/SKILL.md
+++ b/skills/alex-vacca/linkedin-campaign-complete/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: linkedin-campaign-complete
+title: LinkedIn campaign playbook
+description: "Use this skill when building LinkedIn outreach sequences, writing LinkedIn messages or connection requests, planning multi-touch campaigns, choosing high-converting LinkedIn targets (post engagers, event attendees, profile viewers), or scheduling outreach to look human."
+category: Outreach
+---
+
+# LinkedIn Campaign Complete Guide
+
+For message templates, see [references/templates.md](references/templates.md).
+
+## High-Converting LinkedIn Targets
+
+### Tier 1 (Highest Priority)
+- LinkedIn Webinar/Event attendees
+- Post engagers (filter to ICP via Clay)
+- Company page followers
+- Profile viewers
+
+### Tier 2 (Good Priority)
+- Recently created group members
+- Newsletter subscribers
+- Content commenters
+
+**Critical Filter:** "Posted within last 30 days" = Active user
+
+## LinkedIn Copywriting Rules
+
+1. Never over one paragraph long
+2. 3-4 sentences maximum
+3. Focus on creating conversation, not selling
+4. Use eye-catching auto-embedding resources (Loom, posts, webinars)
+
+## LinkedIn Campaign Sequence (Human-Like)
+
+```
+Step 1: View profile (Day 1)
+         ↓
+Step 2: Like a recent post (Day 1-2)
+         ↓
+Step 3: Send connection request (Day 2-3)
+         ↓
+[Wait for acceptance]
+         ↓
+Step 4: Send first message (4-24 hours after acceptance)
+         ↓
+Step 5: Follow-up if no response (Day 5-7)
+```
+
+## Scheduling Best Practices
+
+| Factor | Recommendation |
+|--------|----------------|
+| Timezone | Prospect's working hours (9 AM - 6 PM) |
+| Days | Weekdays only (Mon-Thu best) |
+| Breaks | At least one day off per week |
+| Timing | When they're likely online |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `linkedin-limits-warmup` | Stay within limits while executing |
+| `linkedin-success-factors` | Apply success factors to campaign |
+| `cold-email-4-sequence` | Coordinate LinkedIn + email |
+| `personalization-hooks` | Add hooks to LinkedIn messages |
+
+## Example prompts
+
+```
+Create a LinkedIn sequence for post engagers who match my ICP.
+```
+
+```
+Write connection request notes for VP Sales at SaaS companies.
+```
+
+```
+How do I coordinate LinkedIn messages with my email sequence?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/linkedin-campaign-complete/references/templates.md
+++ b/skills/alex-vacca/linkedin-campaign-complete/references/templates.md
@@ -1,0 +1,130 @@
+# LinkedIn Message Templates
+
+## Profile Viewer Follow-Up
+```
+Hey {{first_name}}, noticed you checked out my profile.
+
+What caught your attention?
+```
+**Reply rate:** 28-35% (vs 8-12% cold)
+
+---
+
+## Connection Acceptance Message
+```
+Thanks for connecting, {{first_name}}.
+
+Quick q — what's your biggest challenge with {{relevant_topic}} right now?
+```
+
+---
+
+## Post Engager Follow-Up
+```
+Hey {{first_name}}, saw you liked my post about {{topic}}.
+
+Is {{pain_point}} something you're dealing with at {{company}}?
+```
+
+---
+
+## Warm Intro Request
+```
+Hey {{first_name}}, noticed we both know {{mutual_connection}}.
+
+I've been working with {{similar_company}} on {{topic}}.
+
+Would you be open to a quick chat?
+```
+
+---
+
+## Event Attendee Follow-Up
+```
+Hey {{first_name}}, saw you attended {{event_name}}.
+
+What was your biggest takeaway?
+
+I've been thinking about {{related_topic}} — curious if that resonated.
+```
+
+---
+
+## Content Comment Follow-Up
+```
+Hey {{first_name}}, your comment on {{post_topic}} was interesting.
+
+Especially the point about {{specific_insight}}.
+
+Is that something you're actively working on at {{company}}?
+```
+
+---
+
+## Newsletter Subscriber Outreach
+```
+Hey {{first_name}}, noticed you subscribed to my newsletter.
+
+Curious what drew you in?
+
+Most subscribers I talk to are dealing with {{common_problem}}.
+```
+
+---
+
+## Group Member Outreach
+```
+Hey {{first_name}}, saw we're both in {{group_name}}.
+
+The discussion on {{topic}} was interesting.
+
+Is that something you're focused on at {{company}}?
+```
+
+---
+
+## Connection Request Notes
+
+### With Note (Higher acceptance, limited characters)
+```
+Hey {{first_name}} — saw your work on {{topic}}. Would love to connect.
+```
+
+### Without Note (Higher volume, slightly lower acceptance)
+- Use for Tier 2 targets
+- Compensate with strong first message
+
+---
+
+## Follow-Up Templates
+
+### After No Response (Day 5-7)
+```
+Hey {{first_name}}, following up on my note.
+
+No worries if {{topic}} isn't a priority right now.
+
+But if it is — happy to share what's working for {{similar_company}}.
+```
+
+### Second Follow-Up (Day 10-14)
+```
+{{first_name}}, last ping on this.
+
+Totally understand if timing's off.
+
+Let me know if worth reconnecting in a few months.
+```
+
+---
+
+## Template Selection Guide
+
+| Scenario | Template | Expected Reply Rate |
+|----------|----------|---------------------|
+| Profile viewer | Profile Viewer Follow-Up | 28-35% |
+| New connection | Acceptance Message | 15-20% |
+| Post engagement | Post Engager Follow-Up | 18-25% |
+| Mutual connection | Warm Intro Request | 20-28% |
+| Event attendee | Event Attendee Follow-Up | 15-22% |
+| Group member | Group Member Outreach | 12-18% |

--- a/skills/alex-vacca/linkedin-limits-warmup/SKILL.md
+++ b/skills/alex-vacca/linkedin-limits-warmup/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: linkedin-limits-warmup
+title: LinkedIn limits and warm-up
+description: "Use this skill when planning LinkedIn campaign volume, avoiding account restrictions or bans, warming up a new or dormant LinkedIn account, setting safe daily limits for connection requests, DMs, and InMails, or recovering an account from restriction."
+category: Outreach
+---
+
+# LinkedIn Limits & Warm-Up Protocol
+
+## LinkedIn Limits (2024-2026)
+
+### Monthly Limits
+- **400** connection requests/month (non-premium)
+- **800** Open InMails/month (premium members)
+- **~120** interactions/day total (stay well below)
+
+### Recommended Daily Limits
+- **15-20** Direct Messages/day
+- **30-40** Open InMails/day
+- **10-15** connection requests/day
+- **40** "other interactions"/day
+
+### What Counts as Interactions
+- DMs, connection requests, InMails
+- Profile views
+- Post likes/comments
+- Page likes
+- Endorsements
+- Joining events/groups
+
+---
+
+## LinkedIn Warm-Up Protocol
+
+### When Needed
+- Inactive accounts
+- New accounts
+- Accounts returning from restriction
+
+### Process
+
+**Days 1-10:**
+- 60 interactions/day maximum
+- Only manual activity (no automation)
+- Mix of views, likes, comments
+- Focus on genuine engagement
+
+**Days 11-20:**
+- Gradually increase to 80/day
+- Start light connection requests (5-10/day)
+- Continue manual engagement
+
+**Days 21+:**
+- Gradual increase to full limits
+- Introduce automation carefully
+- Monitor for warnings
+
+---
+
+## Red Flags to Avoid
+
+1. **Sudden activity spikes** - Gradual increase only
+2. **Same message to everyone** - Vary your copy
+3. **Connecting outside work hours** - Stay within 9 AM - 6 PM
+4. **Weekend activity** - Weekdays only
+5. **Automation too early** - Manual first 2-3 weeks
+
+---
+
+## Account Health Indicators
+
+| Indicator | Healthy | Warning | Danger |
+|-----------|---------|---------|--------|
+| Connection acceptance | >30% | 15-30% | <15% |
+| Message response | >10% | 5-10% | <5% |
+| Profile views | Stable | Declining | Blocked |
+| Pending connections | <500 | 500-700 | >700 |
+
+---
+
+## Recovery from Restriction
+
+1. Stop all automation immediately
+2. Manual activity only for 2 weeks
+3. Respond to existing conversations
+4. Post valuable content
+5. Engage with others' content
+6. Slowly reintroduce outreach
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `linkedin-campaign-complete` | Execute campaigns within limits |
+| `linkedin-success-factors` | Apply success rules while respecting limits |
+| `cold-email-4-sequence` | Coordinate LinkedIn + email to reduce LinkedIn load |
+
+## Example prompts
+
+```
+Create a 3-week warm-up schedule for my dormant LinkedIn account.
+```
+
+```
+How many connection requests can I safely send per day with 200 pending?
+```
+
+```
+My acceptance rate dropped to 20% - what should I change?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/linkedin-success-factors/SKILL.md
+++ b/skills/alex-vacca/linkedin-success-factors/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: linkedin-success-factors
+title: LinkedIn success factors
+description: "Use this skill when reviewing a LinkedIn campaign before launch, auditing LinkedIn outreach performance, checking targeting, message length, lead magnets, scheduling, and human-like behavior, or benchmarking connection acceptance and reply rates."
+category: Outreach
+---
+
+# LinkedIn Key Success Factors
+
+## The 7 Rules
+
+### 1. Do Not Breach Limits
+**Most important rule**
+
+- Stay under 400 connections/month
+- Stay under 120 interactions/day
+- Build in buffer for safety
+
+### 2. Target Active Users Only
+**Don't waste your 400 connection requests**
+
+- Use "Posted within 30 days" filter
+- Check for recent activity
+- Avoid dormant profiles
+
+### 3. Keep Messages Super Short
+**3-4 sentences maximum**
+
+- One paragraph only
+- No walls of text
+- Get to the point fast
+
+### 4. Incorporate Eye-Catching Lead Magnet
+**Stand out in the inbox**
+
+- Loom videos (high engagement)
+- LinkedIn posts (social proof)
+- Webinar links (value offer)
+- Newsletter signups (nurture path)
+
+### 5. Make Steps Appear Human
+**Avoid bot-like behavior**
+
+- Randomize timing between actions
+- Don't follow exact same sequence every time
+- Mix in genuine engagement
+- Take breaks
+
+### 6. Schedule Within Audience Timezone
+**Maximize inbox visibility**
+
+- 9 AM - 6 PM their time
+- Weekdays only
+- Tuesday-Thursday optimal
+- Avoid Monday mornings, Friday afternoons
+
+### 7. Message When They're Online
+**Inbox popup maximizes open rate**
+
+- Check "Active now" indicator
+- Time zones matter
+- Business hours priority
+
+---
+
+## Campaign Checklist
+
+Before launching any LinkedIn campaign:
+
+- [ ] Targets filtered to active users (30-day post activity)
+- [ ] Messages under 4 sentences
+- [ ] Connection request volume under 20/day
+- [ ] Sequence mimics human behavior
+- [ ] Scheduling matches target timezone
+- [ ] Lead magnet or value hook included
+- [ ] Follow-up sequence planned
+- [ ] Account warm-up completed (if needed)
+
+---
+
+## Performance Benchmarks
+
+| Metric | Good | Great | Excellent |
+|--------|------|-------|-----------|
+| Connection acceptance | 25% | 35% | 45%+ |
+| Message response | 10% | 15% | 20%+ |
+| Meeting booked | 2% | 5% | 8%+ |
+
+---
+
+## Common Mistakes
+
+1. **Sending pitch in connection request** - Save it for message
+2. **Generic first message** - Personalize to their profile
+3. **Too many follow-ups** - 2-3 max, then stop
+4. **Ignoring response timing** - Reply quickly
+5. **Not warming up account** - Critical for new/dormant accounts
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `linkedin-campaign-complete` | Full campaign execution |
+| `linkedin-limits-warmup` | Stay within limits |
+| `personalization-hooks` | Create hooks for messages |
+| `gtm-philosophy` | Multi-channel coordination |
+
+## Example prompts
+
+```
+Review my LinkedIn campaign against the 7 success factors.
+```
+
+```
+What lead magnet should I use for targeting RevOps managers?
+```
+
+```
+How do I make my LinkedIn sequence appear more human?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/SKILL.md
+++ b/skills/alex-vacca/list-architect/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: list-architect
+title: The list architect
+description: "Use this skill when building B2B lead lists — ICP definition and scoring, sourcing companies, qualifying accounts, finding contacts, persona mapping, deduplication, and data validation. Triggers on 'lead list', 'list building', 'Sales Navigator', 'boolean search', 'ICP', 'ideal customer profile', 'find leads', 'prospect list', 'email verification', 'list hygiene', 'build a list', 'find prospects', 'deduplicate', 'qualify accounts', 'ABM'."
+category: Prospecting
+contributors:
+  - ivan-falco
+---
+
+Reference files for this skill live in `references/` next to this file — load them with the relative paths given below.
+
+# List Building — Master Orchestrator
+
+You are an expert B2B list builder who has assembled prospect lists for campaigns sending 100K+ cold emails per month. You orchestrate 6 specialized sub-skills and route the user to the right one based on their question.
+
+## Sub-Skill Routing
+
+Analyze the user's request and invoke the appropriate sub-skill:
+
+| User Intent | Sub-Skill | Trigger Phrases | Load |
+|-------------|-----------|-----------------|------|
+| Define target audience, scoring criteria | **define-icp** | "ICP", "ideal customer profile", "who should I target", "scoring", "tier", "firmographic", "criteria" | Read `references/define-icp.md` |
+| Find target companies from data sources | **source-companies** | "find companies", "company list", "Apollo", "Google Maps", "HG Insights", "data sources", "where to find", "import companies" | Read `references/source-companies.md` |
+| Find contacts/people at companies | **find-contacts** | "find contacts", "find people", "boolean search", "Sales Navigator", "export leads", "Evaboot", "titles", "decision makers" | Read `references/find-contacts.md` |
+| Score and qualify individual accounts with ICP matrix, intent data layering, lookalikes | **qualify-accounts** | "qualify", "score accounts", "intent data", "lookalike", "prioritize accounts", "ICP scoring matrix" | Read `references/qualify-accounts.md` |
+| Verify emails/phones, manage bounce rates | **clean-validate** | "verify", "validate", "bounce rate", "email verification", "ZeroBounce", "list hygiene", "data decay", "deliverability" | Read `references/clean-validate.md` |
+| Remove duplicates, merge data sources | **deduplicate** | "deduplicate", "duplicates", "merge", "multiple sources", "clean up list", "data quality" | Read `references/deduplicate.md` |
+| ABM account selection, revenue reverse-engineering, how many accounts, account staging | **account-selection** | "account selection", "ABM accounts", "target account list", "how many accounts", "ABM tier", "account staging", "revenue target", "ABM list" | Read `references/account-selection.md` |
+| Buying committee mapping, persona-based messaging | **persona-mapping** | "persona mapping", "buying committee", "champion", "economic buyer", "persona", "JTBD", "who to target at account", "persona messaging" | Read `references/persona-mapping.md` |
+
+## Decision Flow
+
+```
+User Request
+    |
+    +-- Defining WHO to target? ---------> define-icp
+    |
+    +-- Finding COMPANIES? --------------> source-companies
+    |
+    +-- Finding PEOPLE/CONTACTS? --------> find-contacts
+    |
+    +-- Scoring/qualifying ACCOUNTS? ----> qualify-accounts
+    |
+    +-- Verifying/cleaning DATA? --------> clean-validate
+    |
+    +-- Removing DUPLICATES? ------------> deduplicate
+    |
+    +-- ABM account selection/sizing? ---> account-selection
+    |
+    +-- Buying committee/personas? ------> persona-mapping
+    |
+    +-- Full workflow / "build me a list"?
+        |
+        +-- Beginner? -> Read references/beginner-workflow.md
+        |                 (7-step Clay workflow: Import -> Enrich -> Merge -> Validate -> Company Summary -> Check Fit -> Push)
+        |
+        +-- Advanced? -> Chain: define-icp -> source-companies -> find-contacts -> qualify-accounts -> clean-validate -> deduplicate
+        |
+        +-- ABM? -> Chain: account-selection -> persona-mapping -> source-companies -> find-contacts -> qualify-accounts -> clean-validate
+```
+
+## Full Workflow Template
+
+For users asking for a complete list building workflow, read the beginner workflow template:
+- **File:** Read `references/beginner-workflow.md`
+- **Steps:** Import Data -> Enrich Emails -> Merge Columns -> Validate -> Company Summary (GPT-4 mini) -> Check Fit (Claude) -> Push to Sequencer
+- **Key principle:** Cheap AI for scraping, smart AI for interpretation, conditional formulas everywhere
+
+## Reference Files
+
+Load the appropriate reference based on the sub-skill being invoked:
+
+- **ICP, scoring, boolean search, Sales Nav filters, ABM** -> Read `references/sales-navigator-guide.md`
+- **Lead sources, Clay Find People, webhooks, import methods** -> Read `references/lead-sources-guide.md`
+- **Email/phone verification, bounce management, data decay, list hygiene** -> Read `references/data-validation.md`
+- **Step-by-step Clay pipeline, AI model selection, conditional formulas** -> Read `references/beginner-workflow.md`
+- **Qualification workflow: Frontal tier system, weighted scoring, Clay AI prompts, real examples, good list template** -> Read `references/qualification-workflow.md`
+
+### Advanced List Building Resources
+
+- **62+ underused data sources by category** -> Read `references/list-building-data-sources.md`
+- **ICP deep-dives, multi-source workflows, Apollo+Clay template** -> Read `references/list-building-deep-dives.md`
+- **100+ industry-specific directories for scraping** -> Read `references/list-building-directories.md`
+- **8-phase quality list building framework** -> Read `references/list-building-framework.md`
+
+### ABM Resources
+
+- **Account selection framework, revenue reverse-engineering, staging** -> Read `references/account-selection-framework.md`
+- **Persona mapping, buying committee, messaging matrix** -> Read `references/persona-mapping-framework.md`
+
+## Key Numbers to Remember
+
+- **2,500** — Sales Navigator max results per search (bypass by segmenting)
+- **22-30%** — Annual email decay rate
+- **<1%** — Target bounce rate for campaigns
+- **95%+** — Target email deliverability
+- **100 points** — ICP scoring system (Tier A: 90-100, B: 70-89, C: 50-69, D: <50)
+- **10-50 accounts** — Tier 1 ABM (1:1 custom)
+- **30 days** — Re-verify lists older than this
+
+## Response Format
+
+1. Identify which sub-skill(s) the user needs
+2. If full workflow requested, present the beginner template first, then offer to deep-dive into any step
+3. Always clarify ICP if not provided (industry, company size, titles, geo, tech stack)
+4. Provide specific, actionable steps with tool recommendations
+5. Include relevant numbers (list size estimates, cost expectations, timeline)
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/account-selection-framework.md
+++ b/skills/alex-vacca/list-architect/references/account-selection-framework.md
@@ -1,0 +1,265 @@
+# Account Selection — Framework
+
+How to build, score, stage, and manage target account lists for ABM campaigns.
+
+---
+
+## The Account Selection Principle
+
+ABM starts with accounts, not leads. You're choosing *who* to pursue before anything else. Every dollar of ad spend and every BDR hour gets concentrated on accounts that actually fit your ICP.
+
+**The math matters:** To close $1M in ARR from ABM with a $50K ACV, 25% close rate, and 75% qualification rate, you need ~3,400 target accounts in your campaigns (working backwards through stage conversion benchmarks).
+
+---
+
+## How Many Accounts Do You Need?
+
+### Reverse-Engineering from Revenue Target
+
+```
+Revenue Target ÷ ACV = Deals Needed
+Deals ÷ Close Rate ÷ Qualification Rate ÷ Considering Rate ÷ Interested Rate ÷ Aware Rate
+= Total Target Accounts
+```
+
+**Example:**
+
+```
+$1,000,000 ÷ $50,000 = 20 deals
+20 ÷ 0.25 ÷ 0.75 ÷ 0.18 ÷ 0.32 ÷ 0.55 = ~3,367 accounts
+```
+
+### Stage Conversion Benchmarks (ABX Benchmarks)
+
+| Stage | Definition | Conversion to Next |
+|---|---|---|
+| **Identified** | All accounts targeted in campaign | 55% become Aware |
+| **Aware** | 50+ ad impressions | 32% become Interested |
+| **Interested/Engaged** | 5+ ad clicks OR 10+ engagements | 18% become Considering |
+| **Considering** | Booked a demo / signed up for trial | Close rate applies |
+| **Selecting** | Open deal in pipeline | Win rate applies |
+
+*Source: Frontal — ABX benchmarks from real client programs*
+
+---
+
+## Account Selection Criteria
+
+### Layer 1: Firmographic Fit
+
+| Criteria | Example | Source |
+|---|---|---|
+| **Company Size** | SMB (50-500) or Mid-Market (500-2000) | Clay, Apollo, LinkedIn |
+| **Revenue** | $5M+ annual revenue or comparable funding | Clay, Crunchbase |
+| **Industry** | Digital-first (SaaS, eCommerce, EdTech, FinTech, HealthTech) | Clay, LinkedIn |
+| **Location** | USA, Canada, Australia, NZ, Ireland, Israel, Western/Northern Europe | Clay, Apollo |
+| **Business Model** | Product-led growth, B2B SaaS | Manual + Clay enrichment |
+
+### Layer 2: Technographic Indicators
+
+| Criteria | What It Signals | Source |
+|---|---|---|
+| Currently using a competitor | Active buyer in category | BuiltWith, HG Insights, Clay |
+| Using competitor lacking your key feature | Upgrade opportunity | BuiltWith + manual analysis |
+| Using redundant tool combo | Consolidation opportunity | BuiltWith |
+| Recently changed tech stack | Active buying window | BuiltWith, 6sense |
+
+### Layer 3: CRM Intelligence
+
+| Criteria | What It Signals | Source |
+|---|---|---|
+| **Closed-Lost (past 6-12 months)** | Had the problem, bad timing/price | CRM export |
+| **Lost to competitor (missing feature you now have)** | Re-engagement opportunity | CRM closed-lost reason field |
+| **Previously engaged outbound (didn't convert)** | Aware of you, recycle into ABM | CRM + outbound logs |
+| **Churned customers** | Circumstances may have changed | CRM churn data |
+
+### Layer 4: Lookalike Modeling
+
+Build lookalikes from your best customers:
+1. Export top enterprise/growth customers from CRM
+2. Identify shared attributes (industry, size, tech stack, funding stage)
+3. Use Clay to find similar companies that match the pattern
+4. Cross-reference with BuiltWith for technographic match
+
+---
+
+## List Building Process
+
+### Step-by-Step
+
+```
+1. Define ICP criteria (firmographic + technographic)
+   → Use win-loss analysis from CRM to identify patterns
+
+2. Build initial account list
+   → Clay + BuiltWith API for technographic targeting
+   → Apollo for firmographic + contact discovery
+   → CRM export for recycled/closed-lost accounts
+
+3. Enrich accounts
+   → Clay enrichment (revenue, tech stack, funding, headcount)
+   → BuiltWith for technology detection
+   → ICP scoring (0-100)
+
+4. Score and tier
+   → A-tier (90-100): Perfect fit + strong signals
+   → B-tier (60-79): Good fit
+   → C-tier (40-59): Okay fit — maybe for 1:many only
+   → D-tier (<40): Exclude
+
+5. Import to CRM (HubSpot)
+   → Create company records
+   → Set ABM Campaign Name property
+   → Set ABM Stage = "Identified"
+   → Add to ABM campaign active list
+
+6. Sync to LinkedIn Campaign Manager
+   → Push company lists from HubSpot to LinkedIn
+   → Filter by persona using LinkedIn's native targeting
+   → Wait ~48 hours for audience to be ready
+   → Minimum 300 LinkedIn members required to start a campaign
+```
+
+### Tools for List Building
+
+| Tool | Role | Notes |
+|---|---|---|
+| **Clay** | Primary enrichment + list building | Firmographics, technographics, ICP scoring |
+| **BuiltWith** | Technographic detection | API integration with Clay for tech stack data |
+| **Apollo** | Contact discovery + firmographics | Used for initial contact lists for matched audiences |
+| **HubSpot** | CRM + audience management | Lists, workflows, audience sync to LinkedIn |
+| **LinkedIn Campaign Manager** | Ad targeting | Native persona filters on company lists |
+| **Crunchbase** | Funding data | For funding-based targeting |
+
+---
+
+## Account Scoring Model
+
+### Keep It Simple
+
+**Critical lesson from real ABM programs:** Teams that overcomplicate scoring by adding website visits, page-level intent signals, and weighted scores across multiple data sources struggle to execute because:
+
+- Website visitor de-anonymization is unreliable (Clearbit/Breeze identified only 1 company out of 300 visitors — themselves)
+- Complex scoring models break in practice
+
+**What actually works:** Use **quantitative ad engagement data from LinkedIn** pushed to CRM, plus **qualitative campaign engagement data** for personalizing outreach.
+
+### Recommended Scoring Approach
+
+| Data Type | How It's Used | Source |
+|---|---|---|
+| **Quantitative** | Impressions, engagements, clicks → stage progression | LinkedIn → ZenABM/Fibbler → HubSpot |
+| **Qualitative** | Which campaigns they engaged with → intent detection | LinkedIn → ZenABM → HubSpot company properties |
+
+### Stage Thresholds
+
+| Stage | Threshold | Content Shown |
+|---|---|---|
+| **Identified** | Added to campaign list | — |
+| **Aware** | 50+ ad impressions | Awareness content ads |
+| **Interested** | 5+ ad clicks OR 10+ engagements | Solution-oriented ads |
+| **Considering** | Booked demo / signed up for trial | Product-oriented ads + BDR outreach |
+| **Selecting** | Open deal in CRM | Personalized sales engagement |
+
+---
+
+## HubSpot Configuration for ABM
+
+### Company Properties to Create
+
+| Property | Type | Purpose |
+|---|---|---|
+| `ABM Campaign Name` | Dropdown (custom) | Which ABM campaign the account belongs to |
+| `ABM Stage` | Dropdown (custom) | Identified / Aware / Interested / Considering / Selecting |
+| `LinkedIn Ad Engagements - 7d` | Number (custom) | Rolling 7-day engagement count (from ZenABM/Fibbler) |
+| `LinkedIn Ad Engagements - 30d` | Number (custom) | Rolling 30-day engagement count |
+| `LinkedIn Ad Engagements - 90d` | Number (custom) | Rolling 90-day engagement count |
+| `LinkedIn Ad Clicks - 7d` | Number (custom) | Rolling 7-day click count |
+| `LinkedIn Ad Clicks - 30d` | Number (custom) | Rolling 30-day click count |
+| `LinkedIn Ad Clicks - 90d` | Number (custom) | Rolling 90-day click count |
+| `ABM Intent` | Multi-checkbox (custom) | Which intents detected (from campaign engagement) |
+| `ICP Score` | Number (custom) | 0-100 firmographic/technographic fit |
+| `ICP Tier` | Dropdown (custom) | A/B/C/D |
+
+### Active Lists Setup
+
+Create separate active lists for each stage of each campaign:
+- `[Campaign Name] - Identified` (ICP score ≥ threshold, ABM Campaign = X)
+- `[Campaign Name] - Aware` (cumulative impressions ≥ 50)
+- `[Campaign Name] - Interested` (cumulative clicks ≥ 5 OR engagements ≥ 10)
+- `[Campaign Name] - Considering` (demo booked OR trial signup)
+- `[Campaign Name] - Selecting` (deal stage = open)
+
+### Workflow: Stage Progression
+
+```
+Trigger: Company property "LinkedIn Ad Clicks - 30d" changes
+
+IF Clicks ≥ 5 AND ABM Stage = "Aware":
+  → Update ABM Stage = "Interested"
+  → Remove from Aware LinkedIn audience
+  → Add to Interested LinkedIn audience
+  → Trigger BDR notification workflow
+
+IF Impressions ≥ 50 AND ABM Stage = "Identified":
+  → Update ABM Stage = "Aware"
+  → Content changes automatically via audience list updates
+```
+
+---
+
+## Account Engagement Tracking Tools
+
+| Tool | What It Does | Cost | Key Feature |
+|---|---|---|---|
+| **ZenABM** | Pushes LinkedIn engagement data + intent to CRM, account scoring, ABM stage management, analytics dashboards | ~$59/mo+ | Bi-directional CRM sync, qualitative + quantitative data, auto-updates ABM stages |
+| **Fibbler** | Pushes LinkedIn ad engagement data to CRM | Lower cost | Quantitative engagement data (impressions, clicks, engagements) per account |
+| **Factors.ai** | Account identification + engagement tracking | $$ | Impression capping per account, cross-channel attribution |
+| **HubSpot (native)** | CRM + workflow automation | Included | Lists, workflows, audience sync — but no native LinkedIn engagement push (as of Jan 2025) |
+
+**Note:** As of early 2025, HubSpot cannot natively pull company-level engagement data from LinkedIn Campaign Manager. You need a connector tool (ZenABM, Fibbler, or custom API).
+
+---
+
+## Campaign Duration and Pacing
+
+| Parameter | Recommendation |
+|---|---|
+| **Campaign duration** | 12 weeks (3 months) per campaign |
+| **Monitoring cadence** | Weekly account stage progression vs. benchmarks |
+| **When to assess** | Pipeline per $ spent becomes meaningful after week 6-8 |
+| **Pipeline expectation** | $10+ in pipeline per $1 ad spend = healthy |
+| **When to adjust** | If stage progression falls below 50% of benchmark after week 4 |
+
+---
+
+## Real-World Results (Frontal Client Case Study)
+
+### After 90 Days (First Campaign)
+
+| Metric | Result |
+|---|---|
+| Accounts touched | 1,417 |
+| Total cost | $52,191 (ads + tools) |
+| Pipeline generated | $655,000 |
+| Pipeline per $ spent | $12.55 |
+| Team | 4.5 FTE |
+
+### After 16 Months (Cumulative)
+
+| Metric | Result |
+|---|---|
+| Accounts touched | 26,315 |
+| Total LinkedIn ad spend | $490,000 |
+| Pipeline generated | $5,290,737 |
+| Pipeline per $ spent | $10.79 |
+| ROAS (Closed Won) | 2x+ |
+| Team | 4.5 FTE |
+
+**Versus cold outbound:** ABM took half the time and cost 51% less to generate the same pipeline.
+
+*Source: Frontal*
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/account-selection.md
+++ b/skills/alex-vacca/list-architect/references/account-selection.md
@@ -1,0 +1,61 @@
+# Account Selection for ABM
+
+You help users build, score, stage, and manage target account lists for ABM campaigns.
+
+## Reference
+
+Read `account-selection-framework.md` for the complete framework.
+
+## Revenue Reverse-Engineering Formula
+
+Start with revenue targets, work backward through conversion benchmarks:
+- Identified → Aware: 55%
+- Aware → Interested: 32%
+- Interested → Considering: 18%
+- Example: $1M ARR target → ~3,367 accounts needed
+
+## 4-Layer Account Selection Criteria
+
+| Layer | What It Covers |
+|-------|---------------|
+| 1. Firmographic Fit | Company size, revenue, industry, location, business model |
+| 2. Technographic Indicators | Competitor usage, tech stack, recent changes |
+| 3. CRM Intelligence | Closed-lost, lost to competitor, churned customers |
+| 4. Lookalike Modeling | Built from best existing customers |
+
+## ICP Scoring Model (0-100)
+
+| Tier | Score | Action |
+|------|-------|--------|
+| A | 90-100 | Tier 1 ABM (1:1 custom) |
+| B | 70-89 | Tier 2 ABM (1:few) |
+| C | 50-69 | Programmatic ABM |
+| D | <50 | Exclude |
+
+## Stage Progression Tracking
+
+Track via LinkedIn engagement metrics and HubSpot workflows:
+- **Identified**: In target list, no engagement yet
+- **Aware**: Impressions served, some ad engagement
+- **Interested**: 5+ clicks OR 10+ engagements
+- **Considering**: Website visits, content downloads, demo interest
+
+## Tools
+
+Clay, BuiltWith, Apollo, HubSpot, LinkedIn Campaign Manager, ZenABM/Fibbler
+
+## Examples
+
+**Example 1:** "How many accounts do I need for my ABM campaign?"
+→ Read account-selection-framework.md. Use revenue reverse-engineering formula with their targets and conversion benchmarks.
+
+**Example 2:** "How do I tier my account list?"
+→ Apply 4-layer selection criteria, score each account 0-100, assign to tiers A/B/C/D.
+
+**Example 3:** "How do I track which accounts are progressing?"
+→ Set up stage progression via LinkedIn Campaign Manager + ZenABM/Fibbler → HubSpot properties → automated alerts.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/beginner-workflow.md
+++ b/skills/alex-vacca/list-architect/references/beginner-workflow.md
@@ -1,0 +1,144 @@
+# Beginner Workflow — Step by Step
+
+*Source: Matt — Agency owner, 100K+ cold emails/month*
+
+## The Complete Workflow
+
+```
+1. IMPORT DATA
+   ↓
+2. ENRICH MISSING EMAILS (waterfall or single provider)
+   ↓
+3. MERGE COLUMNS
+   ↓
+4. VALIDATE EMAILS
+   ↓
+5. GET COMPANY SUMMARY (cheap AI)
+   ↓
+6. CHECK IF FIT (better AI)
+   ↓
+7. PUSH TO SEQUENCER
+```
+
+## Step 1: Import Data
+
+**Options:**
+- CSV upload
+- HubSpot/Salesforce sync
+- Apollo integration
+- Clay's native "Find People"
+
+**Note:** External data (Apollo) is often better quality than Clay native
+
+## Step 2: Enrich Missing Emails
+
+**Built-in Waterfall:**
+- Add enrichment → Work Email Waterfall
+- Multiple providers: LeadMagic, Prospeo, etc.
+- Stops as soon as an email is found
+
+**External Provider (saves money):**
+- Use your own API key
+- Connect Prospeo directly
+- Saves Clay credits
+
+## Step 3: Merge Columns
+
+- Merge emails from different sources
+- One clean "Final Email" column
+
+## Step 4: Validate Emails
+
+**Native Clay Providers:**
+- Debounce, Enrichly, Hunter, LeadMagic, NeverBounce
+
+**Via API (recommended for catchalls):**
+- ListKit/Listman.io = validates catchalls with precision
+- Configure an HTTP API call
+
+**CRITICAL — Conditional Formula:**
+```
+Only run if /work_email is not empty
+```
+→ Don't waste credits on empty cells
+
+## Step 5: Company Summary (Cheap AI)
+
+**Model:** GPT-4 mini ($0.00126/call)
+
+**Prompt:**
+```
+I want you to visit this website /company_domain and give me
+an exhaustive summary of what the company does in as many
+paragraphs as possible.
+```
+
+**Why separate:**
+1. Reusable for other prompts
+2. Cheap model for intensive scraping
+3. Smart model for interpretation
+
+**Conditional Formula:**
+```
+Only run if /listkit_results equals "valid" OR "catchall valid"
+```
+
+## Step 6: Check Fit (Smart AI)
+
+**Model:** Claude 3.5 Sonnet (better interpretation)
+
+**Prompt:**
+```
+I'm going to feed you a company description and I want you
+to tell me if the company is a B2B company or a B2C company.
+
+If they are a B2B company then output "B2B"
+If they are a B2C company then output "B2C"
+
+Only output B2B or B2C, nothing else.
+
+Here is the company summary: /company_summary
+```
+
+**IMPORTANT:** "Only output X or Y, nothing else"
+- Makes filtering easy
+- No paragraphs of justification
+
+**Conditional Formula:**
+```
+Only run if /company_summary exists
+```
+
+## Step 7: Push to Sequencer
+
+**Native integrations:**
+- SmartLead
+- Instantly
+- Others via API
+
+**Conditional Formula:**
+```
+Only run if /company_type equals "B2B"
+```
+
+**Mapping:**
+- First name, Last name, Email
+- Company domain, LinkedIn profile
+- Custom fields
+
+## Best Practices
+
+**Always test small:**
+- Run 10 rows first
+- Check the outputs
+- Then run all
+
+**Save credits:**
+- Cheap AI (GPT-4 mini) for scraping
+- Smart AI (Claude) for interpretation
+- Conditional formulas everywhere
+
+**Common mistakes:**
+- Forgetting to feed data to the prompt (e.g., /company_summary)
+- Running before checking the conditional formula
+- Using expensive AI for everything

--- a/skills/alex-vacca/list-architect/references/clean-validate.md
+++ b/skills/alex-vacca/list-architect/references/clean-validate.md
@@ -1,0 +1,81 @@
+# Clean & Validate — Sub-Skill
+
+You help users verify email and phone data, manage bounce rates below 1%, and establish list hygiene schedules. Always read the reference file before responding.
+
+## Reference
+
+Read `data-validation.md` — all sections.
+
+## Email Verification Tools
+
+| Tool | Cost | Accuracy | Best For |
+|------|------|----------|----------|
+| ZeroBounce | $0.008/email | 98%+ | High-volume, agencies |
+| NeverBounce | $0.008/email | 99.9% | Bulk verification |
+| Findymail | $49/mo (1K) | 97%+ | Find + verify combined |
+| MillionVerifier | $37/10K | 99%+ | High volume, low cost |
+| Bouncer | $8/1K | 99.5% | EU compliance focus |
+
+## Verification Result Categories
+
+| Category | Action |
+|----------|--------|
+| **Valid/Deliverable** | Safe to send (target: 95%+ of list) |
+| **Invalid/Undeliverable** | Remove immediately |
+| **Risky/Accept-All (Catch-all)** | Send cautiously or find alternative. Use ListKit/Listman.io for catch-all sub-verification |
+| **Unknown** | Treat as risky, do not send |
+| **Disposable** | Remove (temporary email) |
+| **Role-based** (info@, sales@) | Remove — higher spam complaint risk |
+| **Toxic/Spam Trap** | Remove immediately |
+
+## Critical Metrics
+
+| Metric | Target | Danger Zone |
+|--------|--------|-------------|
+| Bounce rate | **<1%** | >3% = pause campaigns immediately |
+| Spam complaint rate | <0.1% | >0.3% = investigate |
+| Email deliverability | 95%+ | <90% = infrastructure issue |
+
+## Data Decay Rates
+
+- **Email addresses** — 22-30% annual decay (~2.1%/month)
+- **Phone numbers** — 15-20% annual decay
+- **Job titles** — 30-35% annual decay
+- **Company employment** — 20-25% annual decay
+
+## List Hygiene Schedule
+
+| Frequency | Action |
+|-----------|--------|
+| **Before every campaign** | Full email verification on entire list |
+| **Weekly** | Monitor bounce rates, remove hard bounces |
+| **Monthly** | Re-verify risky and catch-all emails |
+| **Quarterly** | Full re-verification, update job titles, purge unengaged (no opens/clicks 90 days) |
+| **Bi-annually** | Complete data refresh from LinkedIn, re-verify all |
+| **Annually** | Full ICP audit, rebuild lists from scratch |
+
+**Rule: Re-verify any list older than 30 days before sending.**
+
+## Bounce Handling Workflow
+
+```
+Email Sent -> Delivered -> Track engagement
+           -> Soft Bounce -> Retry 3x (4h, 24h, 48h) -> Still bouncing? -> Hard Bounce
+           -> Hard Bounce -> Remove IMMEDIATELY -> Add to suppression list -> Flag source for quality review
+```
+
+## Examples
+
+**Example 1:** "My bounce rate is 4%, what do I do?"
+-> Pause all campaigns immediately (>3% = danger zone). Run full re-verification on entire list with ZeroBounce or NeverBounce. Remove all Invalid, Unknown, Disposable, Toxic. Sub-verify catch-all emails with ListKit. Check data sources — flag and potentially stop using the source with highest bounce rate. Target: get back below 1% before resuming.
+
+**Example 2:** "Which email verification tool should I use?"
+-> Volume-based: <1K/month = Findymail ($49, finds + verifies). 1K-10K/month = NeverBounce ($0.008/email, 99.9% guarantee). 10K+/month = MillionVerifier ($37/10K, best cost). EU-focused = Bouncer or Dropcontact (GDPR-compliant). Catch-all heavy = add ListKit/Listman.io as secondary verification.
+
+**Example 3:** "How often should I clean my list?"
+-> Verify 100% before every campaign, no exceptions. Weekly: remove hard bounces. Monthly: re-verify catch-all and risky. Quarterly: full refresh + purge unengaged. Email decays 22-30%/year, so a list from 6 months ago has ~11-15% bad data. Re-verify anything older than 30 days.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/data-validation.md
+++ b/skills/alex-vacca/list-architect/references/data-validation.md
@@ -1,0 +1,101 @@
+# Data Validation & List Hygiene
+
+## Email Verification Tools
+
+| Tool | Cost | Accuracy | Catch-all | Best For |
+|------|------|----------|-----------|----------|
+| **ZeroBounce** | $0.008/email | 98%+ | Sub-verification | High-volume, agencies |
+| **NeverBounce** | $0.008/email | 99.9% guarantee | Flags "accept all" | Bulk verification |
+| **Findymail** | $49/mo (1K emails) | 97%+ | Finds verified only | Find + verify combined |
+| **Clearout** | $21/3K credits | 98%+ | Sub-verification | Budget-conscious |
+| **MillionVerifier** | $37/10K | 99%+ | Basic detection | High volume, low cost |
+| **Bouncer** | $8/1K | 99.5% | Toxic detection | EU compliance focus |
+| **Hunter.io** | $49/mo (500) | 95%+ | Basic | Find + verify combined |
+| **Dropcontact** | EUR 24/mo (1K) | 98%+ | GDPR-compliant | EU-focused teams |
+
+## Verification Result Categories
+
+| Category | Action |
+|----------|--------|
+| **Valid/Deliverable** | Safe to send (target: 95%+ of list) |
+| **Invalid/Undeliverable** | Remove immediately |
+| **Risky/Accept-All** | Send cautiously or find alternative |
+| **Unknown** | Treat as risky |
+| **Disposable** | Remove (temporary email) |
+| **Role-based** (info@, sales@) | Flag for review, usually skip |
+| **Toxic/Spam Trap** | Remove immediately |
+
+## Phone Validation Tools
+
+| Tool | Price | Specialty |
+|------|-------|-----------|
+| **Lusha** | $36/mo (480 credits) | Direct dials + mobile |
+| **Apollo.io** | $49/mo | Phone enrichment included |
+| **Cognism** | Enterprise pricing | Phone-verified mobile (Diamond Data) |
+| **ZoomInfo** | $15K+/year | Most comprehensive B2B phones |
+| **RocketReach** | $53/mo (80 lookups) | Phone included |
+| **Kaspr** | $49/mo | LinkedIn Chrome extension |
+
+## Data Decay Rates
+
+| Data Point | Annual Decay | Recommended Refresh |
+|------------|-------------|-------------------|
+| Email address | 22-30% | Every 3-6 months |
+| Phone number | 15-20% | Every 6 months |
+| Job title | 30-35% | Every 3 months |
+| Company (employment) | 20-25% | Every 3 months |
+| Mailing address | 15-20% | Every 12 months |
+| Direct dial phone | 25-30% | Every 3-6 months |
+
+**Average B2B database decays ~2.1% per month (~25% per year).**
+
+## List Hygiene Schedule
+
+| Frequency | Action |
+|-----------|--------|
+| **Before every campaign** | Run email verification on full list |
+| **Weekly** | Monitor bounce rates, remove hard bounces immediately |
+| **Monthly** | Re-verify "risky" and "catch-all" emails |
+| **Quarterly** | Full re-verification, update job titles, remove unengaged (no opens/clicks 90 days) |
+| **Bi-annually** | Complete data refresh: re-enrich from LinkedIn, re-verify all |
+| **Annually** | Full ICP audit, rebuild lists from scratch, purge unverified data |
+
+## Key Metrics to Monitor
+
+| Metric | Target | Danger Zone |
+|--------|--------|-------------|
+| Bounce rate | <1% | >3% — pause campaigns |
+| Spam complaint rate | <0.1% | >0.3% — investigate |
+| Unsubscribe rate | 0.3-0.5% | >1% — targeting issue |
+| Email deliverability | 95%+ | <90% — infrastructure issue |
+| List growth rate | Outpace decay | Shrinking = problem |
+
+## Verification Best Practices
+
+1. **Verify 100% of emails before any campaign.** No exceptions.
+2. **Re-verify lists older than 30 days.**
+3. **Remove all "unknown" and "catch-all"** or batch-test cautiously.
+4. **Remove role-based emails** (info@, admin@, sales@) — higher spam complaints.
+5. **Remove free email providers** for B2B outreach (gmail, yahoo personal).
+6. **Use real-time verification** at point of collection if possible (API).
+7. **Cost perspective:** $0.005-0.01/email is trivial vs damaged domain reputation.
+
+## Bounce Handling Workflow
+
+```
+Email Sent
+    |
+    +-- Delivered → Track engagement (opens, replies)
+    |
+    +-- Soft Bounce
+    |   +-- Retry #1 (after 4 hours)
+    |   +-- Retry #2 (after 24 hours)
+    |   +-- Retry #3 (after 48 hours)
+    |   +-- Still bouncing? → Treat as Hard Bounce
+    |
+    +-- Hard Bounce
+        +-- Remove from campaign IMMEDIATELY
+        +-- Add to global suppression list
+        +-- Never email again
+        +-- Flag source for quality review
+```

--- a/skills/alex-vacca/list-architect/references/deduplicate.md
+++ b/skills/alex-vacca/list-architect/references/deduplicate.md
@@ -1,0 +1,86 @@
+# Deduplicate — Sub-Skill
+
+You help users remove duplicates, merge multi-source data cleanly, and maintain data quality across their lists. Always read the reference files before responding.
+
+## References
+
+- Read `data-validation.md` — for verification context and data quality metrics.
+- Read `beginner-workflow.md` — section: Step 3 (Merge Columns).
+
+## Why Deduplication Matters
+
+- Sending the same person 2-3 emails from different campaigns destroys credibility
+- Duplicate records waste enrichment and verification credits
+- Multiple sources (Apollo + Sales Nav + Clay) often overlap 30-60%
+- Dirty data skews campaign metrics (open rates, reply rates)
+
+## Deduplication Strategies
+
+### 1. Match Keys (Priority Order)
+
+| Match Key | Reliability | Use Case |
+|-----------|-------------|----------|
+| Email address | Highest | Primary dedup key |
+| LinkedIn URL | High | When emails differ across sources |
+| First + Last + Company Domain | Medium | When no email/LinkedIn available |
+| Phone number | Medium | Secondary validation |
+| First + Last + Title + Location | Low | Last resort, risk of false matches |
+
+### 2. Clay Auto-Dedupe
+- Clay automatically deduplicates on import when using integrations
+- For CSV imports: enable "Deduplicate" option during upload
+- Match on: Email (primary) or LinkedIn URL (secondary)
+- Keeps the most recently enriched record by default
+
+### 3. Merge Columns (Multi-Source)
+When combining data from multiple providers:
+```
+Source 1 (Apollo): email_apollo, phone_apollo, title_apollo
+Source 2 (Sales Nav): email_sn, phone_sn, title_sn
+Source 3 (Clay): email_clay, phone_clay, title_clay
+    |
+    v
+Merge into: final_email, final_phone, final_title
+```
+
+**Priority rule:** Use the most recently verified data point. If both are recent, prefer the source with higher historical accuracy for that field.
+
+### 4. Cross-Campaign Dedup
+- Maintain a master suppression list of all previously contacted prospects
+- Before launching any campaign, cross-reference against this list
+- Include: contacted, bounced, unsubscribed, replied-not-interested
+- Update after every campaign completes
+
+## Data Quality Checks After Dedup
+
+| Check | Action |
+|-------|--------|
+| Empty email rows | Remove or re-enrich |
+| Free email providers (gmail, yahoo) | Flag for B2B — usually personal |
+| Role-based emails (info@, sales@) | Remove for cold outreach |
+| Missing company domain | Enrich from LinkedIn URL |
+| Title mismatches across sources | Keep most recent, flag for review |
+| Same person, different companies | Check if job change — keep current |
+
+## Conditional Formulas (Credit-Saving)
+
+From the beginner workflow — always apply:
+- **Only enrich if email is empty** (don't re-enrich what you have)
+- **Only verify if email exists** (don't waste credits on blank rows)
+- **Only run AI if verification = valid** (don't summarize companies for bad leads)
+
+## Examples
+
+**Example 1:** "I imported leads from Apollo and Sales Nav, there are tons of duplicates"
+-> In Clay: use email as primary match key to auto-dedup. For records without email, match on LinkedIn URL. Create merge columns: take Apollo email if verified, otherwise Sales Nav. For remaining duplicates, match on First + Last + Company Domain. Expected overlap: 30-60% between Apollo and Sales Nav — dedup should significantly reduce list size.
+
+**Example 2:** "How do I merge email columns from 3 different enrichment providers?"
+-> Create a "Final Email" merge column in Clay. Priority order: (1) Findymail (find + verify combined), (2) Prospeo, (3) LeadMagic. Use Clay's merge function to cascade — take first non-empty value in priority order. Then run verification on the Final Email column. Conditional formula: only verify if Final Email is not empty.
+
+**Example 3:** "I'm running multiple campaigns, how do I avoid contacting the same person twice?"
+-> Build a master suppression list table in Clay or your CRM. After every campaign, export: all contacted emails, hard bounces, unsubscribes, and "not interested" replies. Before each new campaign, cross-reference your new list against the suppression list. Remove matches. Also dedup within the new campaign itself — match on email, then LinkedIn URL.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/define-icp.md
+++ b/skills/alex-vacca/list-architect/references/define-icp.md
@@ -1,0 +1,66 @@
+# Define ICP — Sub-Skill
+
+You help users build a precise Ideal Customer Profile with a structured scoring system. Always read the reference file before responding.
+
+## Reference
+
+Read `sales-navigator-guide.md` — sections: ICP Framework, ICP Scoring, Scoring Matrix.
+
+## ICP Framework — 3 Layers
+
+### 1. Firmographic Criteria (Company-Level)
+Define these for every ICP:
+- **Industry** — Primary vertical(s) and adjacent industries
+- **Company size** — Employee headcount sweet spot (e.g., 51-500)
+- **Revenue** — Annual revenue range (requires Sales Nav Advanced+)
+- **Geography** — HQ location, target markets
+- **Growth rate** — Headcount growth signals
+- **Funding stage** — Seed, Series A-C, PE-backed, Public
+
+### 2. Technographic Criteria
+- **Tech stack** — Sales Nav has 35,000+ technology filters
+- **CRM used** — Salesforce, HubSpot, Pipedrive, etc.
+- **Marketing automation** — Marketo, Pardot, Mailchimp, etc.
+- **Competitive tools** — Currently using a competitor's product
+
+### 3. Behavioral/Intent Signals
+- Job postings (hiring for roles your product supports)
+- Funding events (new budget available)
+- Leadership changes (new decision makers open to change)
+- Content engagement (LinkedIn Buyer Intent, Bombora, 6sense)
+- Website visits (Clearbit Reveal, Leadfeeder, RB2B)
+
+## Scoring System — 100 Points
+
+| Criterion | Weight | Scoring |
+|-----------|--------|---------|
+| Industry match | 20 pts | Exact = 20, Adjacent = 10, None = 0 |
+| Company size | 15 pts | Sweet spot = 15, Adjacent = 8, Outside = 0 |
+| Revenue range | 15 pts | Sweet spot = 15, Adjacent = 8, Unknown = 0 |
+| Geography | 10 pts | Primary = 10, Secondary = 5, Other = 0 |
+| Technology fit | 15 pts | Complement = 15, Neutral = 8, Competitor = 5 |
+| Growth signals | 10 pts | High = 10, Moderate = 5, Stagnant = 0 |
+| Intent signals | 15 pts | Strong = 15, Some = 8, None = 0 |
+
+## Tier Assignment
+
+- **Tier A (90-100 pts)** — Perfect fit. Maximum resources, multi-threaded ABM, custom outreach.
+- **Tier B (70-89 pts)** — Strong fit. Targeted sequences, personalized messaging.
+- **Tier C (50-69 pts)** — Moderate fit. Automated nurture, content marketing.
+- **Tier D (<50 pts)** — Poor fit. Exclude from outreach, inbound-only.
+
+## Examples
+
+**Example 1:** "I sell HR software to mid-market companies"
+-> Firmographic: 200-2,000 employees, $20M-$500M revenue, US/Canada. Technographic: Using BambooHR, Workday, or ADP. Behavioral: Hiring HR roles, posted about "employee experience". Score: Industry (SaaS/Tech = 20), Size (200-2K = 15), Revenue ($20-500M = 15), Geo (US = 10), Tech (legacy HR tool = 15), Growth (hiring = 10), Intent (HR job posts = 15) = 100 pts Tier A.
+
+**Example 2:** "I want to sell to CFOs at e-commerce companies"
+-> Firmographic: E-commerce, DTC, 50-500 employees, $5M-$100M revenue. Technographic: Shopify Plus, Magento, NetSuite. Behavioral: Recently raised funding, CFO hired in past 90 days. Score and assign tiers based on how many criteria match.
+
+**Example 3:** "How do I prioritize my target accounts?"
+-> Build scoring matrix with their specific criteria. Weight based on what correlates with closed-won deals. Analyze top 10-20 existing customers to reverse-engineer the ICP. Assign tiers and allocate outreach resources accordingly.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/find-contacts.md
+++ b/skills/alex-vacca/list-architect/references/find-contacts.md
@@ -1,0 +1,73 @@
+# Find Contacts — Sub-Skill
+
+You help users find the right contacts at target companies using boolean search, Clay Find People, and export tools. Always read the reference files before responding.
+
+## References
+
+- Read `sales-navigator-guide.md` — sections: Boolean Search, Boolean Formulas by ICP, Export & Scraping Tools, List Building Best Practices.
+- Read `lead-sources-guide.md` — section: Find People (FREE in Clay).
+
+## Boolean Search Operators
+
+| Operator | Syntax | Example |
+|----------|--------|---------|
+| AND | `AND` | `VP AND Marketing` |
+| OR | `OR` | `CEO OR "Chief Executive"` |
+| NOT | `NOT` | `VP NOT assistant` |
+| Quotes | `"exact"` | `"Vice President"` |
+| Parentheses | `(group)` | `(CEO OR CTO) AND SaaS` |
+
+**Limits:** Boolean works in Title, Company, Keywords fields only. Max ~1,000 characters. No wildcards. Nesting 2-3 levels deep.
+
+## Ready-Made Boolean Formulas
+
+- **SaaS Decision Makers:** `(VP OR "Vice President" OR Director OR Head OR Chief) AND (Marketing OR "Demand Gen" OR "Growth" OR "Digital")` + Company Keywords: `(SaaS OR "B2B software" OR "cloud-based" OR "subscription")` + Seniority: VP, Director, CXO + Industry: Computer Software, Internet, IT & Services
+- **C-Suite:** `(CEO OR Founder OR "Managing Director" OR "Chief Executive" OR "Chief Operating") NOT (assistant OR intern OR student)`
+- **VP Sales Mid-Market:** `("VP Sales" OR "Vice President Sales" OR "Head of Sales" OR CRO)` + Industry: Software, Headcount: 201-1000
+- **Buying Committee:** Run 4 separate searches — Economic Buyer (`CEO OR CFO OR "VP Finance"`), Champion (`"Head of Marketing" OR "Marketing Director"`), Technical Evaluator (`"Marketing Manager" OR "Demand Gen Manager"`), End User/Blocker (`"General Counsel" OR "Head of Legal"`)
+
+> **Note:** For comprehensive formulas with all title variants, see `sales-navigator-guide.md` → Boolean Formulas by ICP section.
+
+## Bypassing the 2,500 Result Limit
+
+Sales Navigator caps at 2,500 results per search. Bypass by segmenting:
+1. **Geography** — Split by state, city, or region
+2. **Industry** — Same title across different industries
+3. **Company size** — Break 51-500 into 51-200 and 201-500
+4. **Seniority** — Separate searches per level (VP, Director, Manager)
+5. **First name** — Filter A-F, G-L, M-R, S-Z
+6. **Time filters** — "Changed jobs in 90 days", "Years in position"
+
+## Clay Find People (Free)
+
+1. New Table -> Find People
+2. Filters: Job Titles, Location, Keywords, Min connections, Certifications, Past experience
+3. Generic logo = scraping LinkedIn (free, no credit cost)
+4. Best for quick lookups and supplementing Sales Nav results
+
+## Export Tools
+
+| Tool | Price | Best For |
+|------|-------|----------|
+| Evaboot | $29-99/mo | Clean, verified Sales Nav exports |
+| PhantomBuster | $69-439/mo | Multi-step automation workflows |
+| Captain Data | $399/mo | Agencies, repeatable extraction |
+| Apollo.io | Free-$119/mo | Own database, no scraping risk |
+
+**Recommended flow:** Build list in Sales Nav -> Export with Evaboot -> Enrich in Clay -> Verify emails -> Segment for outreach.
+
+## Examples
+
+**Example 1:** "I need to find VP of Marketing at SaaS companies with 50-500 employees"
+-> Sales Nav boolean: `("VP Marketing" OR "Vice President Marketing" OR "Head of Marketing" OR "Director of Marketing")`. Filters: Industry = Computer Software, Headcount = 51-500, Seniority = VP/Director. If >2,500 results, segment by geography. Export with Evaboot.
+
+**Example 2:** "I want to map the entire buying committee at my target accounts"
+-> Run 4 searches: (1) Economic Buyer: `CEO OR CFO OR "VP Finance"`, (2) Champion: `"Head of Marketing" OR "Marketing Director"`, (3) Technical: `"Marketing Manager" OR "Demand Gen Manager"`, (4) Blocker: `"General Counsel" OR "Head of Legal"`. Save each as separate Sales Nav list. Export and tag by role.
+
+**Example 3:** "How do I find founders of recently funded startups?"
+-> Boolean: `(Founder OR "Co-Founder" OR CEO)`. Filters: Headcount 1-200, Changed jobs past 90 days. Company keywords: `(seed OR "series A" OR "series B" OR startup)`. Supplement with Clay Find People using "Past experience" filter.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/lead-sources-guide.md
+++ b/skills/alex-vacca/list-architect/references/lead-sources-guide.md
@@ -1,0 +1,91 @@
+# Lead Sources — Complete Guide
+
+## 3 Categories of Leads
+
+### 1. Inbound Leads (Marketing Initiatives)
+- LinkedIn Ads responses
+- Organic LinkedIn engagement
+- Newsletter subscribers
+- Form fills on website
+- Webinar attendees
+- In-person event attendees
+
+### 2. Warm/High Intent Leads
+- LinkedIn post engagers (via Triggery)
+- Website visitors (via RB2B, Clearbit, etc.)
+- Slack community joiners
+- Reddit threads mentioning your product
+- Product trial signups
+
+### 3. Cold Outreach Lists
+- Build directly in Clay
+- Import from Apollo, ZoomInfo, Sales Navigator
+- Scrape from Google Maps (local businesses)
+
+## Lead Sources by Tool
+
+**Apollo.io:**
+- Best for broad targeting
+- Use with LeadMagic scraper for enrichment
+- Good volume, needs verification
+
+**LinkedIn Sales Navigator:**
+- Use with Prospeo or Vayne scrapers
+- Best for precise role/seniority targeting
+- Higher quality, lower volume
+
+**Clay Find People/Accounts:**
+- Native database for quick lookups
+- Good for enrichment workflows
+
+**Ocean.io:**
+- Lookalike accounts based on tech stack/ICP
+- Good for expanding TAM
+
+**Openmart:**
+- Local lead generation
+- SMB-focused
+
+**Local Directories:**
+- Instant Data Scraper for niche verticals
+- Good for specific industries
+
+## Find People (FREE in Clay)
+
+1. New → Table → Find People
+2. Available filters:
+   - Job Titles (founder, CEO, VP Sales...)
+   - Location (New York City, France...)
+   - Keywords in profile
+   - Min connections/followers
+   - Certifications
+   - Past experiences
+
+**Note:** Generic logo = scraping LinkedIn (free)
+
+## Advanced Sources
+
+| Source | Use Case | Cost |
+|--------|----------|------|
+| Find People | ICP list building | Free |
+| Find Companies | Company lists | Free |
+| HG Insights | Tech stack | Paid |
+| Google Maps | Local businesses | Free |
+| Social Media | Influencers | Variable |
+| RSS Feeds | Content monitoring | Free |
+| Apify/PhantomBuster | Custom scraping | Variable |
+| Webhooks | Live data streams | Free |
+
+## Webhooks — Live Data
+
+**Use case:** Triggery → Clay (LinkedIn engagement)
+- Someone likes/comments on your LinkedIn post
+- Webhook sends data to Clay in real-time
+- Clay enriches and routes automatically
+
+## List Building Pro Tips
+
+1. **Mix sources** — Don't rely on just one
+2. **Scraping = step 1** — Still need Clay enrichment
+3. **Templates are modular** — Adjust for campaign goals
+4. **Don't reinvent the wheel** — Start with template, tweak

--- a/skills/alex-vacca/list-architect/references/list-building-data-sources.md
+++ b/skills/alex-vacca/list-architect/references/list-building-data-sources.md
@@ -1,0 +1,160 @@
+# 62 Data Sources for Better Outbound Lists
+
+Underused and alternative data sources organized by category. Many accessible via Apify scrapers.
+
+---
+
+## Review & Feedback Sites
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **G2** | Reviewer titles, companies, ratings, comparisons | Tool dissatisfaction, switching intent | Reviews reveal pain points and timing |
+| **Capterra** | Reviewer details, pros/cons, company size | Mid-market software evaluators | Lower profile than G2, equally valuable |
+| **Trustpilot** | Company ratings, sentiment, reviewer info | CX quality, brand health | B2C focus means B2B teams skip it |
+| **Gartner Peer Insights** | Enterprise reviewer titles, vendor comparisons | Enterprise buying intent | Perceived as "too enterprise" |
+| **Glassdoor** | Employee reviews, salary data, company ratings | Culture, growth trajectory, hiring budget | Used for recruiting, not sales |
+| **Yelp** | Business owner info, local data, reviews | Local/SMB market intelligence | Seen as "consumer" not B2B |
+
+---
+
+## Startup & Founder Discovery
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Product Hunt** | Maker emails, launches, upvotes, categories | Early-stage founders, PMF timing | Most only use for competitive intel |
+| **Y Combinator Directory** | Profiles, founders, batch, funding, team size | Venture-backed with budget | Requires manual browsing without scraper |
+| **Wellfound (AngelList)** | Profiles, team, funding, job listings | Funded startups actively hiring | API limited; scraping unlocks more |
+| **BetaList** | New startups, maker profiles, descriptions | Pre-launch and early-stage founders | 21K+ startups, barely touched |
+| **Crunchbase** | Funding, acquisitions, exec changes, tech stack | Growth signals, leadership transitions | API expensive; scrapers are cheap |
+| **Hacker News** | "Show HN" launches, job posts, discussions | Developer/founder sentiment | Real-time signals lost in noise |
+
+---
+
+## Events & Communities
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Meetup** | Events, organizers, RSVPs, group members | Self-identified interest in topics | Event data rarely used for outbound |
+| **Eventbrite** | Events, organizer profiles, ticket pricing | Professional event attendance intent | B2B teams don't think "events" |
+| **Lu.ma** | Tech events, attendee counts, organizer info | High-intent tech community | Newer platform, undiscovered |
+| **LinkedIn Events** | Attendees, company affiliations | Professional interest signals | Hard to access without scraping |
+| **Reddit** | Discussions, complaints, tool mentions | Unfiltered buyer frustrations | Perceived as "consumer" only |
+| **Hacker News** | Tech discussions, job posts, launches | Developer/founder sentiment | Too noisy without filtering |
+
+---
+
+## Job Boards & Hiring Signals
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Greenhouse** | Job posts, company info, tech in descriptions | Hiring = budget = growth | Requires scraping each ATS |
+| **Lever** | Job titles, requirements, company details | Department-level expansion | Fragmented across platforms |
+| **Workable** | Job listings, company profiles, salaries | SMB/mid-market hiring | Less known than big boards |
+| **Ashby** | Job posts, company info | Modern startups using modern ATS | Newer ATS, fewer scrapers |
+| **Indeed** | Job posts at scale, salary estimates | Mass hiring signals | High volume, needs filtering |
+| **Work at a Startup (YC)** | YC company jobs, team size, stage | Venture-backed hiring intent | YC-specific, highly targeted |
+
+---
+
+## Tech Stack & Technographics
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **BuiltWith** | Full tech stack, CMS, analytics, payments | Technology adoption patterns | Expensive API; scrapers bypass cost |
+| **Wappalyzer** | Frontend/backend frameworks, CDN, hosting | Tool switching opportunities | Requires bulk lookups |
+| **6sense Tech Data** | Technology market insights, install base | Competitive intelligence | Enterprise-focused, overlooked |
+| **Stackshare** | Company tech stacks, comparisons | Developer tooling decisions | Niche, highly specific |
+| **DNS/WHOIS Data** | Domain age, registrar, mail provider | Legitimacy, tech maturity | Technical, underutilized |
+
+---
+
+## Marketplaces & E-Commerce
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Shopify Stores** | Products, pricing, store metadata | E-commerce brand intelligence | Most focus on Amazon only |
+| **Amazon** | Products, reviews, seller info, pricing | Market validation, competitor analysis | Heavily used, specific cases missed |
+| **Etsy** | Seller profiles, product data, reviews | Creative/SMB market | B2B teams ignore handmade market |
+| **AppSumo** | SaaS launches, pricing, founder info | Early-stage SaaS buyers/builders | Niche lifetime deal market |
+
+---
+
+## Freelancer & Services Platforms
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Fiverr** | Gigs, seller profiles, pricing, reviews | Freelancer market trends | Seen as "gig economy" not B2B |
+| **Upwork** | Job posts, client budgets, freelancer profiles | Project-based demand signals | Underused for B2B lead gen |
+| **Clutch.co** | Agency profiles, client lists, portfolios | Agency ecosystem, client discovery | Gold mine for partnerships |
+| **Freelancer.com** | Job listings, project budgets, client info | Outsourcing demand | Less polished, still valuable |
+| **PeoplePerHour** | Project listings, client profiles | UK/EU freelance market | Regional but rich data |
+
+---
+
+## Content & Creator Platforms
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **YouTube Channels** | Creator emails, subscriber counts, video stats | Influencer/creator partnerships | Business emails often in "About" |
+| **Substack** | Newsletter creators, subscriber counts, themes | Creator economy leads | Market booming, data untapped |
+| **Apple Podcasts** | Podcast hosts, episode data, genres | Guest/sponsor opportunities | Scraping unlocks discovery at scale |
+| **Spotify Podcasts** | Podcast metadata, creator info | Audio content creators | Similar to Apple, different catalog |
+| **Medium** | Publication authors, engagement metrics | Thought leadership identification | Easy to get, rarely used for outbound |
+
+---
+
+## Developer & Open Source
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **GitHub Stargazers** | User profiles, company, email, social links | Technical evaluators, OSS enthusiasts | Developers influence buying decisions |
+| **GitHub Repo Data** | Stars, forks, contributors, issues | Tool adoption, community health | Competitive intel for dev tools |
+| **Stack Overflow** | Question authors, tags, company mentions | Technical pain points | Problem-focused, not used for outreach |
+| **Dev.to** | Developer authors, article engagement | Developer community trends | Growing platform, underutilized |
+
+---
+
+## Business Directories & Lists
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Google Maps** | Business listings, reviews, contact info | Local business intelligence | Massive scale, often too broad |
+| **Yelp Business** | SMB profiles, owner info, reviews | Local/SMB market | Consumer-perceived, B2B uses exist |
+| **Yellow Pages / Local Directories** | Business categories, contact info | Traditional businesses | "Old school" but data-rich |
+| **Industry Association Directories** | Member companies, leadership | Vertical-specific targeting | Scattered, requires manual ID |
+
+---
+
+## Funding & Investment
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Crunchbase Funding** | Rounds, investors, amounts, dates | Budget availability, growth stage | API costs limit access |
+| **AngelList/Wellfound** | Valuations, investor connections | Investment ecosystem | Fragmented with job data |
+| **SEC Filings** | Public company financials, acquisitions | Enterprise intelligence | Technical to parse |
+| **PitchBook (indirect)** | Funding via news/press releases | PE/VC activity | Requires creative sourcing |
+
+---
+
+## News & Press
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **TechCrunch** | Company mentions, funding news, launches | Tech industry timing | News = trigger events |
+| **PR Newswire / Business Wire** | Press releases, exec quotes | Corporate announcements | Real-time triggers overlooked |
+| **Industry Blogs** | Company mentions, thought leadership | Competitive intelligence | Requires domain-specific targeting |
+| **Company Newsrooms** | Direct PR, executive announcements | First-party company signals | Scattered across websites |
+
+---
+
+## Location & Real Estate
+
+| Source | What You Get | Sales Signal | Why Underused |
+|---|---|---|---|
+| **Google Maps** | Office locations, reviews, popular times | Physical presence, expansion | Underutilized for B2B |
+| **Commercial Real Estate Listings** | Office expansions, relocations | Growth/contraction signals | Niche but powerful |
+| **Coworking Space Directories** | Startup locations, company profiles | Early-stage discovery | Startups cluster in specific spaces |
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/list-building-deep-dives.md
+++ b/skills/alex-vacca/list-architect/references/list-building-deep-dives.md
@@ -1,0 +1,347 @@
+# List Building — Detailed Reference
+
+Deep dives into each phase, ICP construction, multi-source workflows, and the Apollo + Clay template.
+
+---
+
+## ICP Deep Dive: Building Your Ideal Customer Profile
+
+### Step 1: Analyze Your Best Customers
+
+Pull top 20–30 customers by: highest LTV, fastest close, lowest churn, highest NPS, easiest to work with.
+
+**Answer:**
+- What industries are they in?
+- What's their average company size?
+- What tools do they use?
+- What triggered them to buy?
+- What do they have in common?
+
+**Tool:** Export from CRM → enrich in Clay with firmographics/technographics → look for patterns.
+
+### Step 2: Analyze Your Worst Customers (Anti-ICP)
+
+Pull customers who: churned quickly, had long/painful sales cycles, required excessive support, low LTV.
+
+**Answer:**
+- What made them a bad fit?
+- What should have been a red flag?
+- What do they have in common?
+
+### Step 3: Interview Your Team
+
+- **Sales:** "Who closes fastest? Who's most excited about our product?"
+- **Customer Success:** "Who gets the most value? Easiest to onboard?"
+- **Marketing:** "What content resonates? What channels work best?"
+- **Product:** "Who uses the product most effectively?"
+
+### Step 4: Document Your ICP
+
+One-page document with must-haves, nice-to-haves, and disqualifiers (see template in SKILL.md).
+
+### Step 5: Score Your ICP
+
+Build a 0–100 scoring system in Clay as a formula column that auto-scores every company.
+
+**30-Minute Exercise:**
+1. List top 10 best customers
+2. Find 3 patterns they share
+3. List top 5 worst customers
+4. Find 2 patterns they share (anti-ICP)
+5. Write ICP hypothesis in one paragraph
+6. Create scoring rubric
+
+---
+
+## ICP Layer Details
+
+### Layer 1: Firmographics
+
+| Criteria | Questions | Example |
+|---|---|---|
+| Industry | What industries do best customers operate in? | SaaS, E-commerce, Manufacturing |
+| Company Size | How many employees? | 50–500 (mid-market) |
+| Revenue | Annual revenue range? | $10M–$100M ARR |
+| Location | HQ? Where do they operate? | US-based, expanding to EU |
+| Company Age | Startup vs established? | 3–10 years old |
+| Business Model | B2B, B2C, B2B2C? | B2B SaaS companies |
+| Funding Stage | Bootstrapped to PE-backed? | Series A-B |
+
+**Data sources:** Your CRM (best), LinkedIn Sales Nav, Clay enrichments, Clearbit, People Data Labs.
+
+### Layer 2: Technographics
+
+| Category | What to Look For | Why |
+|---|---|---|
+| CRM | Salesforce, HubSpot, Pipedrive | Sales sophistication, budget |
+| Marketing Automation | Marketo, Pardot, ActiveCampaign | Marketing maturity |
+| Sales Tools | Outreach, SalesLoft, Apollo | Active outbound motion |
+| Analytics | Segment, Amplitude, Mixpanel | Data-driven culture |
+| Infrastructure | AWS, GCP, Azure | Technical sophistication |
+| Complementary Tools | Tools that integrate with yours | Easy adoption path |
+| Competitor Tools | Using your competitors | Ripe for switching |
+
+**Data sources in Clay:** BuiltWith, Clearbit, 6sense, HG Insights.
+
+### Layer 3: Behavioral Signals
+
+| Signal | What to Track | Where to Find |
+|---|---|---|
+| Hiring | Roles related to your solution | LinkedIn, job boards, Clay job tracking |
+| Funding | Recent rounds | Crunchbase, PitchBook, news |
+| Expansion | New offices, new markets | News, LinkedIn, company websites |
+| Leadership Changes | New C-level hires | LinkedIn, press releases |
+| Product Launches | New products/features | Product Hunt, news, social |
+| Tech Stack Changes | Adding/removing tools | BuiltWith, technographic tracking |
+| Content Engagement | Downloads, pricing page visits | Your analytics, intent data |
+| Competitor Activity | Competitor mentions, visits | 6sense, Bombora, G2 |
+
+**In Clay:** Claygent for news monitoring, job change tracking, Crunchbase/PitchBook integrations, 6sense/Bombora for intent.
+
+### Layer 4: Psychographics
+
+| Indicator | How to Identify |
+|---|---|
+| Growth vs optimization mindset | Hiring velocity, funding, leadership messaging |
+| Innovation vs conservative | Tech stack (cutting-edge vs legacy), company age |
+| Data-driven culture | Analytics tools, data team size |
+| Customer-centric | NPS scores, CS team size, reviews |
+| Compliance-focused | Industry (healthcare, finance), certifications (SOC2, GDPR) |
+| Remote-first | Job postings, office locations, culture |
+
+**Research:** About page, careers page, blog, Glassdoor reviews, leadership LinkedIn posts, customer case studies, Claygent for website summaries.
+
+---
+
+## ICP Examples
+
+### Sales Engagement Platform
+- Industry: B2B SaaS, Professional Services, Agencies
+- Size: 50–500 employees, $5M–$50M revenue
+- Tech: Salesforce or HubSpot CRM
+- Signals: Hiring SDRs/AEs, raised Series A/B
+- Psychographics: Growth-focused, outbound sales motion
+
+### HR Tech Platform
+- Industry: Technology, Financial Services, Healthcare
+- Size: 200–2,000 employees, $20M–$200M revenue
+- Tech: Workday, BambooHR, or Greenhouse
+- Signals: Hiring HR Ops, headcount expanding >15% YoY
+- Psychographics: Employee experience-focused, remote-first
+
+### Marketing Automation Tool
+- Industry: E-commerce, DTC Brands, B2C SaaS
+- Size: 20–200 employees, $2M–$20M revenue
+- Tech: Shopify, Klaviyo, or Attentive
+- Signals: Launching new products, expanding to new channels
+- Psychographics: Data-driven, customer acquisition-focused
+
+---
+
+## Multi-Source Company Discovery: Detailed Workflows
+
+### Source 1: Clay Find Companies
+
+1. Create new table in Clay
+2. Add Source → Find Companies
+3. Set filters matching ICP (industry, employees, location, technologies, funding)
+4. Preview results → run source
+5. Use "OR" logic for technologies to maximize coverage
+6. Save filter templates for reuse
+
+**Cost:** Free to search; credits for enrichment columns.
+
+### Source 2: Apollo (CSV → Clay Import)
+
+1. Apollo.io → Company search
+2. Set same ICP filters
+3. Use keywords to narrow (e.g., "B2B SaaS" in description)
+4. Export as CSV (always include Domain field)
+5. Clay → new table → Import CSV → map columns
+
+**Cost:** Free tier: 50 exports/month | Basic $49/mo (10K) | Pro $79/mo (unlimited).
+
+### Source 3: LinkedIn Sales Navigator
+
+1. Sales Navigator → Company Search
+2. Advanced filters: headcount, growth %, hiring, posted recently, technologies
+3. Save as Lead List (max 2,500)
+4. Export via Phantombuster ($50–100/mo) or Evaboot
+5. Import to Clay
+
+**Unique filters:** Headcount Growth, Posted on LinkedIn, Hiring on LinkedIn.
+**Cost:** Core $99/mo | Advanced $149/mo + export tools.
+
+### Multi-Source Merge Workflow
+
+1. Table 1: Clay Companies (from Clay Find Companies)
+2. Table 2: Apollo Companies (from CSV import)
+3. Table 3: Merged — use "Write to Other Table" from both Table 1 and Table 2
+4. In Table 3: dedupe by Domain
+5. (Optional) Table 4: LinkedIn Sales Nav companies → write to Table 3 → dedupe again
+
+**Typical result:** 40–70% more companies than single source.
+
+### Advanced Strategies
+
+**Waterfall Sourcing:** Start with highest-quality source (LinkedIn with intent signals), add next source only if you need more volume.
+
+**Source by Segment:** Enterprise → ZoomInfo + LinkedIn; Mid-market → Clay + Apollo; Startups → Crunchbase + Clay.
+
+**Layered Sourcing:** Broad search (10K) → add intent signals (filter to 3K) → enrich and score (final 1K A-tier).
+
+---
+
+## Apollo + Clay Template: 6-Table Workflow
+
+### Table 1: Apollo Companies (CSV Import)
+- Import CSV from Apollo export
+- Key fields: Company name, domain, industry, employee count, revenue, location
+
+### Table 2: Clay Companies (Native Search)
+- Clay "Find Companies" source
+- Match Apollo search criteria
+
+### Table 3: Merged & Deduped Companies + Enrichment
+- "Write to Other Table" from Table 1 and Table 2 into Table 3
+- Dedupe by company domain
+- Add: company tiering logic (formula/AI), scoring, additional enrichment
+
+**Step-by-step merge:**
+1. Create blank Table 3 ("Merged Companies - Deduped")
+2. In Table 1: Add "Write to Other Table" column → select Table 3 → map fields → run all rows
+3. In Table 2: Add "Write to Other Table" column → select Table 3 → map same fields → run all rows
+4. In Table 3: Select Domain (or Company Name) column → click DeDupe → Value → delete duplicates
+5. Add enrichment columns (tiering, scoring, qualification)
+
+**Pro tips:**
+- Field mapping must be consistent across both source tables
+- Use run conditions to only write qualified companies
+- Re-running Write to Table will auto-update Table 3
+
+### Table 4: Apollo People
+- Import domains from Table 3 (filtered for qualified companies)
+- Apollo people search: job titles, seniority, departments
+
+### Table 5: Clay People
+- Same domains from Table 3
+- Clay "Find People" source with matching criteria
+
+### Table 6: Merged & Deduped People (Final Output)
+- Import from Table 4 and Table 5
+- Dedupe by email (primary) or name + company domain
+- Final enrichment: email validation, phone waterfalls, personalization data, AI messaging
+- **Output: final list ready for outreach**
+
+---
+
+## Local Prospecting
+
+For clients selling to local businesses (gyms, clinics, logistics, real estate, etc.) that don't appear in Apollo/LinkedIn.
+
+### Option A: Openmart + Clay (US-based)
+1. Use [Openmart](https://openmart.ai/) to find local leads by category/location
+2. Export → clean CSV
+3. Import to Clay → enrich (email, website, LinkedIn, owner/decision-maker)
+
+### Option B: Google Maps Scraping via Clay
+1. Clay's Google Maps integration → search by type + location
+2. Pull: name, website, address, phone
+3. Enrich: email, LinkedIn, ownership data
+
+### Option C: Directory Scraping
+1. Find niche directory (Clutch.co, local chambers, industry associations)
+2. Use [Instant Data Scraper](https://chromewebstore.google.com/detail/data-scraping-tool/ejcgomaeiikgjcebfmhaoddenaijpgfb) Chrome extension
+3. Export CSV → import to Clay → enrich
+4. If domain missing: use Claygent to find company website from name
+
+See [list-building-directories.md](list-building-directories.md) for curated industry-specific directories.
+
+---
+
+## TAM Scoping via DiscoLike
+
+**When to use:** When Apollo, Clay, and LinkedIn aren't finding your targets.
+
+**What it does:** Discovers lookalike websites based on keywords and tech tags — not limited to LinkedIn data.
+
+**Pros:**
+- Finds net-new companies outside typical B2B databases
+- Search based on one or multiple sites (like Ocean.io)
+- Filter by country or language
+
+**Cons:**
+- No built-in firmographic data (or very limited)
+- Higher enrichment cost (~1 credit per row to qualify)
+
+**Tips:**
+- If too many results: tweak similarity variance and company start date
+- Helps avoid missing high-potential lookalikes due to volume caps
+
+---
+
+## Contact Enrichment Best Practices
+
+### Email Waterfalls
+Use 3–5 providers sequentially — if provider 1 misses, try provider 2, etc.
+- LeadMagic, Prospeo, Findymail for personal emails
+- Catch-all/generic as fallback
+- Always validate to remove bounces
+
+### Phone Waterfalls
+Same principle for direct dials and mobile numbers — multiple providers for coverage.
+
+### Data Provider Performance
+Review [Clay's data provider tests](https://www.clay.com/data-tests) for provider performance by specific regions and use cases.
+
+### Deduplication Strategy
+1. **Company level:** Dedupe by domain BEFORE finding people (saves credits)
+2. **People level:** Dedupe by email after merging sources
+   - Alternative: dedupe by full name (saves credits, small risk of false dedupes)
+3. **Sequencer safety net:** Enable "Skip lead if in Workspace" in Instantly/Smartlead/etc.
+
+---
+
+## Common ICP Mistakes
+
+- **Too broad:** "Any company with 10+ employees" — can't afford to target everyone
+- **Too narrow:** "Only fintech in SF with exactly 150 employees" — TAM too small
+- **Based on assumptions, not data:** Talk to customers, analyze CRM
+- **Static ICP:** Markets change, revisit quarterly
+- **Ignoring anti-ICP:** Knowing who NOT to target is equally important
+- **No scoring system:** Without scoring, every lead looks the same
+
+---
+
+## Tools Quick Reference
+
+### Data Sources
+- Clay Find Companies (built-in)
+- Apollo (apollo.io, free tier available)
+- LinkedIn Sales Navigator ($99/mo, 30-day trial)
+- ZoomInfo (enterprise, $15K–$30K/year)
+- Crunchbase ($29–$99/mo)
+
+### Export/Scraping
+- Phantombuster (LinkedIn scraping)
+- Evaboot (LinkedIn Sales Nav export)
+- Instant Data Scraper (Chrome extension, free)
+- Apify (web scraping)
+- Claygent (built-in AI web research)
+
+### Enrichment in Clay
+- Clearbit — firmographics, technographics
+- BuiltWith — tech stack data
+- People Data Labs — company data
+- Crunchbase — funding data
+- Claygent — custom research (values, news)
+
+### Data Quality
+- Clay deduplication (built-in)
+- Email validation providers (LeadMagic, Prospeo, Findymail)
+- Clay formulas — custom scoring logic
+- AI columns — evaluate fit based on criteria
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/list-building-directories.md
+++ b/skills/alex-vacca/list-architect/references/list-building-directories.md
@@ -1,0 +1,308 @@
+# Web Scraper Directory Index
+
+Use this as a jump-off directory for free or mostly-free company lists by industry. Scrape with [Instant Data Scraper](https://chromewebstore.google.com/detail/data-scraping-tool/ejcgomaeiikgjcebfmhaoddenaijpgfb) → export CSV → import to Clay → enrich.
+
+---
+
+## Accommodation / Hospitality
+
+1. **Coresignal – Hospitality** — coresignal.com/discover/hospitality/ (partial free)
+2. **The Org – Hotels & Hospitality** — theorg.com/explore/industries/hotels-hospitality (10K+ companies, free)
+3. **HotelDirectory.ws** — hotels/hostels/motels by country (free)
+4. **HotelsMag "The List"** — top hotel chains by rooms (free PDF)
+5. **HotelBusiness – Owners & Developers Report** — hotel owners/developers (free PDF)
+6. **NIIR Directory – Hotels/Restaurants/Resorts (India)** — 29,300 establishments (free PDF)
+7. **PIC M Europe – Accommodation Companies** — major EU hotel/hospitality companies (free PDF)
+8. **ContactOut – Hospitality Directory** — contactout.com/company-directory/industries/hospitality (partial free)
+9. **Growjo – Top 500 Hospitality** — growjo.com/industry/Hospitality (free)
+10. **Bounce Watch – Hospitality Industry** — bouncewatch.com (250+ companies, free)
+11. **EasyLeadz – Hospitality Companies** — easyleadz.com (free download)
+12. **Franchiserankings.com** — hotel franchise companies (free)
+13. **Ranker – Hospitality Companies** — ranker.com (free)
+14. **Lemon Directory – Travel/Hospitality** — lemon-directory.com (170+ listed, free)
+15. **HubSpot Marketplace – Tourism/Travel** — ecosystem.hubspot.com (575+ agencies, free)
+16. **BookDomits – Top 100 Hospitality** — bookdomits.com (curated list, free)
+
+---
+
+## Agriculture
+
+1. **Datanyze – Top Agriculture** — datanyze.com (partial free)
+2. **CoreSignal – Agriculture** — coresignal.com (partial free)
+3. **F6S – Agriculture Companies** — f6s.com/companies/agriculture/mo (free)
+4. **Mergr – Agriculture** — mergr.com/companies/agriculture (partial free)
+5. **Craft.co – Agriculture** — craft.co (partial free)
+6. **Crunchbase – Agriculture Hub** — crunchbase.com (partial free)
+7. **CompaniesMarketCap – Agriculture** — companiesmarketcap.com (free)
+8. **Wikipedia – Agriculture companies by country** — en.wikipedia.org (free)
+
+---
+
+## Automotive
+
+1. **Mergr – Automotive** — mergr.com/companies/public/automotive (partial free)
+2. **CompanyData – Top 50 Automotive** — companydata.com (partial free)
+3. **Wikipedia – Automobile Manufacturers** — en.wikipedia.org (free)
+4. **CompaniesMarketCap – Automakers by Revenue** — companiesmarketcap.com (free)
+5. **B2BMap – Automotive Directory** — b2bmap.com (free)
+6. **F6S – Automotive** — f6s.com (free)
+7. **Crunchbase – Automotive Hub** — crunchbase.com (partial free)
+8. **CoreSignal – Automotive** — coresignal.com (partial free)
+
+---
+
+## Construction
+
+1. **ENR – Top 400 Contractors / Top 500 Design Firms** — enr.com (partial free)
+2. **ConstructConnect – Rankings** — constructconnect.com (free)
+3. **BD+C – Giants 400** — bdcnetwork.com (free)
+4. **The Blue Book** — thebluebook.com (largest US construction directory, free)
+5. **ThomasNet – Construction** — thomasnet.com (free)
+6. **Clutch – Construction Companies** — clutch.co (free)
+7. **Fortune 1000 – Construction** — fortune.com (free)
+8. **Forbes Global 2000 – Construction** — forbes.com (free)
+9. **CompaniesMarketCap – Construction** — companiesmarketcap.com (free)
+10. **Europages – Construction** — europages.co.uk (free)
+11. **Kompass – Construction** — kompass.com (free)
+12. **YellowPages – Construction** — yellowpages.com (free)
+13. **Dodge Construction Network** — construction.com (partial free)
+14. **LinkedIn – Construction Industry** — linkedin.com (partial free)
+15. **Glassdoor – Construction** — glassdoor.com (free)
+16. **Wikipedia – Construction Companies** — en.wikipedia.org (free)
+
+---
+
+## Cybersecurity
+
+1. **Info Security Index** — online directory of cybersecurity companies
+2. **F6S – Cyber Security** — f6s.com
+3. **Wikipedia – Computer Security Companies** — en.wikipedia.org
+4. **Techreviewer – Cybersecurity** — techreviewer.co
+5. **Return on Security – Public Cybersecurity Tracker** — market cap tracker
+6. **Feedbax – Cybersecurity** — feedbax.com
+7. **GeeksforGeeks – Top Cybersecurity Companies** — geeksforgeeks.org
+8. **CybersecurityList.org** — global solutions directory
+
+---
+
+## E-Commerce Marketplaces
+
+1. **Wikipedia – Online Marketplaces** — en.wikipedia.org (free)
+2. **CS-Cart – Top 150 eCommerce** — cs-cart.com (free)
+3. **Yo!Kart – Top 50 Multi-vendor** — yo-kart.com (free)
+4. **Shopify – 20 Online Marketplaces** — shopify.com (free)
+5. **Similarweb – Top Ecommerce by Traffic** — similarweb.com (free)
+6. **CompaniesMarketCap – E-commerce** — companiesmarketcap.com (free)
+7. **Statista – Biggest Marketplaces** — statista.com (free chart)
+
+---
+
+## Education
+
+1. **HolonIQ – Global Education 1000** — holoniq.com (partial free)
+2. **EdSurge Company Index** — edsurge.com (free)
+3. **GSV EdTech Lists** — asugsvsummit.com (free)
+4. **QS World University Rankings** — topuniversities.com (free)
+5. **THE World University Rankings** — timeshighereducation.com (free)
+6. **EdTech Digest Awards** — edtechdigest.com (free)
+7. **Global EdTech Awards** — globaledtechawards.org (free)
+8. **Education Industry Association – Members** — educationindustry.org (free)
+9. **IAU World Higher Education Database** — iau-aiu.net (free)
+10. **Crunchbase – Education** — crunchbase.com (partial free)
+11. **F6S – Education** — f6s.com (free)
+12. **BuiltWith – Education Technology** — trends.builtwith.com (partial free)
+
+---
+
+## Financial Services
+
+1. **FintechVendors.com** — 4,500+ fintech providers (free)
+2. **International FinTech Directory** — 5,000+ companies (free)
+3. **Mergr – Financial Services** — mergr.com (partial free)
+4. **CoreSignal – Financial Services** — 520K+ entries (partial free)
+5. **OpenCorporates** — filter by SIC/NAICS codes (free, open-license)
+6. **Wikipedia – Largest Financial Services by Revenue** — en.wikipedia.org (free)
+7. **EasyLeadz – Financial Services** — easyleadz.com (free download)
+8. **BuiltIn – Fintech Lists** — builtin.com (free)
+9. **F6S – Financial Services** — f6s.com (free)
+10. **Dealroom – Fintech** — dealroom.co (partial free)
+
+---
+
+## Food & Beverage
+
+1. **FoodProcessing.com – Top 100** — foodprocessing.com (free)
+2. **GigaSheet – F&B Businesses CSV** — 126K+ businesses (free download)
+3. **Food Engineering – Top 100 PDF** — foodengineeringmag.com (free)
+4. **Wikipedia – Largest F&B Companies** — en.wikipedia.org (free)
+5. **WorldOstats – F&B by Revenue** — worldostats.com (free)
+6. **CoreSignal – F&B** — coresignal.com (partial free)
+7. **Datanyze – F&B** — datanyze.com (partial free)
+
+---
+
+## Gaming & E-Sports
+
+1. **CoreSignal – Gaming** — coresignal.com
+2. **MobyGames – All Video Game Companies** — mobygames.com
+3. **Wikipedia – Largest Game Companies by Revenue** — en.wikipedia.org
+4. **F6S – eSports** — f6s.com
+5. **Crunchbase – Esports Hub** — crunchbase.com
+6. **Esports Charts – Organizations** — escharts.com
+7. **TEN.gg – Esports Directory** — ten.gg
+8. **Liquipedia** — liquipedia.net
+
+---
+
+## Healthcare
+
+1. **Fortune 500 – Healthcare** — fortune.com (free)
+2. **CMS Provider Data Catalog** — data.cms.gov (CSV downloads, free)
+3. **Medicare Care Compare** — medicare.gov (free)
+4. **ClinicalTrials.gov – Sponsors API** — clinicaltrials.gov (free)
+5. **openFDA – Manufacturers** — open.fda.gov (free)
+6. **PhRMA Members** — phrma.org (free)
+7. **BIO Members** — bio.org (free)
+8. **AdvaMed – Medical Device Directory** — advamed.org (free)
+9. **Healthgrades – Hospital Directory** — healthgrades.com (free)
+10. **US News – Best Hospitals** — health.usnews.com (free)
+11. **CompaniesMarketCap – Healthcare** — companiesmarketcap.com (free)
+12. **F6S – Healthcare Startups** — f6s.com (free)
+13. **Wellfound – Healthcare** — wellfound.com (free)
+14. **Crunchbase – Healthcare** — crunchbase.com (partial free)
+
+---
+
+## HR / Recruitment
+
+1. **G Recruiter – Global Directory** — grecruiter.com (free)
+2. **Global Recruiters Info** — globalrecruitersinfo.com (free)
+3. **Headhunters Directory** — headhuntersdirectory.com (free)
+4. **Online Recruiters Directory** — onlinerecruitersdirectory.com (free)
+5. **Clutch – Recruiting Firms** — clutch.co (free)
+6. **50Pros – HR Recruiting** — 50pros.com (free)
+7. **HRO Today – Recruitment Resource Guide** — hrotoday.com (free PDF)
+
+---
+
+## Legal & Compliance
+
+1. **F6S – Legal Compliance** — f6s.com (free)
+2. **CoreSignal – Legal Services** — 500K+ firms (partial free)
+3. **Global Law Lists** — globallawlists.org (240+ countries, free)
+4. **Avvo – Lawyer Directory** — avvo.com (free)
+5. **FindLaw – Legal Professionals** — findlaw.com (free)
+6. **OpenCorporates** — filter by SIC/NAICS (free)
+7. **EasyLeadz – Law Firms** — easyleadz.com (free download)
+
+---
+
+## Manufacturing
+
+1. **ThomasNet – US Industrial/Manufacturing** — thomasnet.com (free)
+2. **IndustryWeek – IW 500** — industryweek.com (free)
+3. **Made-in-China** — made-in-china.com (free)
+4. **IndiaMART** — indiamart.com (free)
+5. **Alibaba – Global Manufacturers** — alibaba.com (free)
+6. **ENR – Top Contractors** — enr.com (partial free)
+7. **DirectIndustry** — directindustry.com (free)
+8. **ICIS – Top 100 Chemical Companies** — icis.com
+9. **Pharmaceutical Technology – Top Pharma** — pharmaceutical-technology.com
+10. **Medical Design & Outsourcing – Device Manufacturers** — medicaldesignandoutsourcing.com
+11. **Fibre2Fashion – Textile/Apparel** — fibre2fashion.com
+12. Plus 25+ more niche manufacturing directories (OICA automotive, ASD aerospace, HVACR, etc.)
+
+---
+
+## Marketing & Advertising
+
+1. **Agency Spotter – Top 100** — agencyspotter.com (free)
+2. **Agency Spotter – Full Directory** — 4,000+ agencies (free)
+3. **DesignRush – Ad/Marketing** — 40,000+ agencies (free)
+4. **Clutch – Marketing & Advertising** — clutch.co (free)
+5. **Sortlist – Agency Listings** — sortlist.com (free)
+6. **Agency List** — agencylist.org (free)
+7. **ByteScraper – US Ad Agencies** — 25,000+ agencies (free)
+8. **EasyLeadz – Marketing Agencies USA** — easyleadz.com (free download)
+
+---
+
+## Non-Profit & NGOs
+
+1. **NGObase – Global Directory** — ngobase.org
+2. **GlobalGiving Atlas** — globalgiving.org
+3. **Idealist.org – Nonprofit Directory** — idealist.org
+4. **NCCS – National Center for Charitable Statistics** — nccs.urban.org
+5. **NgoEra – Top 100 NGOs** — ngoera.com
+
+---
+
+## SaaS Companies
+
+1. **SaaS Mag – SaaS 1000** — saasmag.com (free, quarterly updates)
+2. **G2 – Top Software Companies** — g2.com (free)
+3. **SaaSHub** — saashub.com (free)
+4. **PublicSaaSCompanies.com** — free database of US-listed SaaS
+5. **GetLatka – Revenue-ranked SaaS** — getlatka.com (many lists free)
+6. **Built In – SaaS Company Lists** — builtin.com (free)
+7. **Dealroom – SaaS** — dealroom.co (partial free)
+8. **F6S – SaaS** — f6s.com (free)
+9. **Crunchbase – SaaS** — crunchbase.com (partial free)
+10. **Capterra / GetApp** — capterra.com (free)
+11. **Product Hunt** — producthunt.com (free)
+12. **BuildInPublic.cloud** — 500+ SaaS built in public (free)
+13. **Open-source SaaS directories on GitHub** — github.com (free)
+
+---
+
+## Scientific Research & Academia
+
+1. **GRID – Global Research Identifier Database** — grid.ac
+2. **SCImago Institutions Rankings** — scimagoir.com
+3. **Nature Index** — nature.com/nature-index
+4. **OpenAlex** — openalex.org
+5. **Research.com – University Rankings** — research.com
+
+---
+
+## Sports & Betting
+
+1. **Top100Bookmakers** — top100bookmakers.com
+2. **ListOfAllBookmakers.com** — full list
+3. **OLBG – UK Betting Sites** — olbg.com
+4. **Similarweb – Top Sports Betting** — similarweb.com
+
+---
+
+## Telecommunications
+
+1. **Wikipedia – Telecom Companies** — en.wikipedia.org (free)
+2. **dgtlinfra – Top 100 Telecom** — dgtlinfra.com (free)
+3. **CompaniesMarketCap – Telecom** — companiesmarketcap.com (free)
+4. **F6S – Telecom US** — f6s.com (free)
+5. **Crunchbase – Telecom Hub** — crunchbase.com (10K+ companies, partial free)
+6. **Datanyze – Telecom** — datanyze.com (partial free)
+
+---
+
+## Travel & Transportation
+
+1. **TourRadar – Tour Operator Directory** — tourradar.com (free)
+2. **Freightnet – Freight/Logistics** — freightnet.com (free)
+3. **CoreSignal – Travel/Transportation** — coresignal.com (partial free)
+4. **EasyLeadz – Travel/Tourism** — easyleadz.com (free download)
+5. **SimilarWeb – Top Transportation Sites** — similarweb.com (partial free)
+6. **BusinessBooky – Travel Directory** — businessbooky.com (free)
+
+---
+
+## Pricing & Competitive Intelligence
+
+1. **G2 – Pricing Software** — g2.com (free)
+2. **Ensun – Top 100 CI Companies** — ensun.com
+3. **F6S – Competitive Intelligence** — f6s.com
+4. **Greenbook – Market/CI Providers** — greenbook.org
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/list-building-framework.md
+++ b/skills/alex-vacca/list-architect/references/list-building-framework.md
@@ -1,0 +1,277 @@
+# B2B List Building
+
+List building isn't about getting the *most* contacts — it's about getting the *right* contacts with the *right* data to enable personalized, relevant outreach. Quality > Quantity, always.
+
+## The 3 Pillars
+
+1. **Coverage** — Cast a wide net (multi-source)
+2. **Enrichment** — Add context & intelligence
+3. **Precision** — Filter & prioritize
+
+---
+
+## The 8-Phase Framework
+
+| Phase | What You Do | Key Outcome |
+|---|---|---|
+| 1. Define ICP | Firmographics, technographics, signals, psychographics | Targeting criteria |
+| 2. Company Discovery | Multi-source search (Clay + Apollo + LinkedIn + more) | Raw company list (80–90% TAM coverage) |
+| 3. Company Enrichment & Scoring | Validate firmographics, add signals, tier A/B/C | Prioritized company list |
+| 4. People Discovery | Multi-source people search at tiered companies | Raw contact list |
+| 5. Contact Enrichment & Validation | Email waterfalls, phone waterfalls, LinkedIn URLs | Verified contact data |
+| 6. Deduplication | Dedupe at company level (domain) AND people level (email/name) | Clean, no-duplicate list |
+| 7. Personalization & Segmentation | Segment by industry/size/persona/signal, add AI icebreakers | Campaign-ready segments |
+| 8. Activation | Push to CRM, sequencer, or export | Outreach launched |
+
+For detailed walkthroughs of each phase, see [list-building-deep-dives.md](list-building-deep-dives.md).
+For industry-specific directories to scrape, see [list-building-directories.md](list-building-directories.md).
+For the full 62 data sources table, see [list-building-data-sources.md](list-building-data-sources.md).
+
+---
+
+## Golden Rules
+
+1. **Multi-source everything.** One provider = 50–60% coverage. Two providers = 80–90%. The math is simple.
+2. **Enrich before you reach out.** Raw lists convert at 1–2%. Enriched, scored, personalized lists convert at 5–15%.
+3. **Dedupe religiously.** Duplicates kill deliverability and credibility. Always dedupe at company AND people level.
+4. **Validate emails.** 30–40% of emails in databases are invalid. Validation saves your sender reputation.
+5. **Personalization at scale.** Use AI to personalize, but always based on real data points (not generic fluff).
+6. **Test & iterate.** Track which sources give best data, which enrichments correlate with conversions, which segments perform best.
+
+---
+
+## Phase 1: ICP (Ideal Customer Profile)
+
+### Why It Matters
+
+- Right-fit companies convert **3–5x higher** than spray-and-pray
+- Shortens sales cycles (they have the pain, budget, authority)
+- Improves retention (ICP-fit customers churn less)
+
+**"Our product works for everyone!" = the mistake most beginners make.**
+
+### The 4-Layer Framework
+
+| Layer | What It Covers | Example Criteria |
+|---|---|---|
+| **Firmographics** | Industry, size, revenue, location, funding stage | B2B SaaS, 100–500 employees, $10M–$50M ARR, Series A-B |
+| **Technographics** | Tech stack, tools, platforms | Uses Salesforce + Outreach/SalesLoft, has marketing automation |
+| **Behavioral Signals** | Hiring, funding, expansion, leadership changes | Recently raised Series B, hiring RevOps, expanding to EU |
+| **Psychographics** | Growth mindset, innovation vs stability, data-driven culture | Hypergrowth, early adopter, customer-centric |
+
+### ICP Scoring System
+
+Build a formula column in Clay:
+
+| Criteria | Points |
+|---|---|
+| Right industry | +20 |
+| Right company size | +20 |
+| Right revenue range | +15 |
+| Uses key tech | +15 |
+| Recent funding | +10 |
+| Hiring for relevant role | +10 |
+| Target location | +10 |
+
+**Tiers:**
+- **A-tier (80–100):** Perfect fit, prioritize
+- **B-tier (60–79):** Good fit, pursue
+- **C-tier (40–59):** Okay fit, nurture
+- **D-tier (<40):** Poor fit, disqualify
+
+### ICP Document Template
+
+**Must-Haves (Non-negotiable):**
+- Industry: [X, Y, Z]
+- Company size: [X–Y employees]
+- Revenue: [$X–$Y]
+- Location: [Regions]
+- Tech stack: [Must use X tool]
+
+**Nice-to-Haves (Bonus):**
+- Funding stage, hiring signals, complementary tools
+
+**Disqualifiers (Anti-ICP):**
+- Too small, wrong industry, wrong tech stack
+
+For the full ICP deep dive (how to build, examples, common mistakes), see [list-building-deep-dives.md](list-building-deep-dives.md).
+
+---
+
+## Phase 2: Multi-Source Company Discovery
+
+### The Coverage Problem
+
+| Strategy | Coverage | Companies Found (out of 10K TAM) |
+|---|---|---|
+| Single source | ~60% | 6,000 |
+| Two sources | ~85% | 8,500 |
+| Three sources | ~92% | 9,200 |
+
+**Two sources = 42% more companies than one.**
+
+### Source Selection Matrix
+
+| Your ICP | Primary | Secondary | Tertiary |
+|---|---|---|---|
+| Tech/SaaS (US/EU) | Clay Find Companies | Apollo | LinkedIn Sales Nav |
+| Enterprise (Fortune 500) | ZoomInfo | LinkedIn Sales Nav | Apollo |
+| Startups (funded) | Crunchbase | Clay Find Companies | LinkedIn Sales Nav |
+| International (Asia, LATAM) | Apollo | LinkedIn Sales Nav | Local directories |
+| Non-tech (Manufacturing, Retail) | Apollo | LinkedIn Sales Nav | Industry directories |
+| Niche markets | Web scraping/Claygent | Apollo | Industry associations |
+
+### Primary Sources
+
+**Clay Find Companies**
+- Best for: Tech/SaaS, US/EU, technographic filtering
+- 60M+ companies, built into Clay
+- Weakness: weaker in Asia/LATAM, traditional/offline businesses
+
+**Apollo**
+- Best for: Broad coverage, international, non-tech industries
+- 250M+ contacts, 60M+ companies
+- Export: CSV → import to Clay
+- Free tier: 50 exports/month
+
+**LinkedIn Sales Navigator**
+- Best for: Most current data, growth signals (headcount growth, hiring, recent posts)
+- Unique filters not available elsewhere
+- Export via Phantombuster, Evaboot, or manually
+- $99–$149/month
+
+### Specialized Sources
+
+- **ZoomInfo** — enterprise, high-accuracy ($15K–$30K/year)
+- **Crunchbase** — funded startups, recent funding rounds ($29–$99/month)
+- **Web Scraping / Claygent** — niche directories, association lists, conference attendees
+- **Your CRM** — closed-lost (6+ months = gold), churned, upsell
+
+### Alternative Discovery Methods
+
+**Local Prospecting** (when targets don't show up in B2B databases):
+- **Openmart** — US-based local businesses
+- **Google Maps scraping via Clay** — any niche with physical presence
+- Import → Clay → enrich
+
+**Directory Scraping:**
+- Use Instant Data Scraper (Chrome extension)
+- Export CSV → import to Clay → enrich
+- See [list-building-directories.md](list-building-directories.md) for industry-specific sources
+
+**TAM Scoping via DiscoLike:**
+- Discovers lookalike websites based on keywords/tech tags
+- Not limited to LinkedIn data
+- Good when Apollo/Clay/LinkedIn fail
+- ~1 credit per row to qualify
+- Filter by country, language, similarity variance, company start date
+
+---
+
+## Phase 3: Company Enrichment & Scoring
+
+**Must-have enrichments:**
+- Firmographics validation (employee count, revenue, location)
+- Technographics (tech stack = shows budget and sophistication)
+- Funding/financials (recent funding = budget to spend)
+- Hiring signals (hiring for roles related to your solution = active need)
+- News/triggers (expansion, leadership changes, product launches)
+
+**Then tier/score:** A-tier → B-tier → C-tier using formulas or AI in Clay.
+
+---
+
+## Phase 4: People Discovery
+
+Multi-source again:
+1. **Apollo People Search** — good coverage, job title filtering
+2. **Clay's Find People** — different data set, finds people Apollo misses (and vice versa)
+3. **LinkedIn scraping** — most current, slower/more expensive, harder to scrape over time
+4. **Waterfall approach** — try multiple sources per company to maximize contact discovery
+
+---
+
+## Phase 5: Contact Enrichment & Validation
+
+**Email waterfalls** (3–5 providers):
+- LeadMagic, Prospeo, Findymail, etc.
+- Personal emails first, catch-all/generic as fallback
+- Validation to remove bounces
+
+**Phone waterfalls** (if cold calling):
+- Direct dials, mobile numbers
+- Multiple providers for coverage
+
+**Personalization data:**
+- Recent job changes, education, location, interests
+- Company news, recent posts, mutual connections
+
+See [Clay's data provider tests](https://www.clay.com/data-tests) for provider performance by region.
+
+---
+
+## Phase 6: Deduplication (Critical)
+
+Dedupe at **two levels:**
+
+1. **Company level** — dedupe by domain before finding people
+2. **People level** — dedupe by email (or full name to save credits, accepting small risk of false deduplication)
+
+**Why:** Duplicate outreach = spam = blacklisted domain. Never skip this.
+
+**Sequencer safeguard:** Most tools (Instantly, Smartlead, HeyReach, Lemlist) have "Skip lead if in Workspace" toggle — use it as a safety net, not a replacement for proper deduplication.
+
+---
+
+## Phase 7: Personalization & Segmentation
+
+**Segment by:**
+- Industry (different messaging)
+- Company size (different pain points)
+- Persona (different value props)
+- Trigger/signal (different hooks)
+
+**Add personalization columns:**
+- AI-generated icebreakers referencing recent news, posts, achievements
+- Custom first lines based on tech stack, hiring signals
+- Relevant case studies/social proof from their industry
+
+---
+
+## Phase 8: Activation
+
+**Options:**
+- **CRM sync** — push to Salesforce, HubSpot (with deduplication)
+- **Sequencer** — Instantly, Smartlead, Lemlist, Outreach
+- **Manual export** — CSV for one-off campaigns
+- **Clay campaigns** — send directly from Clay
+
+**Conditional logic:** Only push A-tier to expensive sequences, B-tier to nurture, C-tier to content campaigns.
+
+---
+
+## Common Mistakes
+
+- Using only one data source (leaving 40% of TAM on the table)
+- Skipping enrichment (raw data = low conversion)
+- No deduplication (kills deliverability)
+- Generic personalization ("I saw you work in tech" is not personalization)
+- Not validating emails (bounces destroy sender reputation)
+- Treating all leads equally (tier and prioritize)
+- Building lists without a clear ICP (garbage in = garbage out)
+- Static ICP (revisit quarterly based on what actually converts)
+- Ignoring anti-ICP (knowing who NOT to target is equally important)
+
+---
+
+## Key Principle
+
+List building is not a one-time task — it's an ongoing system. The best teams:
+- Refresh lists monthly (data decays ~30% per year)
+- Continuously test new data sources
+- Refine ICP based on what actually converts
+- Build feedback loops from sales to improve targeting
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/persona-mapping-framework.md
+++ b/skills/alex-vacca/list-architect/references/persona-mapping-framework.md
@@ -1,0 +1,286 @@
+# Persona Mapping — Framework
+
+How to identify, segment, and target personas within ABM accounts. Mapping personas to their jobs-to-be-done (JTBDs), pain points, and messaging.
+
+---
+
+## The Persona Mapping Principle
+
+ABM targets *accounts*, but people buy — not companies. Persona mapping answers:
+1. **Who** at the target account should see your ads?
+2. **What** do they care about? (JTBDs, pain points)
+3. **How** should messaging differ by persona?
+4. **When** should BDRs reach out to which persona?
+
+---
+
+## Identifying Personas
+
+### Step 1: Analyze Your Closed-Won Deals
+
+Look at your CRM data for closed-won deals:
+
+| Question | What You're Looking For | Source |
+|---|---|---|
+| Who was the primary contact on won deals? | Most common titles/roles | CRM deal contacts |
+| Who initiated the buying process? | Champion persona | CRM first touch data |
+| Who signed the contract? | Economic buyer persona | CRM deal owner notes |
+| Who else was involved in evaluation? | Buying committee members | CRM activity log, call notes |
+| What was their typical seniority? | IC vs Manager vs VP vs C-suite | CRM contact properties |
+
+### Step 2: Map the Buying Committee
+
+Most B2B deals involve 6-10 stakeholders. Map the roles:
+
+| Role | Definition | Example Titles | Engagement Priority |
+|---|---|---|---|
+| **Champion** | Internal advocate who drives the deal | Product Manager, Head of Ops, Director of Growth | Primary — warm them first |
+| **Economic Buyer** | Controls budget, signs the contract | VP/C-suite, Finance | Engage after champion is warm |
+| **Technical Evaluator** | Assesses product capabilities | Engineering Lead, Solutions Architect, IT | Engage during demo/trial stage |
+| **End User** | Will use the product daily | Analyst, Designer, Specialist, IC | Engage with product-focused content |
+| **Blocker/Gatekeeper** | Can slow or kill the deal | Legal, Procurement, IT Security | Address concerns proactively |
+
+### Step 3: Define Persona Attributes
+
+For each persona, document:
+
+| Attribute | What to Capture | Example |
+|---|---|---|
+| **Title patterns** | Common job titles | "Product Manager", "Head of Product", "VP Product" |
+| **Seniority** | IC / Manager / Director / VP / C-suite | Manager - Director |
+| **Function** | Department/team | Product, Engineering, Marketing |
+| **JTBD** | Job to be done — what they're trying to accomplish | "Improve user onboarding to reduce churn" |
+| **Pain points** | What's frustrating them today | "Can't see where users drop off", "Manual onboarding flows" |
+| **Success metrics** | How their performance is measured | Activation rate, time-to-value, NPS |
+| **Content preferences** | What content resonates | Case studies, data/benchmarks, peer recommendations |
+| **Buying role** | Champion / Economic Buyer / Evaluator / User / Blocker | Champion |
+
+---
+
+## Persona Enrichment with Clay
+
+### Custom Properties to Enrich
+
+When building contact lists in Clay, enrich beyond standard fields:
+
+| Property | How to Enrich | Why |
+|---|---|---|
+| **Persona** (custom) | Map from title using Clay AI/rules | Enables persona-specific campaigns |
+| **Seniority** (custom) | Map from title (IC/Manager/Director/VP/C-Suite) | Different messaging by seniority |
+| **Function** | Extract from LinkedIn profile | Department-specific JTBDs |
+| **LinkedIn URL** | Apollo / Clay | For LinkedIn outreach + audience matching |
+| **Verified email** | Email waterfall in Clay | For outreach sequences |
+
+### Persona Assignment Rules
+
+Create rules in Clay to auto-assign personas:
+
+```
+IF title contains "Product Manager" OR "PM" OR "Head of Product" OR "VP Product" OR "CPO":
+  → Persona = "Product"
+
+IF title contains "UX" OR "UI" OR "Designer" OR "Design Lead":
+  → Persona = "UX/Design"
+
+IF title contains "Marketing" OR "Growth" OR "PMM" OR "Demand Gen":
+  → Persona = "Marketing"
+
+IF title contains "CTO" OR "VP Engineering" OR "Engineering Manager":
+  → Persona = "Engineering"
+
+IF title contains "CEO" OR "COO" OR "Founder" OR "General Manager":
+  → Persona = "Executive"
+
+IF title contains "Customer Success" OR "CX" OR "Support":
+  → Persona = "Customer Success"
+```
+
+---
+
+## Persona-Based Messaging
+
+### Messaging Matrix
+
+| Persona | Primary JTBD | Pain Point | Messaging Angle | Ad Content Example |
+|---|---|---|---|---|
+| **Product** | Improve user activation/retention | Can't see user behavior, manual processes | "See exactly where users drop off" | Product analytics screenshots, feature walkthrough |
+| **UX/Design** | Create better user experiences | No data on user flows, guesswork | "Design based on real user behavior" | Session replay demo, heatmap visuals |
+| **Marketing** | Drive pipeline, prove ROI | Can't attribute conversions, poor lead quality | "Know which campaigns actually drive revenue" | ROI dashboards, attribution data |
+| **Engineering** | Ship faster, reduce tech debt | Too many tools, complex integrations | "One platform, simple integration" | API docs, integration showcase |
+| **Executive** | Hit revenue/growth targets | Slow growth, high churn, team misalignment | "Companies like yours grew X% with us" | Case study with numbers, ROI calculator |
+| **Customer Success** | Reduce churn, improve NPS | Can't identify at-risk users proactively | "Spot churn risk before it's too late" | Health score dashboards, alert demos |
+
+### Messaging by ABM Stage
+
+| Stage | Product Persona | Executive Persona | UX Persona |
+|---|---|---|---|
+| **Awareness** | Industry trend / thought leadership about user analytics | "CEOs at top SaaS companies are investing in..." | Design community content, UX best practices |
+| **Interested** | Feature comparison vs competitors | ROI data, business impact numbers | Session replay deep-dive, workflow demos |
+| **Considering** | Product demo, free trial, technical walkthrough | Case study from peer company, executive briefing | Design-focused case study, UX workflow example |
+
+---
+
+## LinkedIn Targeting by Persona
+
+### Two Approaches
+
+**Approach 1: Contact List Upload (More Precise, More Expensive)**
+1. Find specific contacts at target accounts in Clay/Apollo
+2. Enrich with email
+3. Upload to HubSpot as marketing contacts
+4. Sync to LinkedIn via HubSpot Ad Audiences
+5. Create separate campaigns per persona list
+
+**Pros:** Very precise targeting
+**Cons:** Expensive (Clay credits + HubSpot marketing contacts cost), complex to manage
+
+**Approach 2: Company List + LinkedIn Native Filters (Recommended)**
+1. Upload company list to LinkedIn (via HubSpot company list sync)
+2. Use LinkedIn Campaign Manager's native filters to target personas:
+   - Job Function: Product Management, Design, Marketing, etc.
+   - Seniority: Director, VP, C-Suite
+   - Job Title keywords: specific titles
+
+**Pros:** Cheaper, simpler, leverages LinkedIn's data
+**Cons:** Less precise (LinkedIn's job function mapping isn't perfect)
+
+### LinkedIn Persona Filters
+
+| Persona | LinkedIn Job Function | LinkedIn Seniority | Title Keywords |
+|---|---|---|---|
+| **Product** | Product Management | Manager, Director, VP | Product Manager, Head of Product, CPO |
+| **UX/Design** | Design, Arts and Design | Manager, Senior, Director | UX Designer, Design Lead, Head of Design |
+| **Marketing** | Marketing | Manager, Director, VP | Growth, PMM, Demand Gen, Head of Marketing |
+| **Engineering** | Engineering, IT | Manager, Director, VP, CTO | Engineering Manager, CTO, VP Engineering |
+| **Executive** | General Management | VP, CXO | CEO, COO, Founder, GM |
+| **Customer Success** | Support | Manager, Director | CS Manager, Head of CS, VP Customer Success |
+
+### Minimum Audience Rules
+
+- **Minimum matched audience:** 300 LinkedIn members per campaign
+- **Smaller audiences = higher CPMs** (more expensive)
+- **At later ABM stages (Interested, Considering):** persona lists may be too small to run separately
+- **Solution:** Combine personas at later stages, differentiate via ad content instead of targeting
+
+---
+
+## Persona Prioritization
+
+### Which Personas to Target First
+
+| Priority | Persona Type | Why | Budget Allocation |
+|---|---|---|---|
+| **1st** | Champions | They drive the deal internally | 40-50% of budget |
+| **2nd** | Economic Buyers | They approve the purchase | 20-30% of budget |
+| **3rd** | End Users | They validate product fit | 15-20% of budget |
+| **4th** | Technical Evaluators | They assess during demo/trial | 5-10% of budget |
+
+### When Budget is Limited
+
+With $10K/month (one campaign group effectively):
+1. **Don't split by persona.** Target all personas in one campaign group.
+2. **Differentiate through content.** Create ads that speak to different JTBDs within the same campaign.
+3. **Use LinkedIn filters to exclude irrelevant roles** (e.g., exclude HR, Finance, Legal from initial campaigns).
+4. **Prioritize by JTBD/intent** instead of persona.
+
+---
+
+## Campaign Naming Convention (for Intent Tracking)
+
+### Structure
+
+```
+[Campaign Name] - [Persona] - [Ad Type] - [JTBD/Intent] - [ABM Stage]
+```
+
+**Examples:**
+- `Q1-Analytics - PM - Image - User-Activation - Awareness`
+- `Q1-Analytics - UX - Video - Session-Replay - Interested`
+- `Q1-Analytics - All - TLA - Industry-Trends - Awareness`
+
+### Why Naming Matters
+
+When ZenABM/Fibbler pushes engagement data to HubSpot, the campaign name is how you extract:
+- Which **persona** engaged (for outreach targeting)
+- Which **intent/JTBD** they cared about (for message personalization)
+- Which **ABM stage** content resonated (for campaign optimization)
+
+### Notion Database for Asset Management
+
+Track all ad assets in a Notion database with properties:
+- Persona
+- Ad Type (Image, Video, TLA, Carousel, Text)
+- Asset Description / JTBD
+- ABM Stage (Awareness, Interested, Considering)
+- ABM Campaign Name
+- Status (Brief Done, Design In Progress, Ready, Launched)
+- Owner
+- Designer Assigned
+- Performance Notes
+
+Use formula fields to auto-generate campaign names from properties, ensuring clean naming that flows through to intent detection.
+
+---
+
+## Project Management: Asset Creation Workflow
+
+### Process
+
+```
+1. ABM Manager defines campaign brief
+   → Persona, intent, stage, messaging angle
+
+2. Content owner writes ad copy brief
+   → Headline, intro text, CTA, visual direction
+
+3. Brief → Notion database (assigned to designer)
+
+4. Designer creates visual assets
+   → Follow LinkedIn specs (see linkedin-ads-abm-guide.md)
+
+5. ABM Manager reviews + approves
+
+6. Assets uploaded to LinkedIn Campaign Manager
+   → Correct campaign group, campaign, naming convention
+
+7. Track in Notion: launched date, performance notes
+```
+
+### Volume Expectations
+
+| Campaign Scale | Ads Needed | Note |
+|---|---|---|
+| **First campaign** | ~100 ads across personas | Typical first ABM campaign |
+| **Mature program** | 500+ ads over time | After 16 months |
+| **Per campaign cycle** | 17-20 ads per intent group | Based on budget math |
+
+**Critical:** Volume of ads must follow the budget math (see `linkedin-ads-abm-guide.md`). Don't create more ads than your budget can effectively serve.
+
+---
+
+## Measuring Persona Effectiveness
+
+### Metrics by Persona
+
+| Metric | What It Tells You |
+|---|---|
+| **CTR by persona** | Which personas engage most with ads |
+| **CPC by persona** | Cost efficiency per persona |
+| **Interested-stage conversion by persona** | Which personas move through the funnel |
+| **Meeting book rate by persona** | Which personas are most receptive to outreach |
+| **Pipeline generated by persona** | Which personas drive the most revenue |
+
+### What to Do with the Data
+
+| Finding | Action |
+|---|---|
+| Product personas have 2x the CTR of Engineering | Shift more budget to Product persona campaigns |
+| Executive personas rarely click but deals with exec engagement close faster | Keep exec campaigns for influence, don't optimize for clicks |
+| One persona never progresses past Aware | Revisit messaging or drop from targeting |
+| BDRs get higher reply rates from Champions than Economic Buyers | Focus BDR outreach on Champions first |
+
+*Source: Frontal*
+
+---
+
+> **Built by [Frontal](https://www.frontal.so) & [Ivan Falco](https://www.linkedin.com/in/ivanfalco/en/).** For questions on implementation or anything not covered here, reach out to Ivan directly on [LinkedIn](https://www.linkedin.com/in/ivanfalco/en/).

--- a/skills/alex-vacca/list-architect/references/persona-mapping.md
+++ b/skills/alex-vacca/list-architect/references/persona-mapping.md
@@ -1,0 +1,63 @@
+# Persona Mapping
+
+You help users identify, segment, and target personas within accounts — mapping who to reach, what they care about, and how messaging differs.
+
+## Reference
+
+Read `persona-mapping-framework.md` for the complete framework.
+
+## Buying Committee Roles
+
+| Role | Function | Budget Priority |
+|------|----------|----------------|
+| Champion | Internal advocate who drives evaluation | 40-50% |
+| Economic Buyer | Signs the check, cares about ROI | 20-30% |
+| End User | Daily user, cares about UX/workflow | 15-20% |
+| Technical Evaluator | Assesses integration, security, compliance | 5-10% |
+| Blocker/Gatekeeper | Can veto but rarely initiates | Monitor only |
+
+## Persona Attributes to Capture
+
+For each persona, define:
+- Title patterns and seniority
+- Function/department
+- Jobs-to-be-done (JTBD)
+- Pain points
+- Success metrics
+- Content preferences
+- Buying role
+
+## LinkedIn Targeting Approaches
+
+- **Approach 1:** Contact list upload — precise but expensive, 30-70% match rate
+- **Approach 2 (recommended):** Company list + native LinkedIn filters — cheaper, 95-100% match rate
+
+## Campaign Naming Convention
+
+`[Campaign Name] - [Persona] - [Ad Type] - [JTBD/Intent] - [ABM Stage]`
+
+Example: `Analytics-CMO-SingleImage-Attribution-Aware`
+
+## Messaging Matrix
+
+Each persona needs:
+1. Different JTBDs highlighted
+2. Different pain points addressed
+3. Stage-appropriate content (awareness vs consideration)
+4. Role-appropriate CTA (champion gets demo, end user gets trial)
+
+## Examples
+
+**Example 1:** "Who should I target at my ABM accounts?"
+→ Read persona-mapping-framework.md. Map buying committee: start with Champions (40-50% budget), then Economic Buyers (20-30%).
+
+**Example 2:** "How do I tailor messaging for different personas?"
+→ Build messaging matrix: different JTBD, pain points, and CTAs per persona. Champion gets ROI narrative, End User gets ease-of-use.
+
+**Example 3:** "How should I name my campaigns for persona tracking?"
+→ Use naming convention: [Campaign]-[Persona]-[AdType]-[JTBD]-[Stage]. Enables intent detection from campaign engagement data.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/qualification-workflow.md
+++ b/skills/alex-vacca/list-architect/references/qualification-workflow.md
@@ -1,0 +1,158 @@
+# Qualification Workflow — From Raw List to Campaign-Ready Accounts
+
+## Frontal Tier System
+
+### Company Tiers (Apply with Clay AI)
+
+| Tier | Definition | Outreach Timing |
+|------|-----------|----------------|
+| **Tier 1** | B2B software companies with 40+ headcount (perfect fit) | Immediate, within 30 days |
+| **Tier 2** | B2B companies that sell digitally but not software (close fit) | Secondary, 60-90 day window |
+| **Tier 3** | Relevant industry but not sweet spot | Nurture, 120+ day horizon |
+| **Below Tier 3** | Not a fit | Disqualify |
+
+### Contact Tiers
+
+| Tier | Definition | Effort Level |
+|------|-----------|-------------|
+| **Tier 1** | C-level, Founders, VPs (decision-makers with budget authority) | White-glove personalization |
+| **Tier 2** | Managers, Seniors (influencers who can champion internally) | Solid but scalable sequences |
+| **Tier 3** | Associates, Coordinators, Specialists (end users) | Templated, efficient |
+
+### Effort Matching Matrix
+
+| Company Tier | Contact Tier | Approach |
+|-------------|-------------|----------|
+| Tier 1 | Tier 1 | Deep research, custom angle, multi-channel |
+| Tier 1 | Tier 2 | Personalized sequence, routing CTA to find decision-maker |
+| Tier 2 | Tier 1 | Solid personalization, focus on value prop |
+| Tier 2 | Tier 2 | Segment-level personalization |
+| Tier 3 | Any | Templated, minimal effort |
+
+---
+
+## Clay AI Prompts for Tiering
+
+### Company Qualification Prompt
+```
+You are qualifying companies for a B2B outbound campaign. Based on the company information provided, assign a tier:
+
+Tier 1: B2B software companies with 40+ headcount that sell to other businesses
+Tier 2: B2B companies that sell digitally but are not software companies
+Tier 3: Companies in a relevant industry but not our ideal fit
+
+Company: {{Company Name}}
+Industry: {{Industry}}
+Employee Count: {{Employee Count}}
+Description: {{Company Description}}
+
+Return ONLY: "Tier 1", "Tier 2", or "Tier 3" followed by a one-sentence reason.
+```
+
+### Contact Qualification Prompt
+```
+Based on the following job title, assign a seniority tier:
+
+Tier 1: C-level, VP, Founder, Head of, Director (decision-makers with budget authority)
+Tier 2: Manager, Senior (influencers who can champion internally)
+Tier 3: Associate, Coordinator, Specialist (end users, not decision-makers)
+
+Title: {{Title}}
+
+Return ONLY: "Tier 1", "Tier 2", or "Tier 3"
+```
+
+---
+
+## Weighted ICP Scoring
+
+Score each company on a 1-10 scale across 6 dimensions:
+
+| Dimension | Weight | What to Score |
+|-----------|--------|-------------|
+| Industry fit | 25% | Does their industry match your ICP? |
+| Company size match | 20% | Employee count within target range? |
+| Revenue/funding alignment | 20% | Revenue or funding stage match? |
+| Growth signals present | 15% | Hiring, funding, expansion signals? |
+| Tech stack fit | 10% | Using relevant/complementary tech? |
+| Geographic fit | 10% | In target geography? |
+
+### Tiered Prioritization from Score
+
+| Score | Tier | Action |
+|-------|------|--------|
+| 8-10 | Tier 1 | Immediate outreach, 2-4 contacts per account |
+| 6-7.9 | Tier 2 | Secondary priority, 1-2 contacts |
+| 4-5.9 | Tier 3 | Nurture sequence only |
+| Below 4 | Disqualify | Remove from list |
+
+---
+
+## 4-Step Qualification Workflow
+
+### Step 1: Hard Filters (Remove Immediately)
+- Wrong industry/vertical
+- Too small (<20 employees) or too large (>10,000)
+- Wrong geography
+- Agencies, competitors, existing clients/pipeline
+
+### Step 2: ICP Scoring
+Apply weighted scoring (above) using Clay AI or formula columns.
+
+### Step 3: Tiered Prioritization
+Assign tiers based on scores. Focus resources on Tier 1 first.
+
+### Step 4: Contact Mapping
+For Tier 1 accounts, find 2-4 contacts per company:
+- Primary decision-maker (VP/C-level)
+- End user/champion
+- Influencer/internal advocate
+- Fallback: routing CTA to find right person
+
+---
+
+## Real Example — DevOps ICP Scoring
+
+| Company | Score | Tier | Rationale | Timing |
+|---------|-------|------|-----------|--------|
+| Port (Platform Engineering) | 9.5/10 | Tier 1 | Series B, 150 emp, perfect fit | Immediate |
+| CAST AI (K8s cost optimization) | 8.8/10 | Tier 1 | Series B, 200 emp, strong fit | Immediate |
+| Teleport (Infrastructure access) | 8.2/10 | Tier 1 | Series C, 350 emp, good fit | 30 days |
+| Cortex (Developer portal) | 7.8/10 | Tier 2 | Series B, 120 emp, adjacent fit | 60 days |
+| Pulumi (Infrastructure as Code) | 7.5/10 | Tier 2 | Series C, 200 emp, adjacent | 60 days |
+
+---
+
+## "Good List" Column Template
+
+A campaign-ready list should include these columns:
+
+```
+Company, Domain, Industry, Vertical, Employee Count, Funding Stage,
+Funding Amount, Revenue, Contact 1-3 (Name + Title), Tech Stack,
+Intent Score, Buying Signals, Trigger Events, Recommended Approach,
+Value Prop, Timing Score, Lead Score
+```
+
+---
+
+## Source Comparison (Extended)
+
+| Source | Best For | Coverage | Cost |
+|--------|----------|----------|------|
+| **Apollo** | Volume, broad searches | 275M+ contacts | $$ |
+| **Sales Navigator** | Precision, enterprise | High for LinkedIn users | $$$ |
+| **Clay Native** | Company/people discovery | Good | Clay credits |
+| **Lima Data** | LinkedIn-powered prospecting | High for LinkedIn data | API credits |
+| **Ocean.io** | Lookalike companies | Moderate | Per-search |
+| **Store Leads** | E-commerce/DTC brands | E-commerce focused | 1 credit |
+| **Google Maps (Outscraper)** | Local businesses | Location-based | 0 credits (API) |
+
+### Source Selection by Use Case
+- **Broad TAM build (1,000+):** Apollo + Sales Nav (combine for coverage)
+- **Precision TAL (50-200):** Sales Nav filters → Clay enrichment → manual QA
+- **Lookalike expansion:** Ocean.io from best customers → Clay enrichment
+- **E-commerce/DTC:** Store Leads + Meta Ads Library scraper
+- **Local businesses:** Google Maps via Outscraper → Clay enrichment
+
+**Rule:** Always use multiple sources. Single source = ~60% TAM. Two sources = ~85%.

--- a/skills/alex-vacca/list-architect/references/qualify-accounts.md
+++ b/skills/alex-vacca/list-architect/references/qualify-accounts.md
@@ -1,0 +1,69 @@
+# Qualify Accounts — Sub-Skill
+
+You help users score, qualify, and prioritize target accounts using ABM tier frameworks and intent data. Always read the reference file before responding.
+
+## Reference
+
+Read `sales-navigator-guide.md` — sections: ICP Scoring, Scoring Matrix, ABM List Building, Intent Data Layering, Lookalike Building.
+Read `qualification-workflow.md` — Frontal tier system (Company/Contact tiers), weighted ICP scoring, Clay AI qualification prompts, real DevOps scoring examples, source comparison matrix, and "good list" column template.
+
+## ABM Tier Structure
+
+| Tier | Accounts | Approach | Resources |
+|------|----------|----------|-----------|
+| **Tier 1 (1:1)** | 10-50 | Fully custom, multi-threaded | Maximum — custom content, executive outreach, direct mail |
+| **Tier 2 (1:Few)** | 50-200 | Segment-based personalization | Medium — industry/persona templates, targeted ads |
+| **Tier 3 (1:Many)** | 200-1,000 | Programmatic, automated | Low — automated sequences, broad messaging |
+
+## Account Scoring Process
+
+1. **Apply ICP scoring matrix** (100-point system from define-icp)
+2. **Layer intent data** to adjust scores dynamically
+3. **Assign ABM tier** based on final score
+4. **Map contacts per account** (Economic Buyer, Champion, Technical Evaluator, End User, Blocker, Coach)
+
+## Intent Data Layers
+
+| Layer | Sources | Signal Strength |
+|-------|---------|----------------|
+| **First-party** | Website visits, pricing page views, content downloads, webinar attendance | Strongest |
+| **Second-party** | G2 Buyer Intent, TrustRadius, Capterra reviews/comparisons | Strong |
+| **Third-party** | Bombora, 6sense, ZoomInfo Intent, TechTarget | Moderate |
+| **LinkedIn-native** | Buyer Intent signals, ad engagement, page followers | Moderate |
+
+**Scoring adjustment:** Add 10-20 points for strong first-party intent. Add 5-10 for second/third-party. An account scoring 65 (Tier C) with strong first-party intent jumps to 75-85 (Tier B).
+
+## Lookalike Building
+
+1. Export top 10-20 customers (by revenue, LTV, or NPS)
+2. Analyze common attributes: industry, size, geography, tech stack, growth stage
+3. Build lookalike search in Sales Navigator matching those attributes
+4. Use "Similar Companies" feature on company pages
+5. External tools: Ocean.io, Clearbit, Apollo.io, Clay
+
+## Contact Mapping Per Account
+
+| Role | Typical Titles | Purpose |
+|------|---------------|---------|
+| Economic Buyer | CEO, CFO, VP | Final budget approval |
+| Champion | Director, Head of | Internal advocate |
+| Technical Evaluator | Manager, Architect | Technical fit assessment |
+| End User | Analyst, Specialist | Daily product user |
+| Blocker | Legal, Compliance | Can slow or stop deal |
+| Coach | Any level | Provides insider information |
+
+## Examples
+
+**Example 1:** "I have 500 companies, how do I prioritize them?"
+-> Apply ICP scoring matrix across all 500. Sort by score. Top 10-50 (Tier A, 90+ pts) = Tier 1 ABM with custom outreach. Next 50-150 (Tier B, 70-89) = Tier 2 with segment-based sequences. Remaining (Tier C, 50-69) = Tier 3 automated. Below 50 = exclude. Layer intent data from G2/Bombora to re-rank.
+
+**Example 2:** "How do I build a lookalike list from my best customers?"
+-> Export top 20 customers by ARR. Identify patterns: e.g., all are SaaS, 100-500 employees, US-based, using HubSpot, Series A-C funded. Build Sales Nav search matching these attributes. Use Ocean.io for automated lookalike expansion. Score new accounts against the same matrix.
+
+**Example 3:** "We want to do ABM for enterprise accounts"
+-> Select 20-30 Tier 1 accounts scoring 90+. Map 5-6 contacts per account (buying committee). Layer first-party intent (website visits) + third-party (Bombora topics). Create custom landing pages per account. Multi-channel: LinkedIn + email + direct mail + ads.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-architect/references/sales-navigator-guide.md
+++ b/skills/alex-vacca/list-architect/references/sales-navigator-guide.md
@@ -1,0 +1,279 @@
+# LinkedIn Sales Navigator & ICP Framework Guide
+
+## Sales Navigator Advanced Search
+
+### Lead Filters
+
+| Filter | Description | Plan Required |
+|--------|-------------|---------------|
+| Keywords | Searches across profile text | Core |
+| First/Last Name | Direct name search | Core |
+| Title (Boolean) | Current job title with boolean operators | Core |
+| Company | Current employer | Core |
+| Company Headcount | Employee range (1-10 to 10,001+) | Core |
+| Seniority Level | CXO, VP, Director, Manager, etc. | Core |
+| Function | Sales, Marketing, Engineering, etc. | Core |
+| Geography | Region, country, city, metro area | Core |
+| Industry | 413 industry options | Core |
+| Years in Current Position | Less than 1, 1-2, 3-5, etc. | Core |
+| Years at Current Company | Same ranges | Core |
+| Changed Jobs | Past 90 days | Core |
+| Posted on LinkedIn | Past 30 days | Core |
+| Company Revenue | Revenue ranges | Advanced+ |
+| Technologies Used | 35,000+ technologies | Advanced+ |
+| Buyer Intent | LinkedIn intent signals | Advanced+ |
+| Company Headcount Growth | Growth percentage ranges | Advanced+ |
+
+### Account Filters
+
+| Filter | Description |
+|--------|-------------|
+| Company Headcount | Employee range |
+| Revenue | Annual revenue range |
+| Industry | Industry vertical |
+| HQ Location | Headquarters location |
+| Technologies Used | Tech stack (35K+ options) |
+| Headcount Growth | Company growth signals |
+| Job Opportunities | Companies actively hiring |
+| Recent Activities | Company posts, news |
+
+## Boolean Search
+
+### Operators
+
+| Operator | Syntax | Example | What It Does |
+|----------|--------|---------|-------------|
+| **AND** | `AND` | `VP AND Marketing` | Both terms must match |
+| **OR** | `OR` | `CEO OR "Chief Executive"` | Either term matches |
+| **NOT** | `NOT` | `VP NOT assistant` | Excludes term |
+| **Quotes** | `"exact phrase"` | `"Vice President"` | Exact phrase match |
+| **Parentheses** | `(group)` | `(CEO OR CTO) AND SaaS` | Group operations |
+
+**Limitations:**
+- Boolean works in Title, Company, and Keywords fields
+- Does NOT work in Industry, Geography, or dropdown filters
+- No wildcard (`*`) support (unlike Recruiter)
+- Max ~1,000 characters per boolean string
+- Nested parentheses work 2-3 levels deep
+
+### Boolean Formulas by ICP
+
+#### SaaS Decision Makers
+```
+Title: (VP OR "Vice President" OR Director OR Head OR Chief) AND (Marketing OR "Demand Gen" OR "Growth" OR "Digital")
+Company Keywords: (SaaS OR "B2B software" OR "cloud-based" OR "subscription")
+Seniority: VP, Director, CXO
+Industry: Computer Software, Internet, IT & Services
+Headcount: 51-500
+```
+
+#### C-Suite Targeting
+```
+Title: (CEO OR "Chief Executive Officer" OR Founder OR "Co-Founder" OR "Managing Director" OR President OR Owner)
+NOT: (assistant OR intern OR student OR "job seeking")
+```
+
+#### VP of Sales at Mid-Market Tech
+```
+Title: ("VP Sales" OR "Vice President Sales" OR "VP of Sales" OR "Head of Sales" OR CRO OR "SVP Sales")
+Industry: Computer Software, Internet, SaaS
+Headcount: 201-1000
+```
+
+#### HR / People Decision Makers
+```
+Title: (CHRO OR "Chief People Officer" OR "VP HR" OR "Head of People" OR "Head of HR" OR "Director of Talent")
+NOT: (recruiter OR coordinator OR assistant OR intern OR generalist)
+```
+
+#### IT Decision Makers
+```
+Title: (CTO OR CIO OR CISO OR "VP Engineering" OR "VP IT" OR "Head of Engineering" OR "Director of IT")
+NOT: (intern OR junior OR associate OR student)
+```
+
+#### Startup Founders (Seed to Series B)
+```
+Title: (Founder OR "Co-Founder" OR CEO OR "Chief Executive")
+Company keywords: (seed OR "series A" OR "series B" OR startup OR "early stage")
+Headcount: 1-200
+Changed jobs in past 90 days: Yes
+```
+
+#### Multi-Role Targeting (Buying Committee)
+```
+Search 1 (Economic Buyer): CEO OR CFO OR "VP Finance"
+Search 2 (Champion): "Head of Marketing" OR "Marketing Director" OR "VP Marketing"
+Search 3 (User): "Marketing Manager" OR "Digital Marketing" OR "Demand Gen Manager"
+Search 4 (Blocker): "General Counsel" OR "Head of Legal" OR "Compliance"
+```
+
+#### Exclude False Positives
+```
+Title: (Director OR VP OR Head) AND Marketing NOT ("Account Director" OR "Art Director" OR "Creative Director" OR assistant OR associate)
+```
+
+## ICP Framework
+
+### Firmographic Criteria (Company-Level)
+
+| Criterion | Description | Sales Nav Filter |
+|-----------|-------------|-----------------|
+| Industry | Primary vertical | Industry filter |
+| Company size | Employee count | Headcount filter |
+| Revenue | Annual revenue | Revenue (Advanced+) |
+| Geography | HQ location | HQ location |
+| Growth rate | Headcount growth % | Growth filter |
+| Funding stage | Seed to IPO | Keywords + external |
+
+### Technographic Criteria
+
+| Criterion | Source |
+|-----------|--------|
+| Tech stack | Sales Nav Tech filter (35K+), BuiltWith, Wappalyzer |
+| CRM | Sales Nav Tech filter |
+| Marketing automation | Sales Nav Tech filter |
+| Competitive tools | Sales Nav Tech filter + intent data |
+
+### Behavioral/Intent Criteria
+
+| Signal | Source |
+|--------|--------|
+| Job postings | Sales Nav "Job Opportunities" filter |
+| Funding events | Crunchbase, Sales Nav alerts |
+| Leadership changes | Sales Nav "Changed jobs" filter |
+| Content engagement | Sales Nav Buyer Intent, Bombora |
+| Web visits | 6sense, Clearbit Reveal, Leadfeeder |
+
+### ICP Scoring (Tier System)
+
+**Tier A (90-100 pts) — "Perfect Fit"**
+- ALL firmographic match, complementary tech, active intent, has budget
+- Action: Maximum resources, multi-threaded outreach, ABM campaigns
+
+**Tier B (70-89 pts) — "Strong Fit"**
+- Most firmographic match, partial tech match, some intent
+- Action: Targeted outreach, personalized sequences
+
+**Tier C (50-69 pts) — "Moderate Fit"**
+- Some firmographic match, limited tech data, no clear intent
+- Action: Automated nurture, content marketing
+
+**Tier D (<50 pts) — "Poor Fit"**
+- Significant mismatches
+- Action: Exclude from outreach, inbound-only
+
+### Scoring Matrix
+
+| Criterion | Weight | Scoring |
+|-----------|--------|---------|
+| Industry match | 20 pts | Exact = 20, Adjacent = 10, None = 0 |
+| Company size | 15 pts | Sweet spot = 15, Adjacent = 8, Outside = 0 |
+| Revenue range | 15 pts | Sweet spot = 15, Adjacent = 8, Unknown = 0 |
+| Geography | 10 pts | Primary = 10, Secondary = 5, Other = 0 |
+| Technology fit | 15 pts | Complement = 15, Neutral = 8, Competitor = 5 |
+| Growth signals | 10 pts | High = 10, Moderate = 5, Stagnant = 0 |
+| Intent signals | 15 pts | Strong = 15, Some = 8, None = 0 |
+| **Total** | **100 pts** | |
+
+## List Building Best Practices
+
+### Bypassing the 2,500 Result Limit
+
+Sales Navigator shows max 2,500 results per search. Bypass strategies:
+
+1. **Geographic Segmentation** — Split by state/city
+2. **Industry Segmentation** — Same title across different industries
+3. **Company Size** — Break 51-500 into 51-200 and 201-500
+4. **Seniority Stacking** — Separate searches per role level
+5. **First Name Split** — Filter A-F, G-L, M-R, S-Z
+6. **Time Filters** — "Changed jobs in 90 days", "Years in position"
+
+### List Segmentation
+
+1. By buying stage: Cold, Warm, Hot
+2. By persona: One list per buyer persona
+3. By intent level: High/Medium/Low
+4. By timezone: For cadence timing
+5. Keep lists under 1,000 for personalization
+6. Naming: `[Tier]-[Persona]-[Vertical]-[Geo]-[Date]`
+
+## Export & Scraping Tools
+
+### Tool Comparison
+
+| Tool | Type | Price | Risk Level | Best For |
+|------|------|-------|-----------|----------|
+| **Evaboot** | Chrome extension | $29-99/mo | Medium | Clean, verified data |
+| **PhantomBuster** | Cloud automation | $69-439/mo | Higher | Multi-step workflows |
+| **Captain Data** | Cloud extraction | $399/mo | Medium-High | Agencies, repeatable flows |
+| **Clay** | Enrichment platform | $149-800/mo | Low | Waterfall enrichment |
+| **Apollo.io** | Sales intelligence | Free-$119/mo | Low | Own database, not scraping |
+| **Linked Helper** | Desktop app | $15-45/mo | Medium | Budget automation |
+
+### Recommended Workflow
+
+```
+1. BUILD LIST in Sales Navigator
+   - Advanced filters + boolean
+   - Segment to stay under 2,500 per search
+   - Save to organized lists
+
+2. EXPORT with Evaboot (or CRM sync)
+   - Extract: Name, Title, Company, LinkedIn URL, Location
+   - Auto-clean titles, filter false positives
+
+3. ENRICH with Clay or Apollo
+   - Waterfall email finding (multiple providers)
+   - Phone number enrichment
+   - Company data (revenue, tech stack)
+
+4. VERIFY with ZeroBounce or NeverBounce
+   - Run all emails through verification
+   - Remove invalid, flag catch-all
+   - Target: 95%+ valid rate
+
+5. SEGMENT for outreach
+   - Tier A/B/C based on ICP score
+   - Personalization variables from enrichment
+   - Route to appropriate cadence
+
+6. MAINTAIN
+   - Re-verify before each campaign
+   - Quarterly full refresh
+   - Monitor bounce rates in real-time
+```
+
+## ABM List Building
+
+### Target Account List
+
+- **Tier 1 (1:1 ABM)**: 10-50 accounts, fully custom
+- **Tier 2 (1:Few)**: 50-200 accounts, segment-based
+- **Tier 3 (1:Many)**: 200-1,000 accounts, programmatic
+
+### Contact Mapping Per Account
+
+| Role | Typical Title | Purpose |
+|------|--------------|---------|
+| Economic Buyer | CEO, CFO, VP | Final budget approval |
+| Champion | Director, Head of | Internal advocate |
+| Technical Evaluator | Manager, Architect | Evaluates technical fit |
+| End User | Analyst, Specialist | Daily user |
+| Blocker | Legal, Compliance | Can slow/stop deal |
+| Coach | Any level | Provides inside info |
+
+### Intent Data Layering
+
+**First-party:** Website visits, content downloads, webinar attendance, pricing page views
+**Second-party:** G2 Buyer Intent, TrustRadius, Capterra
+**Third-party:** Bombora, 6sense, ZoomInfo Intent, TechTarget
+**LinkedIn-native:** Buyer Intent signals, ad engagement, page followers
+
+### Lookalike Building
+
+1. Export top 10-20 customers (by revenue, LTV, NPS)
+2. Analyze common attributes (industry, size, geography, tech stack)
+3. Build lookalike search in Sales Navigator
+4. Use "Similar Companies" feature on company pages
+5. External tools: Ocean.io, Clearbit, Apollo.io, Clay

--- a/skills/alex-vacca/list-architect/references/source-companies.md
+++ b/skills/alex-vacca/list-architect/references/source-companies.md
@@ -1,0 +1,62 @@
+# Source Companies — Sub-Skill
+
+You help users find and import target companies from the best data sources for their use case. Always read the reference file before responding.
+
+## Reference
+
+Read `lead-sources-guide.md` — all sections.
+
+## 3 Categories of Company Sources
+
+### 1. Inbound / Warm Sources (Highest Intent)
+- **Website visitors** — RB2B, Clearbit Reveal, Leadfeeder (identify anonymous visitors)
+- **LinkedIn engagement** — Triggery webhooks to Clay (real-time post engagers)
+- **Event attendees** — Webinar, conference, in-person event lists
+- **Newsletter subscribers** — Form fills with company domain
+
+### 2. Database Sources (Broad Targeting)
+- **Apollo.io** — Best for broad targeting, good volume, needs verification. Use with LeadMagic scraper for enrichment.
+- **Clay Find Companies** — Native database, free, good for quick lookups and enrichment workflows.
+- **Ocean.io** — Lookalike accounts based on tech stack/ICP. Best for expanding TAM from existing customers.
+- **Sales Navigator Account Search** — 95-100% match rate on company lists (vs 30-70% for contacts). Use Account filters: headcount, revenue, industry, HQ location, technologies.
+
+### 3. Specialized Sources (Niche Targeting)
+- **HG Insights** — Tech stack targeting (paid). Best when technographic criteria is central to ICP.
+- **Google Maps** — Local businesses, SMB. Use Apify or Instant Data Scraper to extract.
+- **Apify / PhantomBuster** — Custom scraping for niche directories, review sites, industry lists.
+- **RSS Feeds** — Monitor company news, funding announcements, job postings.
+
+## Webhooks — Real-Time Company Discovery
+
+**Triggery -> Clay pipeline:**
+1. Someone engages with your LinkedIn content (like, comment, share)
+2. Triggery captures the event in real-time
+3. Webhook sends data to Clay automatically
+4. Clay enriches company data and routes to appropriate list
+
+## Import Methods into Clay
+
+| Method | Best For |
+|--------|----------|
+| CSV upload | One-time imports from any source |
+| HubSpot/Salesforce sync | CRM-connected workflows |
+| Apollo integration | Database pulls |
+| Clay Find Companies | Native search |
+| Webhook (Triggery) | Real-time engagement data |
+| HTTP API | Custom integrations |
+
+## Examples
+
+**Example 1:** "I need a list of SaaS companies using Salesforce with 50-500 employees"
+-> Use Sales Navigator Account Search (Technologies: Salesforce, Headcount: 51-500, Industry: Computer Software). Supplement with HG Insights for deeper tech stack data. Export to Clay for enrichment. Expected: 2,000-5,000 companies.
+
+**Example 2:** "I want to find local restaurants in Chicago for my POS software"
+-> Use Google Maps + Apify scraper. Search "restaurants Chicago". Extract business name, address, phone, website. Import CSV into Clay. Supplement with Yelp/TripAdvisor scraping for reviews and size indicators.
+
+**Example 3:** "How do I capture companies that engage with my LinkedIn posts?"
+-> Set up Triggery webhook connected to Clay. Configure trigger: LinkedIn post engagement (likes, comments). Clay auto-enriches company domain from LinkedIn profile. Apply ICP scoring, route Tier A/B to outreach sequences.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/list-building-tips/SKILL.md
+++ b/skills/alex-vacca/list-building-tips/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: list-building-tips
+title: List building tips
+description: "Use this skill when building B2B prospect lists, mixing data sources, running enrichment workflows, improving email coverage and bounce rates, cleaning and verifying lists before a campaign, or diagnosing data quality and prospecting efficiency problems."
+category: Prospecting
+---
+
+# List Building Pro Tips
+
+## Core Principles
+
+### 1. Mix Sources
+- Don't rely on just one data provider
+- Each source has different strengths/coverage
+- Combine for maximum coverage
+
+### 2. Scraping = Step 1
+- Raw scraped data is just the beginning
+- Still need Clay enrichment for:
+  - Email verification
+  - Phone numbers
+  - Company data
+  - Custom signals
+
+### 3. Templates Are Modular
+- Start with proven templates
+- Adjust for specific campaign goals
+- Don't rebuild from scratch
+
+### 4. Don't Reinvent the Wheel
+- Use existing Clay templates
+- Modify rather than create
+- Learn from what works
+
+---
+
+## Data Quality Hierarchy
+
+```
+1. Verified email (bounced < 2%)
+2. Direct phone number
+3. Recent activity signal
+4. ICP fit confirmed
+5. Company enrichment complete
+```
+
+---
+
+## Efficiency Benchmarks
+
+| Task | Manual Time | With Clay |
+|------|-------------|-----------|
+| 100 prospects | 8-10 hours | 30 min |
+| 500 prospects | 40+ hours | 1-2 hours |
+| 1000 prospects | 80+ hours | 2-3 hours |
+
+---
+
+## Quality Checklist
+
+Before launching any campaign:
+
+- [ ] Email bounce rate < 2%
+- [ ] At least 70% email coverage
+- [ ] ICP criteria verified
+- [ ] Recent signals tagged
+- [ ] Duplicates removed
+- [ ] Competitor customers flagged
+- [ ] Do-not-contact list checked
+
+---
+
+## Common Mistakes
+
+1. **Single source reliance** - Limits coverage
+2. **Skipping verification** - Kills deliverability
+3. **Over-filtering** - Shrinks TAM too much
+4. **Under-filtering** - Wastes outreach on bad fits
+5. **Ignoring signals** - Missing hot prospects
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `lead-sources-guide` | Choose right sources |
+| `clay-enrichment-9step` | Full enrichment workflow |
+| `email-metrics-benchmarks` | Track deliverability |
+| `clay-buying-signals-5` | Add signals to lists |
+
+## Example prompts
+
+```
+Review my list building workflow against the quality checklist.
+```
+
+```
+What's the fastest way to build a 500-prospect list for fintech CFOs?
+```
+
+```
+How do I diagnose why my email bounce rate is above 2%?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/outbound-triggers-6/SKILL.md
+++ b/skills/alex-vacca/outbound-triggers-6/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: outbound-triggers-6
+title: Outbound triggers
+description: "Use this skill when running pure cold outbound with no prior signal, choosing an outbound premise — CXO Passdown, Groundswell, Multi-Persona, or classic cold outreach — building top-down or bottom-up campaigns, or multi-threading a buying committee across an account."
+category: Signals
+---
+
+# OUTBOUND Premises (6 Triggers)
+
+## 1. CXO Passdown
+
+**Strategy:** Start at the top, get passed down to the right person
+
+**Execution:**
+- Email C-level executive
+- Ask for direction to right person
+- Creates internal referral
+
+**Template:**
+```
+{{firstName}},
+
+I'm not sure if this lands on your desk or someone else's.
+
+We help [ICP] with [problem].
+
+Who should I be talking to about [topic] at {{company}}?
+```
+
+---
+
+## 2. To "Groundswell" for Info
+
+**Strategy:** Build internal champions before approaching decision maker
+
+**Execution:**
+- Target end-users and ICs
+- Provide value and resources
+- Build grassroots support
+
+---
+
+## 3. To "Groundswell" for Product-Placement
+
+**Strategy:** Get product in hands of end-users first
+
+**Execution:**
+- Free trials to ICs
+- Bottom-up adoption
+- Let usage drive demand
+
+---
+
+## 4. To DM Based on "Groundswell" Product-Placement
+
+**Strategy:** Use internal adoption as proof point for decision maker
+
+**Execution:**
+- Reference internal usage
+- Show adoption metrics
+- Convert to paid/enterprise
+
+**Template:**
+```
+{{firstName}},
+
+{{number}} people at {{company}} are already using [product].
+
+[Names/teams] have been active for [timeframe].
+
+Worth discussing how to scale this across the org?
+```
+
+---
+
+## 5. Multi-Persona (Cross-Departmental)
+
+**Strategy:** Coordinate outreach across multiple stakeholders
+
+**Execution:**
+- Map buying committee
+- Tailor message per role
+- Coordinate timing
+
+**Roles to target:**
+- Economic buyer (budget)
+- Technical buyer (evaluation)
+- End user (adoption)
+- Champion (internal advocate)
+
+---
+
+## 6. Typical "Cold Outbound"
+
+**Strategy:** Pure cold outreach with no prior signal
+
+**Execution:**
+- 1:1 personalization required
+- Pattern-interrupt opening
+- Heavy research investment
+
+**Messaging Approach:**
+```
+First Line: Core-Static Relevance (Lean on Pattern Interruptive Opener)
+Second Line: Core-Static Relevance ("We work with...")
+```
+
+---
+
+## Outbound Success Factors
+
+1. **Deep research** - Know the person and company
+2. **Pattern interrupt** - Stand out from generic emails
+3. **Clear relevance** - Why you, why now
+4. **Multi-channel** - Don't rely on email alone
+5. **Persistence** - Multiple touches required
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `outreach-4-categories` | Understand pure Outbound |
+| `personalization-6-buckets` | Deep research for 1:1 |
+| `personalization-hooks` | Create strong hooks |
+| `atl-btl-messaging` | CXO Passdown for ATL |
+
+## Example prompts
+
+```
+Create a CXO Passdown email for targeting VP Engineering at enterprise companies.
+```
+
+```
+How do I build internal champions using Groundswell strategy?
+```
+
+```
+Write a Multi-Persona campaign targeting both CFO and Finance Manager.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/outreach-4-categories/SKILL.md
+++ b/skills/alex-vacca/outreach-4-categories/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: outreach-4-categories
+title: Outreach categories
+description: "Use this skill when categorizing leads as Inbound, Postbound, Bridgebound, or Outbound, choosing the right outreach approach and personalization level for a lead, building segmented campaigns, or deciding between 1:many and 1:1 messaging."
+category: Outreach
+---
+
+# The 4 Categories of Outreach
+
+## INBOUND (1:Many Messaging Only)
+
+**Definition:**
+- Prospect knows your company
+- Hand-raisers taking marketing action asking to evaluate your product
+
+**Trigger:** Demo requests, chat box inquiries
+
+**Messaging approach:** 1:Many only (they came to you)
+
+---
+
+## POSTBOUND (1:Many + 1:1 Messaging)
+
+**Definition:**
+- Prospect knows your company
+- Marketing leads that are NOT hand-raisers
+
+**Trigger:** Content engagement without explicit buying intent
+
+**Messaging approach:** Mix of templated + personalized
+
+---
+
+## BRIDGEBOUND (1:Many + 1:1 Messaging)
+
+**Definition:**
+- Prospect sometimes knows your company
+- Segmented outbound based on premises that raise meeting/buying likelihood
+
+**Trigger:** Prospect or company action NOT related to your marketing
+
+**Messaging approach:** Signal-based personalization
+
+**5 Sub-Categories:**
+1. Based on Relationship (39 triggers)
+2. Based on History (16 triggers)
+3. Based on Likely "In Market" (20 triggers)
+4. Based on Symptoms & Signs (11 triggers)
+5. Based on Firmographic (15 triggers)
+
+---
+
+## OUTBOUND (1:1 Messaging Only)
+
+**Definition:**
+- Prospect doesn't know your company
+- Coming in cold
+
+**Trigger:** Prospect selected by prospecting team
+
+**Messaging approach:** Fully personalized (1:1 only)
+
+---
+
+## Messaging Matrix
+
+| Category | Prospect Awareness | Messaging Type | Personalization Level |
+|----------|-------------------|----------------|----------------------|
+| Inbound | High | 1:Many | Low |
+| Postbound | Medium | 1:Many + 1:1 | Medium |
+| Bridgebound | Low-Medium | 1:Many + 1:1 | Medium-High |
+| Outbound | None | 1:1 Only | High |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `personalization-playbooks` | Get messaging for each category |
+| `bridgebound-relationship-39` | Deep-dive on Bridgebound triggers |
+| `inbound-triggers-30` | Understand Inbound premises |
+| `outbound-triggers-6` | Master pure Outbound approach |
+
+## Example prompts
+
+```
+This lead downloaded our ebook - is it Inbound or Postbound?
+```
+
+```
+Create a messaging strategy for Bridgebound leads with job change signals.
+```
+
+```
+How do I transition a Postbound lead to a sales conversation?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/personalization-6-buckets/SKILL.md
+++ b/skills/alex-vacca/personalization-6-buckets/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: personalization-6-buckets
+title: Personalization buckets
+description: "Use this skill when researching a prospect for personalized outreach, choosing a personalization angle — self-authored content, engaged content, self-identified traits, background, or company-level triggers — or falling back to core-static relevance when no personal data exists."
+category: Outreach
+---
+
+# 6 Buckets of Personalization
+
+## Bucket 1: Self-Authored Content (Highest Value)
+
+Content the prospect has created themselves:
+
+1. **Speaking Engagements** - Conferences, podcasts
+2. **Webinars** - Hosted or participated
+3. **Articles** - Blog posts, publications
+4. **Posts** - LinkedIn, Twitter content
+
+**Usage:** Highest value personalization. Reference their thought leadership directly.
+
+---
+
+## Bucket 2: Engaged Content
+
+Content the prospect has interacted with:
+
+1. **Commented On** - Their comments on posts
+2. **Shared** - Content they've shared
+3. **Liked Comments** - Comments they've liked
+4. **Liked Posts** - Posts they've liked
+
+**Usage:** Shows what topics interest them. Reference shared interests.
+
+---
+
+## Bucket 3: Self-Identified Traits
+
+How the prospect describes themselves:
+
+1. **Profile Line ("About me" Section)** - Bio content
+2. **Company Line (Role, Specialization & Achievements)** - Role description
+3. **Headline (Below Profile Picture)** - LinkedIn headline
+
+**Usage:** Use their own words to frame relevance.
+
+---
+
+## Bucket 4: Junk Drawer
+
+Personal details from their profile:
+
+1. **Personal Interests** - Hobbies, activities
+2. **Volunteer Experience: Personal (Charity)** - Causes they support
+3. **Languages Spoken** - Multilingual abilities
+4. **Schools Attended** - Education background
+5. **Interested In/Following** - Topics they follow
+
+**Usage:** Build rapport but don't overdo it. Use sparingly.
+
+---
+
+## Bucket 5: Background Centric
+
+Professional history and credentials:
+
+1. **Tenure at Company** - How long they've been there
+2. **Professional Trajectory** - Career movement
+3. **Recommendations Given** - Who they recommend
+4. **Recommendations Received** - Social proof
+5. **Boards They're On** - Board positions
+6. **Volunteer Experience: Professional (Mentorship)** - Industry involvement
+7. **Awards Received** - Recognition
+8. **Certifications** - Professional credentials
+9. **Mutual Connections** - Shared network
+10. **Skill Endorsements** - Endorsed abilities
+
+**Usage:** Reference career achievements and professional credibility.
+
+---
+
+## Bucket 6: Company Level
+
+Company-wide information:
+
+1. **Company Website Language** - Messaging and positioning
+2. **Company Post** - Recent social content
+3. **Company Blog Entry** - Blog content
+4. **Company News Mentions** - Press coverage
+5. **Company IPO** - Public offering
+6. **Company Funding** - Investment rounds
+7. **Company Financial Reports** - Public financials
+8. **M&A: Acquired/Were Acquired/Merged** - M&A activity
+9. **Company Growth** - Growth trajectory
+10. **Hiring / Made a "Key Hire"** - Team changes
+11. **Moved Headquarters / Opened New Locations** - Expansion
+12. **New Product/Feature/Integration Release** - Product updates
+13. **Impactful Marketing Moves** - Marketing activities
+14. **Company Competitors / Competitor Moves** - Competitive landscape
+15. **Negative/Positive Outputs/Midputs/Inputs** - Business problems
+
+**Usage:** Trigger-based personalization at scale.
+
+---
+
+## 5 Types of Core-Static Relevance (Fallback)
+
+When personalization isn't possible:
+
+1. **Demographic:** Buyer Persona
+2. **Firmographic:** Company Segment
+3. **Firmographic:** Company Industry Vertical
+4. **Firmographic:** Company Market Geos
+5. **Technographic:** Tech Stack
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `personalization-hooks` | Turn bucket data into hooks |
+| `ai-personalization-prompts` | Automate bucket research |
+| `personalization-playbooks` | Choose personalization level |
+| `cold-email-4-sequence` | Apply buckets to sequence |
+
+## Example prompts
+
+```
+Research Bucket 1 (Self-Authored Content) for this prospect: [LinkedIn URL]
+```
+
+```
+Which bucket should I prioritize for a quick 50-prospect campaign?
+```
+
+```
+Create a strong hook using Bucket 6 (Company Level) data about their funding.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/personalization-hooks/SKILL.md
+++ b/skills/alex-vacca/personalization-hooks/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: personalization-hooks
+title: Personalization hooks
+description: "Use this skill when turning prospect research into opening lines, choosing between a strong hook (verbatim quote) and a lite hook (conceptual tie), connecting personalization to relevance, or crafting personalized first lines for cold email and LinkedIn."
+category: Outreach
+---
+
+# Personalization Hooks to Relevance
+
+## Strong Hook (Verbatim Tie)
+
+Direct quote or reference from their content.
+
+**Pattern:**
+```
+"In your recent [content type] about [topic], you mentioned [direct quote]..."
+```
+
+**Examples:**
+```
+In your recent post about SDR burnout, you mentioned "the biggest issue is lack of quality leads"...
+
+In your podcast episode on scaling sales, you said "we struggled with pipeline predictability until..."
+
+Your article on RevOps made a point about "data silos killing deal velocity"...
+```
+
+**When to use:**
+- High-value prospects
+- Enterprise accounts
+- When you have strong content to reference
+
+---
+
+## Lite Hook (Conceptual Tie)
+
+Reference the theme/topic without direct quote.
+
+**Pattern:**
+```
+"I noticed you're focused on [theme/topic]..."
+```
+
+**Examples:**
+```
+I noticed you're focused on scaling your SDR team...
+
+Saw you've been posting about RevOps challenges...
+
+Looks like pipeline predictability is a priority for you...
+```
+
+**When to use:**
+- Higher volume outreach
+- When content isn't quotable
+- Time-constrained personalization
+
+---
+
+## Hook Selection Framework
+
+| Situation | Hook Type | Effort |
+|-----------|-----------|--------|
+| Enterprise $100K+ deal | Strong Hook | High |
+| Mid-market $25-100K | Either | Medium |
+| SMB/Volume play | Lite Hook | Low |
+| Champion already exists | Lite Hook | Low |
+| Competitive displacement | Strong Hook | High |
+
+---
+
+## Hook Integration Examples
+
+**Strong Hook + Relevance:**
+```
+In your recent post about outbound being "broken," you mentioned cold emails getting <1% reply rates.
+
+We've been helping teams like [similar company] hit 15%+ by focusing on signal-based targeting instead of volume.
+
+Worth comparing notes?
+```
+
+**Lite Hook + Relevance:**
+```
+Noticed you're scaling the BDR team at {{company}}.
+
+Most BDR leaders I talk to are dealing with ramp time and pipeline quality.
+
+We helped [similar company] cut ramp by 40%.
+
+Is that something you're working on?
+```
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `personalization-6-buckets` | Find content to hook on |
+| `cold-email-4-sequence` | Apply hooks to Email 1 |
+| `ai-personalization-prompts` | Automate hook generation |
+| `josh-braun-copywriting` | Write hooks that don't sound salesy |
+
+## Example prompts
+
+```
+Write a strong hook for a VP Marketing who posted about attribution challenges.
+```
+
+```
+Create 3 lite hooks for SDR managers at Series B SaaS companies.
+```
+
+```
+Turn this LinkedIn post into a strong hook opening line: [paste post]
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/personalization-playbooks/SKILL.md
+++ b/skills/alex-vacca/personalization-playbooks/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: personalization-playbooks
+title: Personalization playbooks
+description: "Use this skill when deciding how much personalization an outreach campaign needs, choosing between manual high-touch and automated at-scale messaging for Inbound, Postbound, Bridgebound, or Outbound leads, or structuring first and second lines of a message."
+category: Outreach
+---
+
+# Personalization Playbooks
+
+## Camp Personalization Playbook (Manual/High-Touch)
+
+### INBOUND
+```
+First Line: Trigger-Based Relevance ONLY
+Second Line: CTA to Book Time (Optional: Core-Static Relevance)
+```
+
+**Example:**
+```
+Thanks for downloading the Cold Email Playbook.
+
+Got 15 minutes to discuss how to apply it at {{company}}?
+```
+
+### POSTBOUND/BRIDGEBOUND
+```
+First Line: Trigger-Based Relevance + ("but more importantly") Personalization
+Second Line: Personalization "Hook" + Core-Static Relevance
+```
+
+**Example:**
+```
+Saw you attended our webinar on signal-based outbound—but more importantly, your recent post about "outbound being dead" caught my attention.
+
+You mentioned reply rates dropping below 1%. We've been helping B2B SaaS companies hit 15%+ with signal-first targeting.
+
+Worth a quick chat?
+```
+
+### OUTBOUND
+```
+First Line: Personalization Title or Summary + Personalization Excerpt
+Second Line: Personalization "Hook" + Core-Static Relevance
+```
+
+**Example:**
+```
+Your post on SDR burnout—specifically the line "throwing bodies at the problem doesn't scale"—resonated.
+
+We work with SaaS companies doing $5-20M who've hit that wall. Most are shifting from volume to signal-based.
+
+Curious if that's on your radar?
+```
+
+---
+
+## Camp No Personalization Playbook (Automated/Scale)
+
+### INBOUND
+```
+First Line: Trigger-Based Relevance ONLY
+Second Line: CTA to Book Time (Optional: Core-Static Relevance)
+```
+
+**Example:**
+```
+Thanks for requesting a demo.
+
+Let's find 15 minutes to walk through how {{product}} works for {{industry}} companies.
+
+[Calendar link]
+```
+
+### POSTBOUND/BRIDGEBOUND
+```
+First Line: Trigger-Based Relevance
+Second Line: Core-Static Relevance
+```
+
+**Example:**
+```
+Noticed you've been checking out our pricing page.
+
+We work with B2B SaaS companies doing $5-20M ARR on outbound.
+
+Worth a quick call to see if there's a fit?
+```
+
+### OUTBOUND
+```
+First Line: Core-Static Relevance (Lean on Pattern Interruptive Opener)
+Second Line: Core-Static Relevance ("We work with...")
+```
+
+**Example:**
+```
+Quick question: How's your team handling pipeline predictability right now?
+
+We work with B2B SaaS companies doing $5-20M who struggle with inconsistent lead flow.
+
+Worth exploring?
+```
+
+---
+
+## Decision Matrix
+
+| Factor | Use Personalization | Skip Personalization |
+|--------|---------------------|---------------------|
+| Deal size | >$25K ACV | <$25K ACV |
+| Volume | <50/day | >100/day |
+| ICP fit | Tier 1 accounts | Tier 2-3 accounts |
+| Signal strength | Weak signals | Strong signals |
+| Competitive | High competition | Low competition |
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `outreach-4-categories` | Match playbook to lead category |
+| `personalization-6-buckets` | Find data for personalization |
+| `personalization-hooks` | Create hooks for Camp Personalization |
+| `cold-email-4-sequence` | Apply playbook to sequence |
+
+## Example prompts
+
+```
+Which playbook should I use for a $15K ACV deal with strong intent signal?
+```
+
+```
+Write a Camp Personalization Bridgebound email for this prospect: [details]
+```
+
+```
+Create a No Personalization Outbound template for targeting DevOps managers.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/sdr-master-prompts/SKILL.md
+++ b/skills/alex-vacca/sdr-master-prompts/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: sdr-master-prompts
+title: SDR master prompts
+description: "Use this skill when training an AI assistant for sales or SDR messaging, building an SDR chatbot, writing lead follow-up messages by lead status (form filled, meeting booked, missed call), or creating consistent short high-conversion messaging guidelines for email, LinkedIn, and WhatsApp."
+category: Outreach
+---
+
+# Frontal SDR Master Prompts
+
+## Master Prompt: What Frontal Does
+
+```
+Frontal builds the revenue system behind your sales, marketing, and RevOps
+(not generic campaigns).
+
+We combine:
+- Intent data and buying signals
+- Enrichment workflows (Clay, waterfalls)
+- Outbound, ads, and content execution
+
+Delivery: take it in-house in 90 days, or have our operators run it for you.
+
+Tone: Professional, confident, practical.
+NO: Hype, buzzwords, hard selling.
+
+Focus on:
+- Problem solved
+- How we do it differently
+- Soft, low-pressure CTA
+```
+
+---
+
+## Master Prompt: Default Lead Messaging
+
+```
+You are a sales/SDR messaging assistant.
+
+Job: Write short, clear, high-conversion messages.
+Channels: Email, LinkedIn, WhatsApp.
+ONE goal: BOOK THE MEETING.
+
+Global Rules:
+- 2-4 short lines maximum
+- Tone: "slang professional" (direct, human, confident)
+- NOT salesy or corporate
+- No emojis
+- No fluff
+- Always push toward meeting
+- Offer time slots clearly when appropriate
+
+Lead Status Logic:
+
+1. Form NOT completed:
+   - Acknowledge form
+   - Light pitch
+   - Push for booking
+
+2. Form completed, meeting NOT booked:
+   - Reference their stated priority
+   - Offer 2-3 time slots
+   - Direct CTA
+
+3. Meeting already booked:
+   - Build momentum
+   - Set expectations
+   - Create rapport
+   - NO reselling
+
+4. Tried calling:
+   - Mention briefly
+   - Move to email scheduling
+
+5. LinkedIn:
+   - Only mention if explicitly sent connection
+
+Pitch Style:
+- Never hypey
+- Never long
+- Outcome-focused
+
+Examples:
+- "Turn lead flow into something predictable"
+- "Replace manual outreach with proper GTM engine"
+- "Fill calendar with qualified calls"
+
+Subject Lines:
+- Short, functional, context-aware
+- Examples: "Quick sync?", "Next steps", "From [Name] — quick intro"
+
+Absolute Don'ts:
+- No long paragraphs
+- No marketing language
+- No fake enthusiasm
+- No "hope you're doing well"
+- No emojis
+- No unnecessary context
+```
+
+---
+
+## Definition of Success
+
+**What counts:**
+- Reply
+- Conversation started
+- Meeting booked
+
+**NOT:**
+- Long messages
+- Clever wording
+- Over-explaining
+- Sounding impressive
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `sdr-outbound-rules` | Rules the prompts follow |
+| `cold-email-4-sequence` | Sequence structure |
+| `atl-btl-messaging` | Adjust prompt for seniority |
+| `personalization-playbooks` | Personalization level |
+
+## Example prompts
+
+```
+Use the Default Lead Messaging prompt to write a follow-up for a prospect who filled out a form but didn't book.
+```
+
+```
+Create a LinkedIn message using Frontal's tone for a VP Marketing.
+```
+
+```
+Write a WhatsApp message for a lead who missed their demo call.
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/sdr-outbound-rules/SKILL.md
+++ b/skills/alex-vacca/sdr-outbound-rules/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: sdr-outbound-rules
+title: SDR outbound rules
+description: "Use this skill when training SDRs, standardizing outbound email quality, reviewing or rewriting cold emails against word-count and CTA rules, choosing one of the 8 allowed messaging frameworks, or setting tone guidelines by offer type."
+category: Outreach
+---
+
+# SDR Outbound Writing Rules
+
+## Core Writing Rules
+
+```
+Emails: 60-90 words maximum
+No bullets in cold emails
+One CTA only
+
+CTA Rules:
+- Clear and direct
+- Respectful of their time
+- Scheduling-oriented when possible
+```
+
+---
+
+## Personalization Inputs to Use
+
+- Name
+- Company
+- Role
+- Industry
+- Challenge (if known)
+- Goal (if known)
+- Source/trigger
+- Familiarity level
+
+---
+
+## 8 Allowed Messaging Frameworks
+
+### 1. Before/After
+Show transformation from current state to desired state.
+
+### 2. Pattern Interrupt
+Break expected email patterns to grab attention.
+
+### 3. Ask Before Pitch
+Lead with question, earn right to pitch.
+
+### 4. Upfront Value
+Provide value before asking for anything.
+
+### 5. Do the Math
+Calculate potential impact with numbers.
+
+### 6. Challenge of Similar Companies
+Reference industry-specific patterns.
+
+### 7. Neutral Insight
+Share third-party resource, build trust.
+
+### 8. Typical Problems by Role
+Address role-specific pain points.
+
+---
+
+## Tone by Offer Type
+
+### Agency Services
+- Consultative
+- Strategic
+- Calm
+- Position as trusted advisor
+
+### Accelerator
+- Slang professional
+- Friendly
+- Curious
+- Approachable expert
+
+### Outbound Cold
+- Pattern interrupt
+- Short
+- Clear
+- Direct but not aggressive
+
+---
+
+## Quality Standards
+
+### Good Email
+- 60-90 words
+- One clear CTA
+- Specific social proof
+- Relevant trigger
+- Human tone
+
+### Bad Email
+- 150+ words
+- Multiple CTAs
+- Vague claims
+- No personalization
+- Corporate tone
+
+---
+
+## Review Checklist
+
+Before sending any outreach:
+
+- [ ] Under 90 words?
+- [ ] Single CTA?
+- [ ] Trigger or personalization included?
+- [ ] Social proof specific (numbers)?
+- [ ] Tone matches offer type?
+- [ ] No buzzwords?
+- [ ] No fake enthusiasm?
+- [ ] Would you respond to this?
+
+---
+
+## Combines with
+
+| Skill | Why |
+|-------|-----|
+| `sdr-master-prompts` | AI prompts following these rules |
+| `email-writing-frameworks` | Approved framework structures |
+| `josh-braun-copywriting` | Quality writing principles |
+| `email-metrics-benchmarks` | Track rule impact on metrics |
+
+## Example prompts
+
+```
+Review this email against the SDR outbound rules checklist.
+```
+
+```
+Rewrite this 150-word email to be under 90 words.
+```
+
+```
+Which of the 8 frameworks should I use for a cold outbound campaign?
+```
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/SKILL.md
+++ b/skills/alex-vacca/signal-sourcer/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: signal-sourcer
+title: The signal sourcer
+description: "Use this skill when running signal-based selling — buying signals, intent data, signal scoring and stacking, website visitor tracking, job changes, hiring, funding, competitor and tech-stack signals, and signal-to-action GTM plays. Triggers on 'buying signals', 'intent data', 'signal scoring', 'website visitors', 'job change', 'hiring signal', 'funding signal', 'competitor signal', 'tech change', 'warm outbound', 'signal stacking', 'RB2B', 'Trigify', 'GTM plays'."
+category: Signals
+---
+
+Reference files for this skill live in `references/` next to this file — load them with the relative paths given below.
+
+# Signal Sourcer — Orchestrator
+
+You are an expert in signal-based selling who has designed signal-driven GTM motions achieving 35-40% reply rates through multi-signal stacking. You specialize in buying signal identification, tool selection, signal scoring frameworks, and signal-to-action playbooks.
+
+## Routing Logic
+
+Analyze the user's request and delegate to the appropriate sub-skill. If the request spans multiple signal types, invoke the most relevant sub-skill first, then layer in others.
+
+### Sub-Skill Router
+
+| User asks about... | Route to | Path |
+|---|---|---|
+| Job changes, new roles, champion tracking, vendor amnesty period, days 14-45 | **job-changes** | Read `references/job-changes.md` |
+| Funding rounds, Series A/B/C, new budget, post-raise outreach | **funding** | Read `references/funding.md` |
+| Hiring signals, job postings, missing roles, leaving employees, skills targeting | **hiring** | Read `references/hiring.md` |
+| Website visitors, RB2B, pixel tracking, IP identification, visitor alerts | **website-visitors** | Read `references/website-visitors.md` |
+| Company events, M&A, expansion, IPO, product launches, leadership changes | **company-events** | Read `references/company-events.md` |
+| Tech stack changes, vendor switches, new tool adoption, BuiltWith | **tech-changes** | Read `references/tech-changes.md` |
+| Competitor engagement, bad reviews, LinkedIn scraping, battle cards | **competitor-signals** | Read `references/competitor-signals.md` |
+| Content engagement, post likes/comments, webinar attendance, Trigify | **content-engagement** | Read `references/content-engagement.md` |
+| Signal stacking, scoring framework, action thresholds, multi-signal, compound scoring | **multi-signal** | Read `references/multi-signal.md` |
+| Tool setup, comparison, pricing, which tool to use | Read `references/tool-setup-guides.md` directly |
+
+### Multi-Signal Requests
+
+When the user asks about combining signals or building a full signal strategy:
+1. Start with **multi-signal** sub-skill for the scoring framework
+2. Then pull in specific signal sub-skills for each signal type they need
+3. Reference tool-setup-guides.md for tool recommendations
+
+## Core Reference Files
+
+Load the appropriate reference based on context:
+
+- **6 core buying signals, benchmarks** -> Read `references/buying-signals.md`
+- **Scoring framework, weights, thresholds, SLAs** -> Read `references/signal-scoring.md`
+- **137 buying triggers taxonomy** -> Read `references/signal-taxonomy.md`
+- **Job change tracking in Clay** -> Read `references/job-change-tracking.md`
+- **Tool setup: RB2B, Trigify, Common Room, Bombora, etc.** -> Read `references/tool-setup-guides.md`
+- **11 executable GTM plays** -> Read `references/gtm-plays.md`
+- **30-trigger quick ref with detection tools, timing windows, Clay credit costs, signal freshness rules, reliability tiers, signal sources by data party** -> Read `references/signal-detection-tools.md`
+
+## Key Benchmarks (cite these)
+
+| Metric | Value |
+|---|---|
+| Cold outreach reply rate | 6-8% |
+| Single signal reply rate | 18-22% |
+| Multi-signal (3+) reply rate | 35-40% |
+| Job change response lift | 3x vs cold |
+| Job change peak window | Days 14-45 |
+| Website visitor reply rate | 25-30% |
+| Signal-based contract value | 3-4x baseline |
+| Multi-channel ABM meeting rate | 36% |
+
+## Signal Scoring Quick Reference
+
+| Score | Heat Level | Action | SLA |
+|---|---|---|---|
+| 150+ | Red Hot | Immediate manual outreach by AE | < 1 hour |
+| 100-149 | Hot | SDR personalized sequence | < 24 hours |
+| 50-99 | Warm | Automated nurture + SDR monitoring | < 72 hours |
+| 20-49 | Cool | Marketing nurture campaigns | This week |
+| 0-19 | Cold | Monitor for signal changes | Ongoing |
+
+## Response Format
+
+1. Identify which signals are relevant to the user's situation
+2. Route to the correct sub-skill(s) for detailed guidance
+3. Recommend a scoring framework with specific weights
+4. Map signals to actions (who does what, when, on which channel)
+5. Recommend tools based on budget, geography, and use case
+6. Provide ready-to-use outreach templates tied to each signal
+
+## Examples
+
+Example 1: "How do I track job changes for signal-based outreach?"
+-> Route to **job-changes** sub-skill
+
+Example 2: "Build me a complete signal scoring system"
+-> Route to **multi-signal** sub-skill, then reference specific signal sub-skills
+
+Example 3: "What signals should I track for my SaaS product?"
+-> Start with **multi-signal** for framework, then recommend 3-5 signal sub-skills based on ICP
+
+Example 4: "How do I set up RB2B?"
+-> Route to **website-visitors** sub-skill + read `references/tool-setup-guides.md`
+
+Example 5: "I want to target companies using a competitor's product"
+-> Route to **competitor-signals** sub-skill
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/buying-signals.md
+++ b/skills/alex-vacca/signal-sourcer/references/buying-signals.md
@@ -1,0 +1,84 @@
+# Buying Signals — Ranked by Purchase Correlation
+
+## 6 Core Buying Signals
+
+### 1. Former Customers & Alumni Users
+- Trust already established + known playbook
+- Faster proof of value
+- Query: Previous users of your product at new companies
+
+### 2. New Leadership ≤90 days
+- Mandate for early wins
+- Vendor amnesty period
+- Budget air cover for new initiatives
+- Query: LinkedIn job changes, press releases
+- **Peak engagement: days 14-45**
+
+### 3. High-Intent Website & Content
+- BOFU pages: pricing, competitor comparisons, demo, integrations
+- Shows active evaluation
+- Query: Website visitor tracking, content downloads
+- **25-30% reply rate (they know you)**
+- Act within 24-48 hours
+
+### 4. Tech Stack Change
+- Active change project indicates openness
+- Fresh pain from transition
+- New gaps in workflow
+- Query: BuiltWith, job postings mentioning new tools
+- **Active buying window**
+
+### 5. Expansion (Raise, New Region/Product)
+- Board targets create urgency
+- Scale pain emerges
+- Standardization moment
+- Query: Crunchbase, press releases, job postings
+- **Reach out 2-4 weeks after**
+
+### 6. Hiring or Downsizing
+- Hiring = ramp pressure, need efficiency
+- Downsizing = do-more-with-less mandate
+- Query: LinkedIn company growth, layoff news
+- **Signals budget allocation and priority areas**
+
+## 5 Buying Signals for Clay Workflows
+
+### 1. Recent Job Changes (0-90 days)
+- 3x higher response rate
+- Peak engagement: days 14-45
+- They're actively building their stack
+
+### 2. Company Hiring for Specific Roles
+- Signals budget allocation
+- Shows growth trajectory
+- Indicates priority areas
+
+### 3. Website Visitors
+- 25-30% reply rate (they know you)
+- Act within 24-48 hours
+- Highest intent signal
+
+### 4. Funding Announcements
+- Reach out 2-4 weeks after
+- New budget available
+- Mandate for growth spending
+
+### 5. Technology Changes
+- Active buying window
+- Fresh pain from transition
+- Open to new solutions
+
+## Signal Performance Benchmarks
+
+| Signal Type | Reply Rate |
+|-------------|------------|
+| Cold outreach (no signal) | 6-8% |
+| Single signal-based | 18-22% |
+| Multi-signal stacked (3+) | 35-40% |
+
+## Signal Workflow Tips
+
+- **Don't mention signal explicitly in email** (prospects get these constantly)
+- **Act fast** (hot signals expire in 3-7 days)
+- **Stack signals for heat scoring** (3+ signals = reach out same day)
+- **Signal-based outreach = 3-4x higher contract values**

--- a/skills/alex-vacca/signal-sourcer/references/company-events.md
+++ b/skills/alex-vacca/signal-sourcer/references/company-events.md
@@ -1,0 +1,79 @@
+# Company Event Signals
+
+Company events are firmographic triggers from the signal taxonomy (Category V). They indicate organizational change, new priorities, and buying windows. These include M&A activity, geographic expansion, product launches, leadership changes, and public market events.
+
+## Reference Files
+
+- Read `signal-taxonomy.md` for Category V: Firmographic Triggers (15 triggers)
+- Read `buying-signals.md` for expansion signal (#5 by purchase correlation)
+
+## 15 Firmographic Triggers
+
+### Financial Events
+1. **IPO** - Major transformation, compliance needs, new reporting requirements
+2. **Funding raised** - See funding sub-skill for detailed playbook
+3. **Financial reports released** - Public data on priorities and challenges
+
+### M&A Activity
+4. **Acquired another company** - Integration pain, tech consolidation, new headcount
+5. **Was acquired** - Leadership change, vendor review, stack consolidation
+6. **Merged** - Duplicate tools, standardization mandate, new org structure
+
+### Growth Signals
+7. **Hypergrowth** - Scale pain, process breaks, need for automation
+8. **Started hiring** - See hiring sub-skill for detailed playbook
+9. **Headquarters move** - New market, possible rebrand, vendor re-evaluation
+10. **New locations opened** - Geographic expansion, regional needs
+
+### Product and Marketing
+11. **New product released** - GTM needs, new team formation
+12. **New feature released** - Engineering investment signals priorities
+13. **New integration released** - Tech ecosystem expansion, partnership signals
+14. **Impactful marketing move** - Budget available, growth mindset
+15. **Competitor made impactful move** - Competitive pressure, urgency to respond
+
+## Scoring by Event Type
+
+| Event | Points | SLA | Rationale |
+|---|---|---|---|
+| Acquisition (acquirer) | 35 | < 72h | Integration creates tool needs |
+| Was acquired | 40 | < 72h | Vendor review inevitable |
+| Merger | 40 | < 72h | Stack consolidation |
+| IPO | 50 | < 72h | Compliance + transformation |
+| New location | 25 | This week | Regional expansion needs |
+| HQ move | 20 | This week | Possible vendor switch |
+| New product launch | 30 | < 72h | GTM team forming |
+| Competitor move | 15 | This week | Urgency catalyst |
+
+## Detection Sources
+
+- **Press releases** - TechCrunch, PR Newswire, company blogs
+- **Crunchbase / PitchBook** - M&A data, funding
+- **LinkedIn** - Leadership announcements, company updates
+- **Clay enrichment** - Auto-detect company news events
+- **Google Alerts** - Set up for target accounts
+- **SEC filings** - IPO, financial reports (public companies)
+
+## Key Rules
+
+- Company events are public information - no privacy concerns
+- M&A signals have a 2-6 week optimal outreach window after announcement
+- IPO = highest-scoring company event (50pts) due to transformation scope
+- Stack with leadership changes (job-changes skill) for compound scoring
+- Always reference the business challenge the event creates, not the event itself
+
+## Examples
+
+Example 1: "A target account just acquired a company"
+-> 35pts signal. Outreach within 72h. Reference integration pain (duplicate tools, process alignment, new headcount onboarding). Position your solution as the consolidation layer. Check for new leadership hires post-acquisition
+
+Example 2: "Monitor M&A activity in my target market"
+-> Clay: Set up Crunchbase/news monitoring on ICP accounts, filter for acquisition/merger events, enrich with decision-maker contacts, trigger SDR alerts for qualified matches within 72h
+
+Example 3: "A company just opened a new office in EMEA"
+-> 25pts signal. Reference regional expansion challenges (compliance, local processes, team coordination). Lighter touch - this week SLA. Stack with any hiring signals for the new location
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/competitor-signals.md
+++ b/skills/alex-vacca/signal-sourcer/references/competitor-signals.md
@@ -1,0 +1,90 @@
+# Competitor Signals
+
+Competitor signals come from Category III of the signal taxonomy (Based on Likely "In Market"). They reveal prospects actively evaluating alternatives, unhappy with current vendors, or engaging with competitor content. G2 comparison activity = 60 points (Tier 1).
+
+## Reference Files
+
+- Read `signal-taxonomy.md` for Category III: Competitors (triggers 8-16)
+- Read `gtm-plays.md` for Play 8 (Bad Reviews) and Play 11 (Inbound Followers)
+
+## 9 Competitor Triggers (from Taxonomy)
+
+1. **Churned customers (negative review)** - Left competitor, left a bad review
+2. **Churned customers (disintegration)** - Integration broke, product sunset
+3. **Current customers (website activity)** - Competitor users visiting your site
+4. **Current customers (integration use)** - Using a tool that integrates with yours
+5. **In-cycle customers** - Actively evaluating competitors now
+6. **Engaged with competitor content** - Liking/commenting on competitor posts
+7. **Followers of competitor page** - Brand-aware of the category
+8. **Mutual connections with competitor** - Network proximity
+9. **G2/Capterra comparison activity** - Active vendor comparison
+
+## Scoring by Signal Type
+
+| Competitor Signal | Points | SLA | Rationale |
+|---|---|---|---|
+| G2 comparison (your product vs competitor) | 60 | < 24h | Active vendor comparison |
+| Churned competitor customer (bad review) | 50 | < 24h | Pain is documented and public |
+| Competitor user visiting your website | 50 | < 1h | Cross-shopping actively |
+| In-cycle evaluation | 45 | < 24h | Buying window open |
+| Engaged with competitor LinkedIn content | 25 | < 72h | Category interest |
+| Follower of competitor page | 15 | This week | Passive awareness |
+
+## Play: Bad Reviews Targeting (Play 8)
+
+1. Scrape G2/Capterra for negative reviews of competitors (identifiable reviewers)
+2. Match reviewers to LinkedIn profiles via Clay
+3. Reference their specific pain point from the review
+4. Offer an alternative comparison
+
+**Template:**
+```
+Just saw your review of {{competitor}}...
+We researched and tested 3 alternatives (that do not suck).
+Shall I send the report to you?
+Cheers,
+[Name]
+```
+
+## Play: Competitor LinkedIn Followers
+
+1. Scrape competitor LinkedIn company page followers via Clay/Phantombuster
+2. Filter to ICP contacts (title, company size, industry)
+3. They are category-aware - position your differentiator
+
+**Template:**
+```
+Hey {{first_name}}, noticed you follow {{competitor}}.
+Most {{title}}s I talk to chose us over them because of {{key_differentiator}}.
+Worth a quick look? Here is a 2-min comparison: [link]
+```
+
+## Play: Competitor Customer Targeting
+
+1. Identify competitor customers via BuiltWith, LinkedIn, G2 profiles
+2. Look for renewal timing (annual contracts = predictable switch windows)
+3. Time outreach 60-90 days before likely renewal
+
+## Key Rules
+
+- Bad reviews are public data - ethical to reference
+- Do NOT trash-talk the competitor - position as an alternative, not a replacement
+- G2 comparison activity is a Tier 1 signal (60pts) - send competitive battlecard within 24h
+- Competitor users on your website = cross-shopping, highest urgency
+- Stack with intent data: competitor follower (15pts) + Bombora surge (40pts) + website visit (50pts) = 105pts Hot
+
+## Examples
+
+Example 1: "Target unhappy users of our competitor"
+-> Scrape G2/Capterra negative reviews, match to LinkedIn profiles in Clay, filter to ICP, reference their specific pain point. 50pts signal, SDR personalized outreach within 24h
+
+Example 2: "Someone from a competitor customer just visited our pricing page"
+-> Compound signal: competitor customer (implied) + pricing visit (80pts). Tier 1 response within 1 hour. They are actively cross-shopping. AE or senior SDR outreach
+
+Example 3: "Scrape our competitor LinkedIn followers for outreach"
+-> Clay/Phantombuster to scrape followers, enrich with company data, filter ICP, score at 15pts base. Personalized outreach referencing category interest and your key differentiator. Stack with other signals to prioritize
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/content-engagement.md
+++ b/skills/alex-vacca/signal-sourcer/references/content-engagement.md
@@ -1,0 +1,101 @@
+# Content Engagement Signals
+
+Content engagement signals span INBOUND and POSTBOUND categories in the taxonomy. They reveal brand awareness, category interest, and research activity. LinkedIn engagement = 30 points (Tier 2). Webinar attendance = 25 points. These are warm prospects who already know you.
+
+## Reference Files
+
+- Read `signal-taxonomy.md` for INBOUND triggers 1-30 (content, events, social engagement)
+- Read `gtm-plays.md` for Play 11 (Inbound Followers)
+
+## Content Signal Types
+
+### First-Party (Your Content)
+| Signal | Points | Category |
+|---|---|---|
+| Webinar attendance | 25 | INBOUND - Category interest |
+| Case study download | 35 | INBOUND - Research phase |
+| Newsletter subscriber | 15 | INBOUND - Brand awareness |
+| 3+ blog posts read | 20 | INBOUND - Early research |
+| Email click-through | 15 | POSTBOUND - Active interest |
+| Aggressive email opens | 10 | POSTBOUND - Monitoring |
+
+### Second-Party (Social Engagement)
+| Signal | Points | Category |
+|---|---|---|
+| Commented on your LinkedIn post | 35 | POSTBOUND - Active engagement |
+| Liked your LinkedIn post | 25 | POSTBOUND - Passive engagement |
+| Followed company LinkedIn page | 15 | INBOUND - Brand awareness |
+| Community engagement (Slack/Discord) | 30 | INBOUND - Active interest |
+| Engaged with employee personal page | 20 | POSTBOUND - Network awareness |
+
+## Trigify Setup (LinkedIn Engagement Tracking)
+
+1. **Create account** at trigify.io
+2. **Add LinkedIn URLs** to monitor (your company page, executive profiles, competitor pages)
+3. **Configure signal types**: Engagement, Social Signals, Job Changes
+4. **Set up Clay webhook**:
+   - Clay: Create table with webhook source, copy webhook URL
+   - Trigify: Select data sources, enter Clay webhook URL, test connection
+5. **Trigify sends automatically** on each new engagement event
+
+### What Trigify Captures
+- Person: name, title, company, LinkedIn URL
+- Engagement: post URL, type (like/comment), comment text
+- Company data: size, industry, domain
+- Signal type: engagement, job change, viral post
+
+### Pricing
+- Plans based on tracked profiles and signal volume
+- Free trial available
+- Starts at $69/mo, scales to $549/mo for high volume
+
+## Play: Inbound Followers (Play 11)
+
+1. Monitor new LinkedIn followers daily (Trigify or manual)
+2. Filter to ICP via Clay enrichment
+3. Personalized outreach within 24-48 hours
+
+**Template:**
+```
+Hey {{first_name}}, thanks for the follow.
+Noticed you are a {{title}} at {{company}}.
+Most {{title}}s I talk to are dealing with {{common_problem}}.
+Is that on your radar?
+```
+
+## Play: Post Engagers
+
+1. Track likes/comments on your high-performing posts (Trigify)
+2. Commenters > Likers in intent (active vs passive)
+3. Reference the post topic in outreach
+
+**Template:**
+```
+Hey {{first_name}}, saw your comment on our post about {{topic}}.
+Sounds like {{relevant_insight_from_comment}}.
+We actually built [solution] for exactly that - want a closer look?
+```
+
+## Key Rules
+
+- Commenters are 2x more valuable than likers (active engagement vs passive)
+- Webinar attendees > registrants (they actually showed up)
+- Do NOT reference the exact signal ("I saw you liked my post") - reference the topic interest
+- Stack content signals with website visits for compound scoring: blog visits (20pts) + LinkedIn engagement (30pts) + email click (15pts) = 65pts Warm
+- Trigify is the primary tool for LinkedIn engagement tracking ($69-$549/mo)
+
+## Examples
+
+Example 1: "Set up Trigify to track LinkedIn engagement"
+-> Create Trigify account, add company page + executive LinkedIn URLs, configure for likes/comments/follows, set up Clay webhook, filter to ICP contacts, route qualified engagers to SDR Slack channel
+
+Example 2: "Someone commented on our LinkedIn post and they match ICP"
+-> 35pts signal (comment). Outreach within 24-48h. Reference the topic of the post and their comment insight. Warm touch, not a hard sell. Check for other signals to stack
+
+Example 3: "Track who attends our webinars and follow up"
+-> 25pts per attendee. Enrich in Clay with company/title data, filter to ICP, send recording + relevant offer within 48h. SDR owns outreach. Registrants who did NOT attend get lighter nurture follow-up
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/funding.md
+++ b/skills/alex-vacca/signal-sourcer/references/funding.md
@@ -1,0 +1,82 @@
+# Funding Signals
+
+Funding rounds are the #5 buying signal by purchase correlation. They indicate new budget availability, board-mandated growth targets, and urgency to scale. Reach out 2-4 weeks after announcement for optimal timing.
+
+## Reference Files
+
+- Read `buying-signals.md` for signal ranking and benchmarks
+- Read `signal-taxonomy.md` for firmographic triggers (Category V)
+
+## Why Funding Signals Work
+
+- **New budget available** - board expects the money to be deployed
+- **Mandate for growth spending** - investors want velocity
+- **Scale pain emerges** - what worked at Series A breaks at Series B
+- **Standardization moment** - time to replace patchwork tools
+- Series A/B/C funding = 45 points (Tier 2 signal)
+- Funding $10M+ = Act within 24 hours (Tier 2 SLA)
+- Funding <$10M = Act within 72 hours (Tier 3 SLA)
+
+## Timing Framework
+
+| Window | Priority | Action |
+|---|---|---|
+| Week 1 | Too early | They are celebrating, doing press - monitor only |
+| Weeks 2-4 | Peak | Outreach window - they are planning spend |
+| Weeks 5-8 | Good | Still allocating budget, hiring started |
+| Weeks 9+ | Declining | Budget likely committed to vendors already |
+
+## Detection Sources
+
+- **Crunchbase** - API or Clay enrichment for funding rounds
+- **Press releases** - TechCrunch, company blogs, LinkedIn announcements
+- **Clay enrichment** - Auto-detect funding events on target accounts
+- **LinkedIn posts** - Founders/CEOs announce rounds
+- **PitchBook / CB Insights** - Premium data for larger deals
+
+## Signal Scoring by Round
+
+| Round | Points | Rationale |
+|---|---|---|
+| Seed / Pre-Seed | 20 | Early stage, limited budget |
+| Series A ($5-15M) | 35 | Building initial stack |
+| Series B ($15-50M) | 45 | Scaling pain, replacing tools |
+| Series C+ ($50M+) | 45 | Enterprise needs, standardization |
+| IPO | 50 | Major transformation, compliance needs |
+
+## Outreach Template
+
+```
+Congrats on the {{round}} - exciting time for {{company}}.
+
+Most {{industry}} companies at this stage struggle with
+{{relevant_problem}} as they scale from {{current_stage}} to {{next_stage}}.
+
+We helped {{similar_company}} navigate exactly that after their raise.
+
+Worth a quick chat?
+```
+
+## Key Rules
+
+- Do NOT lead with "I saw you raised money" - everyone does this
+- Reference the growth challenge the funding creates, not the funding itself
+- $10M+ rounds get SDR personalized sequence within 24 hours
+- <$10M rounds get lighter congratulations + nurture within 72 hours
+- Stack with hiring signals for compound scoring: funding (45pts) + hiring (40pts) = 85pts Warm
+
+## Examples
+
+Example 1: "Track funding rounds for my target accounts"
+-> Set up Clay table with Crunchbase enrichment, filter by round size and ICP fit, trigger Slack alerts for $10M+ rounds, auto-enqueue SDR sequence for qualified accounts
+
+Example 2: "A prospect just raised Series B"
+-> Weeks 2-4 optimal window. Reference scaling challenges specific to their stage. SDR personalized outreach within 24h. Score = 45pts base, stack with any other active signals
+
+Example 3: "Build a funding-based outbound workflow"
+-> Clay: Crunchbase monitoring on ICP accounts, filter round >= $5M, enrich contacts (VP+), calculate weeks-since-announcement, route week 2-4 to SDR Slack channel, auto-add to CRM with signal tag
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/gtm-plays.md
+++ b/skills/alex-vacca/signal-sourcer/references/gtm-plays.md
@@ -1,0 +1,219 @@
+# 11 GTM Plays — Detailed Execution
+
+## Play 1: New Team Members
+
+**Signal:** Company recently added team members in relevant department
+
+**Execution:**
+- Reference the new hire's name in copy
+- Shows you're paying attention to their growth
+- Works best 2-4 weeks after hire announcement
+
+**Template:**
+```
+Noticed {{company}} just added {{new_hire_name}} to the {{department}} team.
+
+Growing teams usually means [relevant challenge].
+
+We helped {{similar_company}} handle this by [solution].
+
+Worth a quick chat?
+```
+
+## Play 2: Skills-Targeting
+
+**Signal:** LinkedIn profile displays specific skills relevant to your product
+
+**Execution:**
+- Target based on listed skills (not just job titles)
+- More precise than title-based targeting
+- Clay can extract skills from LinkedIn profiles
+
+**Use Cases:**
+- Salesforce skill → Salesforce add-on products
+- Python skill → Developer tools
+- HubSpot skill → Marketing automation
+
+## Play 3: Role-Targeting
+
+**Signal:** Uncommon job title indicates company priority
+
+**Execution:**
+- Target very specific, unusual titles
+- Title existence = company budget/priority
+
+**Examples:**
+- "Happiness Manager" → Employee wellbeing budget exists
+- "E-commerce Specialist" → Confirmed e-commerce operation
+- "RevOps Manager" → Revenue operations is a priority
+- "Growth Engineer" → Technical growth function exists
+
+## Play 4: Industry-Level Research
+
+**Signal:** Create your own signal through surveys
+
+**Execution:**
+1. Survey ICP experts on topics they care about
+2. Opens conversations with value-first approach
+3. Use insights as content later
+
+**Template:**
+```
+Hey {{first_name}} — we're surveying {{role}} experts on {{topic}}.
+
+We have a page listing {{insight_type}} used at {{company_types}}.
+
+Want to contribute?
+[Link]
+
+You can add your links too (socials, projects, blog, website).
+We get ~XXk monthly visits so it's good exposure.
+```
+
+## Play 5: Resources for Individual Contributors (Evergreen)
+
+**Signal:** New SDRs/ICs starting roles continuously
+
+**Execution:**
+- Automated, always-on campaign
+- Send useful resource when someone starts a new IC role
+- Long-term brand building
+
+**Template:**
+```
+Hey {{first_name}}, congrats on the new role at {{company_name}}.
+
+We know how tough outreach can be, so we compiled our highest-converting
+cold email frameworks (used by 364 SDRs already!).
+
+Here they are: [Link]
+
+Good luck!
+```
+
+## Play 6: Leaving Employees
+
+**Signal:** Team members recently left (relevant department)
+
+**Execution:**
+- Reference the departing person's name
+- Position around coverage gap
+- Timing: 1-2 weeks after departure
+
+**Template:**
+```
+Saw {{former_employee}} recently left {{company}}.
+
+That usually creates a gap in {{function_area}}.
+
+We've been helping companies like {{similar_company}} cover that gap with [solution].
+
+Worth exploring?
+```
+
+## Play 7: Companies Without Dedicated Employees
+
+**Signal:** No one with specific title at company
+
+**Execution:**
+- Identify companies missing a key role
+- Position your product as the solution
+- Works well for automation/outsourcing products
+
+**Example Logic:**
+- No "Content Manager" + $5M+ revenue = Content gap
+- No "DevOps Engineer" + Growing engineering team = DevOps need
+- No "SDR Manager" + SDR team exists = Management gap
+
+## Play 8: Bad Reviews Targeting
+
+**Signal:** Negative G2/Capterra review of competitor
+
+**Execution:**
+- Scrape negative reviews (identifiable reviewers)
+- Reference their specific pain
+- Offer alternatives
+
+**Template:**
+```
+Just saw your review of {{competitor}}...
+
+We researched and tested 3 alternatives (that don't suck).
+
+Shall I send the report to you?
+
+Cheers,
+[Name]
+```
+
+## Play 9: AI-Generated Ideas
+
+**Signal:** Create personalized value through AI research
+
+**Execution:**
+1. Use AI to generate 2 relevant ideas for their business
+2. Add your offer as the 3rd (with humor)
+3. Offer more ideas with context
+
+**Template:**
+```
+Based on {{company_description}}, here are 3 ideas:
+
+[1] {{AI_generated_idea_1}}
+[2] {{AI_generated_idea_2}}
+[3] Hire a sales prospecting agency to start generating leads on autopilot
+
+I'd probably give better ideas with more context.
+
+Want to chat?
+```
+
+## Play 10: ServiceBell Allbound Plays
+
+**Signal:** Website visitor activity
+
+**Execution:**
+- Coordinate outbound with real-time website visits
+- Call/email when prospect is on site
+- Multi-touch engagement strategy
+
+**Sequence:**
+1. Visitor hits pricing page → Trigger alert
+2. SDR calls within 2 minutes
+3. If no answer → Immediate email
+4. Next day → LinkedIn connection
+
+## Play 11: Inbound Followers
+
+**Signal:** New LinkedIn follower matches ICP
+
+**Execution:**
+- Monitor new followers daily
+- Filter to ICP via Clay
+- Personalized outreach within 24-48 hours
+
+**Template:**
+```
+Hey {{first_name}}, thanks for the follow.
+
+Noticed you're a {{title}} at {{company}}.
+
+Most {{title}}s I talk to are dealing with {{common_problem}}.
+
+Is that on your radar?
+```
+
+## Core GTM Philosophy
+
+- **Scale what top performers do** — Study best reps, systematize their approach
+- **Diagnose before prescribing** — BIPSY framework: Behaviors, Individual, Process, Skill, You
+- **Signal-based outreach = 3-4x higher contract values**
+- **You can't burn your TAM** — Re-engage with new angles
+- **Lead with pain, not features**
+- **Segment and convert, don't over-personalize** — Gorgias went from 200 sequences to 10 modular ones
+
+## Multi-Channel Coordination
+
+- Email + ads + referrals = extra $2M ARR (case study)
+- ABM approach = 36% meeting rate vs 10% non-ABM
+- Warm before you touch principle

--- a/skills/alex-vacca/signal-sourcer/references/hiring.md
+++ b/skills/alex-vacca/signal-sourcer/references/hiring.md
@@ -1,0 +1,84 @@
+# Hiring Signals
+
+Hiring is the #6 buying signal by purchase correlation. It reveals budget allocation, growth trajectory, and priority areas. Hiring signals include new roles posted, missing roles at a company, leaving employees, and skills-based targeting.
+
+## Reference Files
+
+- Read `buying-signals.md` for signal ranking and benchmarks
+- Read `signal-taxonomy.md` for firmographic triggers (Companies that Started Hiring)
+- Read `gtm-plays.md` for plays 1-3, 5-7 (hiring-related GTM plays)
+
+## Why Hiring Signals Work
+
+- **Signals budget allocation** - if they are hiring for a role, budget exists
+- **Shows growth trajectory** - expanding teams = scaling pain
+- **Indicates priority areas** - what roles they hire reveals what they value
+- **Ramp pressure** - new hires need tools to be productive fast
+- Relevant job posting = 40 points (Tier 2 signal)
+- Act within 24 hours of detection
+
+## Five Hiring Signal Types
+
+### 1. New Team Members (Play 1)
+Company recently added members to relevant department. Reference the new hire by name, reach out 2-4 weeks after.
+
+### 2. Leaving Employees (Play 6)
+Team members recently left a relevant department. Position around the coverage gap, reach out 1-2 weeks after departure.
+
+### 3. Missing Roles (Play 7)
+Company lacks a specific title entirely. No "Content Manager" + $5M+ revenue = content gap your product can fill.
+
+### 4. Skills-Targeting (Play 2)
+LinkedIn profiles display specific skills relevant to your product. More precise than title-based targeting - Clay extracts skills from profiles.
+
+### 5. Role-Targeting (Play 3)
+Uncommon job titles indicate company priority. "RevOps Manager" = revenue operations is a budget line. "Growth Engineer" = technical growth function exists.
+
+## Outreach Templates
+
+**New team members:**
+```
+Noticed {{company}} just added {{new_hire_name}} to the {{department}} team.
+Growing teams usually means [relevant challenge].
+We helped {{similar_company}} handle this by [solution].
+Worth a quick chat?
+```
+
+**Leaving employees:**
+```
+Saw {{former_employee}} recently left {{company}}.
+That usually creates a gap in {{function_area}}.
+We have been helping companies like {{similar_company}} cover that gap with [solution].
+Worth exploring?
+```
+
+**Missing roles:**
+```
+Noticed {{company}} does not have a dedicated {{role}} yet.
+Most {{industry}} companies at your stage handle {{function}} with [your solution type].
+We helped {{similar_company}} do exactly that.
+```
+
+## Key Rules
+
+- Job postings are public intent data - no privacy concerns
+- Stack hiring + funding for strong compound signal (40 + 45 = 85pts Warm)
+- Missing role signal works best for automation/outsourcing products
+- Skills-targeting is more precise than title-based targeting
+- Reference the growth challenge, not "I saw your job posting"
+
+## Examples
+
+Example 1: "Find companies hiring SDRs as a signal"
+-> Clay: scrape job boards for SDR postings at ICP companies, enrich with company data, filter by size/industry, reach out to VP Sales referencing team growth and ramp challenges
+
+Example 2: "Target companies that do not have a dedicated RevOps person"
+-> Clay: pull ICP company list, check LinkedIn for "RevOps" titles, filter to companies with 0 results, reach out to VP Sales/CRO positioning your tool as the RevOps layer they are missing
+
+Example 3: "Someone just left the marketing team at a target account"
+-> 1-2 week window. Reference the coverage gap by name. Position your solution as a way to maintain output during the transition. SDR sequence within 24h of detection
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/job-change-tracking.md
+++ b/skills/alex-vacca/signal-sourcer/references/job-change-tracking.md
@@ -1,0 +1,50 @@
+# Job Change Tracking
+
+## Overview
+
+Monitor job changes of your contacts as buying signals.
+
+## Two Methods in Clay
+
+### 1. Monitor Existing Table
+- Actions > Monitor for Job Changes
+- Specify the LinkedIn URL column
+- Save and run
+
+### 2. Create New Tracking Table
+- +Create New > Table > Track Job Changes
+- Or copy a template
+
+## Historical vs Future Tracking
+
+### Historical
+- Include "Company LinkedIn URL"
+- Checks if the contact has changed companies
+
+### Future
+- Only "Person LinkedIn URL"
+- Monitors future changes
+
+## Behavior
+
+- New row created for each detected change
+- Complete history maintained
+- Delay from a few minutes to several hours depending on volume
+
+## Signal Value
+
+- 3x higher response rate vs cold
+- Peak engagement: days 14-45 after change
+- They're actively building their stack
+- Vendor amnesty period (new leadership willing to try new tools)
+
+## Best Trigger Template
+
+```
+Hey congrats on the new role at {{company}}.
+
+As you're taking over {{department}}, curious how you're
+currently handling {{relevant_problem}}?
+
+We helped {{similar_company}} with exactly that.
+```

--- a/skills/alex-vacca/signal-sourcer/references/job-changes.md
+++ b/skills/alex-vacca/signal-sourcer/references/job-changes.md
@@ -1,0 +1,76 @@
+# Job Change Signals
+
+Job changes are the #2 buying signal by purchase correlation. New leaders have a mandate for early wins, vendor amnesty period, and budget air cover. Response rate is 3x higher than cold outreach, with peak engagement at days 14-45.
+
+## Reference Files
+
+- Read `job-change-tracking.md` for Clay setup and tracking methods
+- Read `buying-signals.md` for signal ranking and benchmarks
+
+## Why Job Changes Work
+
+- **3x higher response rate** vs cold outreach
+- **Peak engagement: days 14-45** after the change (vendor amnesty period)
+- New leaders actively build their stack in first 90 days
+- Trust already established with former champions
+- Champion job change to target account = 75 points (Tier 1 signal)
+
+## Clay Setup - Two Methods
+
+### Method 1: Monitor Existing Table
+1. Go to Actions > Monitor for Job Changes
+2. Specify the LinkedIn URL column
+3. Save and run - new row created for each detected change
+
+### Method 2: Create New Tracking Table
+1. +Create New > Table > Track Job Changes
+2. Include "Person LinkedIn URL" for future monitoring
+3. Include "Company LinkedIn URL" to detect if they already changed
+
+### Historical vs Future
+- **Historical**: Include both Person + Company LinkedIn URLs - checks if contact already changed
+- **Future**: Only Person LinkedIn URL - monitors ongoing changes
+
+## Timing Framework
+
+| Window | Multiplier | Action |
+|---|---|---|
+| Days 0-13 | Too early | Monitor only - they are still settling in |
+| Days 14-45 | Peak (1.5x) | Immediate outreach - vendor amnesty window |
+| Days 46-90 | Good (1.0x) | Standard outreach - still building stack |
+| Days 90+ | Declining (0.7x) | Lower priority - stack likely set |
+
+## Outreach Template
+
+```
+Hey congrats on the new role at {{company}}.
+
+As you are taking over {{department}}, curious how you are
+currently handling {{relevant_problem}}?
+
+We helped {{similar_company}} with exactly that.
+```
+
+## Key Rules
+
+- Do NOT mention you tracked their job change ("I saw you moved to...")
+- Reference the role/department naturally, not the signal itself
+- Former champions get AE-owned outreach (warm relationship)
+- New contacts at target accounts get SDR sequence
+- Stack with other signals for compound scoring: job change (75pts) + website visit (50pts) = Hot
+
+## Examples
+
+Example 1: "Track when my past customers change jobs"
+-> Set up Clay historical tracking with Person + Company LinkedIn URLs, filter to ICP companies, trigger AE outreach within 24h
+
+Example 2: "Someone just started as VP Sales at a target account"
+-> Day 14-45 window = peak timing. Send congratulations + reference relevant problem for their new role. AE owns if former champion, SDR if new contact
+
+Example 3: "Build a job change signal workflow in Clay"
+-> Create tracking table with Person LinkedIn URLs, add enrichment columns (new company, title, start date), filter ICP match, calculate days-since-change, route to Slack alerts for day 14+ changes
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/multi-signal.md
+++ b/skills/alex-vacca/signal-sourcer/references/multi-signal.md
@@ -1,0 +1,123 @@
+# Multi-Signal Stacking and Scoring
+
+Multi-signal stacking is the highest-performing outbound strategy: 3+ signals = 35-40% reply rate vs 6-8% cold. This sub-skill covers the scoring framework, recency multipliers, action thresholds, response SLAs, and compound scoring logic.
+
+## Reference Files
+
+- Read `signal-scoring.md` for the complete scoring framework (weights, recency, thresholds, SLAs, plays)
+- Read `gtm-plays.md` for 11 executable GTM plays and multi-channel coordination
+- Read `signal-detection-tools.md` for 30-trigger quick reference with detection tools, timing windows, Clay credit costs, signal freshness rules (when signals expire), reliability tiers, and signal sources by data party (1st/2nd/3rd)
+
+## Performance Benchmarks
+
+| Approach | Reply Rate | Contract Value |
+|---|---|---|
+| Cold outreach (no signal) | 6-8% | Baseline |
+| Single signal-based | 18-22% | 2-3x baseline |
+| Multi-signal stacked (3+) | 35-40% | 3-4x baseline |
+| Signal + ABM multi-touch | 36% meeting rate | Highest |
+
+## Signal Scoring Framework
+
+### Tier 1 - Hot Signals (50-100 points)
+| Signal | Points |
+|---|---|
+| Demo/pricing request | 100 |
+| 3+ pricing page visits in 7 days | 80 |
+| Champion job change to target account | 75 |
+| Multiple stakeholders from same account | 70 |
+| Product trial signup | 65 |
+| G2 comparison with competitors | 60 |
+| 5+ website visits in 2 weeks | 50 |
+
+### Tier 2 - Warm Signals (20-49 points)
+| Signal | Points |
+|---|---|
+| Series A/B/C funding | 45 |
+| Relevant job posting | 40 |
+| Bombora topic surge (score 70+) | 40 |
+| Case study download | 35 |
+| LinkedIn engagement with your content | 30 |
+| Webinar attendance | 25 |
+| 3+ blog post visits | 20 |
+
+### Tier 3 - Cool Signals (5-19 points)
+| Signal | Points |
+|---|---|
+| Company news (expansion) | 15 |
+| Single website visit | 10 |
+| Industry report download | 10 |
+| Email open (no click) | 5 |
+| Social follow (no engagement) | 5 |
+
+## Recency Multipliers
+
+| Recency | Multiplier |
+|---|---|
+| Last 24 hours | 1.5x |
+| Last 7 days | 1.2x |
+| Last 14 days | 1.0x |
+| Last 30 days | 0.7x |
+| 30+ days ago | 0.3x |
+
+## Action Thresholds
+
+| Score | Heat Level | Action | SLA | Owner |
+|---|---|---|---|---|
+| 150+ | Red Hot | Immediate manual outreach | < 1 hour | AE |
+| 100-149 | Hot | Personalized sequence | < 24 hours | SDR |
+| 50-99 | Warm | Automated nurture + SDR monitoring | < 72 hours | SDR + Marketing |
+| 20-49 | Cool | Marketing nurture campaigns | This week | Marketing |
+| 0-19 | Cold | Monitor for signal changes | Ongoing | System |
+
+## Compound Scoring Examples
+
+| Scenario | Signals | Calculation | Score | Heat |
+|---|---|---|---|---|
+| Red Hot | Pricing page (80) + Champion job change (75) + Bombora surge (40) | 80+75+40 | 195 | Red Hot |
+| Very Warm | Funding (45) + Hiring (40) + 3 blog visits (20) | 45+40+20 | 105 | Hot |
+| Warm | Website visit (10) + LinkedIn engagement (30) + Email click (15) | 10+30+15 | 55 | Warm |
+| Cool | Blog visit (10) + Email open (5) | 10+5 | 15 | Cold |
+
+## Building a Complete Scoring System
+
+1. **Choose your signals** - Pick 5-10 signals from Tiers 1-3 based on ICP and available tools
+2. **Assign weights** - Use the framework above as starting point, adjust based on your conversion data
+3. **Set recency decay** - Apply multipliers so stale signals do not inflate scores
+4. **Define thresholds** - 150/100/50/20 breakpoints, adjust after 30 days of data
+5. **Map actions** - Each threshold gets a specific play, channel, owner, and SLA
+6. **Automate routing** - Clay scores + Slack alerts + CRM updates
+7. **Review monthly** - Recalibrate weights based on closed-won attribution
+
+## Implementation Tools
+
+- **Clay**: Custom scoring formulas with enrichment data
+- **Common Room**: Built-in scoring across 50+ sources ($1K+/mo)
+- **Koala**: Product + website signal scoring (Free/$750/mo)
+- **HubSpot/Salesforce**: Native lead scoring with intent integration
+- **6sense**: AI predictive scoring ($35K+/yr)
+
+## Key Rules
+
+- 3+ signals = always worth immediate outreach (35-40% reply rate)
+- Recency matters more than signal count - 1 fresh Tier 1 signal > 3 stale Tier 2 signals
+- Response speed is the #1 lever: 5-min response = 21x more likely to qualify vs 30 min
+- 50% of signal value is lost after 7 days - speed wins
+- Stack across categories (website + social + firmographic) for strongest compound signals
+- Recalibrate weights monthly based on actual conversion data
+
+## Examples
+
+Example 1: "Build me a complete signal scoring system"
+-> Design 3-tier framework with 8-10 signals, assign weights from the table above, apply recency multipliers, define 5 heat levels with actions/SLAs/owners, recommend Clay for scoring automation, set monthly review cadence. Map each threshold to a GTM play from `gtm-plays.md` (e.g., Play 5 for hiring signals, Play 8 for competitor bad reviews, Play 9 for champion job changes).
+
+Example 2: "A prospect has 3 signals firing - what do I do?"
+-> Calculate compound score: sum points for each signal, apply recency multipliers, map to heat level. 150+ = AE immediate outreach within 1 hour (see Play 9: Champion Change). 100-149 = SDR personalized sequence within 24h. Include all 3 signals as context for personalization (without mentioning them directly).
+
+Example 3: "How do I prioritize my signal queue?"
+-> Sort by compound score (highest first), then by recency of most recent signal. Red Hot (150+) always first. Within same heat level, prioritize accounts with freshest signals (24h > 7d > 14d). Assign capacity: AE handles top 5 Red Hot/day, SDR handles top 20 Hot/day. Use Play 10 (ServiceBell Allbound) for website visitor signals, Play 11 (Inbound Followers) for content engagement.
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/signal-detection-tools.md
+++ b/skills/alex-vacca/signal-sourcer/references/signal-detection-tools.md
@@ -1,0 +1,168 @@
+# Signal Detection Tools & Freshness Rules
+
+## 30 Sales Triggers — Quick Reference with Detection Tools
+
+### 1. Funding & Financial Signals
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 1 | Series A+ Funding | Crunchbase, PredictLeads, Owler, PitchBook | 0-90 days | 1 (Intellizence) |
+| 2 | Revenue Milestone | News monitoring, Serper | 30-60 days | 0 (Serper API) |
+| 3 | IPO Filing/Preparation | SEC filings, Crunchbase | 60-180 days | 1 |
+| 4 | M&A Activity | Crunchbase, PredictLeads, News | 30-90 days | 1 |
+| 5 | New Investment Round | Clay + Intellizence | 0-60 days | 1 |
+
+### 2. Hiring & Team Changes
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 6 | New Executive Hire | LinkedIn (Clay/Lima Data), Sales Nav | Days 14-30 | 1 |
+| 7 | Hiring Surge (5+ roles) | LinkedIn Jobs, PredictLeads, Clay | 30-90 days | 1 |
+| 8 | SDR/BDR Hiring | LinkedIn, PredictLeads | 14-60 days | 1 |
+| 9 | Department Expansion | LinkedIn headcount data | 30-90 days | 1 |
+| 10 | Champion Job Change | Clay, LoneScale, Champify | 0-30 days | 1-2 |
+
+### 3. Technology & Digital Signals
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 11 | New Tech Adoption | BuiltWith, HG Insights, TheirStack | 30-90 days | 0 (Claygent) |
+| 12 | Tech Stack Removal | BuiltWith, HG Insights | 0-30 days | 0 (Claygent) |
+| 13 | Website Redesign | Claygent + web scrape | 30-60 days | 1-2 |
+| 14 | New Product Launch | News, Serper, Company blog | 14-60 days | 0 (Serper API) |
+| 15 | Running LinkedIn Ads | Serper API | Active = active budget | 0 (Serper API) |
+
+### 4. Competitive & Vendor Intelligence
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 16 | Negative G2/Capterra Reviews | Zenrows + G2/Capterra | 0-90 days | 3 |
+| 17 | Competitor Contract Expiry | PredictLeads, intent data | 60-90 days before renewal | 1 |
+| 18 | Competitor Downgrade/Churn | BuiltWith (tech removal) | 0-30 days | 0 (Claygent) |
+| 19 | Pricing Page Visits | RB2B, Common Room, Vector | 0-7 days | Varies |
+| 20 | Comparison Shopping | G2 buyer intent, 6sense | 7-30 days | 3 |
+
+### 5. Product & Business Events
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 21 | Geographic Expansion | News, LinkedIn, PredictLeads | 30-90 days | 0-1 |
+| 22 | New Office/Location | News, Google Maps | 30-90 days | 0 (Serper API) |
+| 23 | Regulatory Change Impact | Industry news, Serper | 0-60 days | 0 (Serper API) |
+| 24 | Conference/Event Attendance | Event sites, LinkedIn, scraping | -14 to +7 days | 0-1 |
+| 25 | Partnership Announcement | News, LinkedIn posts | 14-60 days | 0 (Serper API) |
+
+### 6. Marketing & Reputation Signals
+
+| # | Trigger | Detection Tool | Timing Window | Clay Credits |
+|---|---------|---------------|---------------|-------------|
+| 26 | LinkedIn Post Engagement | Clay, Trigify, Teamfluence | 0-7 days | 1 |
+| 27 | Content Topic Shift | Company blog monitoring | 30-60 days | 0 (Claygent) |
+| 28 | Award/Recognition | News, Serper | 14-30 days | 0 (Serper API) |
+| 29 | PR/Media Mention | Serper, Google News | 7-30 days | 0 (Serper API) |
+| 30 | Community Engagement | PhantomBuster, Clay | 0-14 days | 1-2 |
+
+---
+
+## Signal Freshness Rules
+
+| Signal Type | Fresh Until | Optimal Outreach Window | Decay Rate |
+|-------------|-------------|------------------------|------------|
+| Champion job change | 30 days | 0-14 days | Fastest — act immediately |
+| LinkedIn post engagement | 30 days | 0-7 days | Fast |
+| Pricing page visits | 7 days | 0-3 days | Very fast |
+| Conference/event | 21 days | -7 to +7 days around event | Fast |
+| Tech stack change | 60 days | 0-30 days | Moderate |
+| New executive hire | 90 days | Days 14-30 (first 90 days open to ideas) | Moderate |
+| Hiring activity | 60 days | 14-30 days | Moderate |
+| Funding news | 90 days | Weeks 2-8 post-announcement | Moderate |
+| Series C deployment | 180 days | Weeks 5-12 (budget allocation phase) | Slow |
+| G2/review activity | 90 days | 0-30 days | Moderate |
+| Negative competitor reviews | 180 days | 0-60 days | Slow |
+| Company news/PR | 30 days | 7-30 days | Moderate |
+| Regulatory change | 60 days | 0-60 days | Moderate |
+
+### Freshness Rules for Outreach
+- **If signal is within optimal window** → Prioritize, reference directly
+- **If signal is fresh but past optimal** → Use as context, don't lead with it
+- **If signal is expired** → Drop from signal-based messaging, revert to ICP-based
+
+---
+
+## Signal Reliability Tiers
+
+### Tier 1 — Highest Intent (Same-day outreach)
+- Funding announcement (Series A+)
+- Expansion into new market/geography
+- Leadership change in buyer's department
+- **= Budget is approved or about to be. Act fast.**
+
+### Tier 2 — Strong Intent (30-90 day window)
+- Competitor tech adoption/removal
+- Partnership or acquisition announcement
+- Hiring surge in relevant department (5+ roles)
+- **= Investment is happening. Timing window is 30-90 days.**
+
+### Tier 3 — Moderate Intent (Nurture sequence)
+- Job postings (1-3 roles)
+- Industry award or recognition
+- Product launch or feature release
+- **= Activity is there, but intent is less urgent.**
+
+### Tier 4 — Weak Intent (Context only)
+- Social media activity
+- Website traffic spikes
+- General news mentions
+- **= Interesting context. Not a trigger on its own.**
+
+---
+
+## Signal Sources by Data Party
+
+### 1st-Party (Your Own Data) — Strongest
+| Source Type | Tools |
+|-----------|-------|
+| CRM | HubSpot, Salesforce, Attio |
+| Product usage | Mixpanel, Amplitude, Intercom |
+| Meeting forms | Chili Piper, Default, Calendly |
+| Gated content | Webflow, Distribute, Gamma |
+| Marketing sequences | beehiiv, customer.io, Kit |
+| Website visitors | Common Room, RB2B, Vector |
+
+### 2nd-Party (Partner Data) — Strong
+| Source Type | Tools |
+|-----------|-------|
+| Partner signals | Crossbeam, PartnerStack |
+| Warm intros | LinkedIn, The Swarm, Commsor |
+| Review sites | G2, Capterra |
+| Champion moves | Clay, LoneScale, Champify |
+| Ad insights | ZenABM, Fibbler, Vector |
+| LinkedIn engagement | Clay, Teamfluence, Trigify |
+
+### 3rd-Party (Public Data) — Moderate to Strong
+| Source Type | Tools |
+|-----------|-------|
+| Technographic | BuiltWith, HG Insights, TheirStack |
+| Job openings | Clay, PredictLeads |
+| Firmographic | Apollo, Amplemarket, Cognism |
+| People data | Sales Nav, Clay |
+| Web data | Clay, Apify, Zenrows |
+| Social | Clay, PhantomBuster, Trigify |
+| Funding | Crunchbase, Owler, PitchBook |
+
+---
+
+## Cost Optimization for Signal Detection
+
+| Signal | Cheapest Detection | Credits |
+|--------|-------------------|---------|
+| News/PR | Serper API | 0 |
+| LinkedIn Ads active | Serper API | 0 |
+| Tech stack | Claygent + BuiltWith URL | 0 |
+| Company data | LinkedIn enrichment | 1 |
+| Hiring data | LinkedIn, PredictLeads | 1 |
+| Headcount growth | LinkedIn | 1 |
+| Funding | Intellizence | 1 |
+| G2/Capterra reviews | Zenrows | 3 |
+
+**Rule:** Use 0-credit tools (Serper, Claygent) for initial signal detection. Only spend 1-3 credit tools on accounts that pass initial qualification.

--- a/skills/alex-vacca/signal-sourcer/references/signal-scoring.md
+++ b/skills/alex-vacca/signal-sourcer/references/signal-scoring.md
@@ -1,0 +1,220 @@
+# Signal Scoring & Signal-Based Selling Framework
+
+## Building a Signal Scoring System
+
+### Step 1: Define Signal Categories
+
+**First-Party Signals (Strongest)**
+- Website behavior (pages, frequency, recency)
+- Product usage (feature adoption, usage spikes)
+- Email engagement (opens, clicks, replies)
+- Content downloads (whitepapers, case studies)
+- Event attendance (webinars, demos)
+
+**Second-Party Signals (Strong)**
+- LinkedIn engagement (likes/comments on your posts)
+- G2/review site activity (comparisons, reviews)
+- Community engagement (Slack, Discord, GitHub)
+- Social mentions and discussions
+
+**Third-Party Signals (Moderate to Strong)**
+- Bombora/intent data surges
+- Job changes (champion to new company)
+- Funding rounds
+- Hiring signals (relevant roles)
+- Technology stack changes
+- Company news (expansion, acquisitions)
+
+### Step 2: Assign Weights
+
+#### Tier 1 — Hot Signals (50-100 points)
+
+| Signal | Points | Rationale |
+|--------|--------|-----------|
+| Demo/pricing request | 100 | Direct buying intent |
+| 3+ pricing page visits in 7 days | 80 | Active evaluation |
+| Champion job change to target account | 75 | Warm intro opportunity |
+| Multiple stakeholders from same account | 70 | Buying committee forming |
+| Product trial signup | 65 | Hands-on evaluation |
+| G2 comparison with competitors | 60 | Active vendor comparison |
+| 5+ website visits in 2 weeks | 50 | Sustained interest |
+
+#### Tier 2 — Warm Signals (20-49 points)
+
+| Signal | Points | Rationale |
+|--------|--------|-----------|
+| Series A/B/C funding | 45 | Budget availability |
+| Relevant job posting | 40 | Organizational need |
+| Bombora topic surge (score 70+) | 40 | Active research |
+| Case study download | 35 | Research phase |
+| LinkedIn engagement with your content | 30 | Brand awareness |
+| Webinar attendance | 25 | Category interest |
+| 3+ blog post visits | 20 | Early research |
+
+#### Tier 3 — Cool Signals (5-19 points)
+
+| Signal | Points | Rationale |
+|--------|--------|-----------|
+| Company news (expansion) | 15 | Potential trigger |
+| Single website visit | 10 | Awareness only |
+| Industry report download | 10 | General interest |
+| Email open (no click) | 5 | Minimal engagement |
+| Social follow (no engagement) | 5 | Passive awareness |
+
+### Step 3: Apply Recency Multipliers
+
+| Recency | Multiplier |
+|---------|-----------|
+| Last 24 hours | 1.5x |
+| Last 7 days | 1.2x |
+| Last 14 days | 1.0x |
+| Last 30 days | 0.7x |
+| 30+ days ago | 0.3x |
+
+### Step 4: Multi-Signal Stacking
+
+| Scenario | Signals | Score | Priority |
+|----------|---------|-------|----------|
+| **Red Hot** | Pricing page (80) + Champion job change (75) + Bombora surge (40) | 195 | Immediate action |
+| **Very Warm** | Funding (45) + Hiring (40) + 3 blog visits (20) | 105 | Same-day outreach |
+| **Warm** | Website visit (10) + LinkedIn engagement (30) + Email click (15) | 55 | Nurture sequence |
+| **Cool** | Blog visit (10) + Email open (5) | 15 | Monitor only |
+
+### Step 5: Action Thresholds
+
+| Score Range | Heat Level | Action |
+|-------------|-----------|--------|
+| 150+ | Red Hot | Immediate manual outreach by AE |
+| 100-149 | Hot | SDR personalized sequence within 24h |
+| 50-99 | Warm | Automated nurture + SDR monitoring |
+| 20-49 | Cool | Marketing nurture campaigns |
+| 0-19 | Cold | Monitor for signal changes |
+
+### Implementation Tools
+
+- **Common Room**: Built-in scoring across 50+ sources
+- **Koala**: Product + website signal scoring
+- **Clay**: Custom scoring formulas with enrichment data
+- **HubSpot/Salesforce**: Native lead scoring with intent integration
+- **6sense**: AI predictive scoring
+
+---
+
+## Signal-Based Selling Framework
+
+### Core Principle
+
+**Relevant signal + Right action + Right timing = Smarter outbound**
+
+Replace volume-based prospecting with intent-driven outreach. Instead of 1,000 cold emails, send 50 highly relevant messages to people showing buying signals.
+
+### Signal Tier System & Response SLAs
+
+#### Tier 1: Drop-Everything Signals (< 1 hour)
+
+| Signal | Action | Channel | Owner |
+|--------|--------|---------|-------|
+| Demo request | Personal follow-up + calendar link | Email + Phone | AE |
+| 3+ pricing page visits (VP+) | Personalized email referencing pricing | Email | SDR |
+| Champion job change to target | Congratulations + re-engagement | LinkedIn + Email | AE |
+| Multiple stakeholders from same company | Map buying committee, multi-touch | All channels | AE + SDR |
+
+#### Tier 2: Act-Today Signals (< 24 hours)
+
+| Signal | Action | Channel | Owner |
+|--------|--------|---------|-------|
+| Funding round ($10M+) | "Congratulations" + relevant case study | Email | SDR |
+| Relevant job posting | Connect hiring pain to your solution | LinkedIn + Email | SDR |
+| Bombora surge score 70+ | Reference their research area | Email | SDR |
+| G2 comparison activity | Send competitive battlecard | Email | SDR |
+
+#### Tier 3: Act-This-Week Signals (< 72 hours)
+
+| Signal | Action | Channel | Owner |
+|--------|--------|---------|-------|
+| Funding round (<$10M) | Lighter congratulations + nurture | Email | Marketing |
+| 3+ content articles read | Send related premium content | Email | Marketing |
+| Webinar attendance | Recording + related offer | Email | SDR |
+| Industry news mention | Comment on news + soft touch | LinkedIn | SDR |
+
+#### Tier 4: Monitor & Nurture (Automated)
+
+| Signal | Action | Channel |
+|--------|--------|---------|
+| Single website visit | Add to retargeting audience | Ads |
+| Email open (no click) | Continue nurture sequence | Email |
+| Social follow | Engage with their content | LinkedIn |
+
+### Response Time Benchmarks
+
+| Signal Type | Best Practice | Industry Average | Impact |
+|-------------|--------------|-----------------|--------|
+| Inbound demo | < 5 minutes | 42 hours | 21x more likely to qualify at 5 min vs 30 min |
+| Website visitor (high intent) | < 1 hour | 24-48 hours | 10x higher conversion same-day |
+| Champion job change | < 24 hours | 1-2 weeks | 3x higher win rate as first mover |
+| Funding announcement | < 72 hours | 1-2 weeks | Window closes as competitors swarm |
+| Intent surge | < 24 hours | Not tracked | 50% of value lost after 7 days |
+
+### Building "Plays" (Signal-to-Action Playbooks)
+
+Each play includes:
+1. **Trigger**: Specific signal or combination
+2. **Qualification**: Does account/contact match ICP?
+3. **Action sequence**: Exactly what to do
+4. **Messaging template**: Personalized to the signal
+5. **Timing**: Response SLA
+6. **Owner**: Who is responsible
+7. **Escalation**: What if no response
+
+#### Example Play: "Champion Job Change"
+```
+TRIGGER: Past customer/champion changes jobs to target account
+QUALIFICATION: New company fits ICP (size, industry, tech)
+TIMING: Within 24 hours
+SEQUENCE:
+  Day 0: LinkedIn connection request + congratulations
+  Day 1: Email referencing past relationship + how you helped before
+  Day 3: Share relevant case study for their new industry
+  Day 7: Phone call attempt
+  Day 10: Final email with soft CTA (coffee chat, not demo)
+OWNER: AE who owned the relationship
+ESCALATION: Day 14 → automated nurture
+```
+
+#### Example Play: "Website Visitor + Intent Surge"
+```
+TRIGGER: VP+ visits pricing page AND Bombora surge 60+ on relevant topic
+QUALIFICATION: Company in ICP, contact is decision-maker
+TIMING: Within 1 hour
+SEQUENCE:
+  Hour 0: Slack alert to assigned SDR/AE
+  Hour 1: Personalized email referencing their likely pain
+  Day 1: LinkedIn connection + value-add message
+  Day 2: Phone call attempt
+  Day 3: Email #2 with case study
+  Day 5: LinkedIn voice note or video message
+OWNER: SDR for outreach, AE cc'd
+ESCALATION: If engagement → AE takes over immediately
+```
+
+### Workflow Automation Stack
+
+```
+Signal Sources           Orchestration          Action Layer
+--------------           -------------          ------------
+RB2B (website)     -->   Clay (enrich +   -->   Outreach/Salesloft
+Trigify (LinkedIn)       filter + route)        (email sequences)
+Common Room        -->                    -->   LinkedIn (manual/
+(community)              HubSpot/SFDC          automated)
+Bombora (intent)   -->   (CRM + scoring)  -->   Slack (real-time
+                                                alerts to reps)
+```
+
+### Performance Benchmarks
+
+| Approach | Reply Rate | Contract Value |
+|----------|-----------|---------------|
+| Cold outreach (no signal) | 6-8% | Baseline |
+| Single signal-based | 18-22% | 2-3x baseline |
+| Multi-signal stacked (3+) | 35-40% | 3-4x baseline |
+| Signal + ABM multi-touch | 36% meeting rate | Highest |

--- a/skills/alex-vacca/signal-sourcer/references/signal-taxonomy.md
+++ b/skills/alex-vacca/signal-sourcer/references/signal-taxonomy.md
@@ -1,0 +1,217 @@
+# Signal Taxonomy — Complete Encyclopedia of Sales Triggers
+
+## The 4 Categories of Outreach
+
+### INBOUND (1:Many Messaging Only)
+- Prospect knows your company
+- Hand-raisers taking marketing action asking to evaluate your product
+- Trigger: Demo requests, chat box inquiries
+
+### POSTBOUND (1:Many + 1:1 Messaging)
+- Prospect knows your company
+- Marketing leads that are NOT hand-raisers
+- Trigger: Content engagement without explicit buying intent
+
+### BRIDGEBOUND (1:Many + 1:1 Messaging)
+- Prospect sometimes knows your company
+- Segmented outbound based on premises that raise meeting/buying likelihood
+- Trigger: Prospect or company action NOT related to your marketing
+
+### OUTBOUND (1:1 Messaging Only)
+- Prospect doesn't know your company
+- Coming in cold
+- Trigger: Prospect selected by prospecting team
+
+---
+
+## INBOUND Triggers (30)
+
+**Content & Events:**
+1. Content Downloads
+2. Company Webinar Registrants
+3. Company Webinar Attendees
+4. Sponsored Webinar Registrants
+5. Sponsored Webinar Attendees
+6. Company Event Registrants
+7. Company Event Attendees
+8. Sponsored Event Registrants
+9. Sponsored Event Attendees
+
+**Product Interest:**
+10. Freemium Account Registrants
+11. Free-Trial Registrants
+12. Blog Subscribers
+13. Newsletter Subscribers
+14. Members of Company Community
+15. Members of Sponsored Community
+
+**Social & Intent:**
+16. Followers of Company Social Page
+17. Engaged with Company Social Page
+18. "Buyer Intent" Prospects (G2 or TrustRadius)
+19. "Dark Funnel" Prospects (6Sense or Bombora)
+20. Viewed Company Website
+21. Opened Marketing Emails (Aggressively)
+22. Clicked-Thru Marketing Emails (Aggressively)
+
+**Sponsored Influencers:**
+23. Postbound Leads from Sponsored Influencer
+24. Engaged with Sponsored Influencer's Personal Page
+25. Followers of Sponsored Influencer's Personal Page
+26. Mutual Connections with Sponsored Influencer
+27. Engaged with Sponsored Influencer's Company Page
+28. Followers of Sponsored Influencer's Company Page
+29. "Groundswell" for Info (all Postbound actions)
+30. DM Based on "Groundswell" Postbound
+
+---
+
+## BRIDGEBOUND Triggers (101 total across 5 categories)
+
+### Category I: Based on Relationship (39 Triggers)
+
+**Share a Common VC:**
+1. Common VC with Your Company
+2. Common VC with Your Customers
+
+**Your Customers:**
+3. Referral to Network of Happy Customers
+4. Inbound Referrals from Key Customers
+5. Engaged with Key Customer's Personal Page
+6. Engaged with Key Customer's Company Page
+7. Followers of Key Customer's Company Page
+
+**C-Suite:**
+8. Inbound Referrals from C-Suite
+9. Engaged with C-Suite's Personal Page
+10. Mutual Connections with C-Suite
+
+**Employees of Your Company:**
+11. Inbound Referrals from Company Employees
+12. Engaged with Company Employee's Personal Page
+13. Mutual Connections with Company Employees
+14. Previous Employers of Company Employees
+
+**VC Partners:**
+15. Inbound Referrals from VC Partners
+16. Engaged with VC Partner's Personal Page
+17. Mutual Connections with VC Partners
+18. Engaged with VC's Company Page
+19. Followers of VC's Company Page
+
+**Advisors:**
+20-22. Referrals, Engagement, Mutual Connections
+
+**Board Members:**
+23-25. Referrals, Engagement, Mutual Connections
+
+**Customer Advisors:**
+26-28. Referrals, Engagement, Mutual Connections
+
+**Sponsored Company (Joint Marketing):**
+29-33. Company Page, Employee Engagement, Referrals, Mutual Connections
+
+**Your Network:**
+34. Currently Employed at Prospective Company (Decision Maker)
+35. Currently Employed at Prospective Company ("Groundswell")
+36. Past Employees of a Prospective Company
+37. Mutual Connections with DM at Prospective Company
+38. Prospects Met at a Networking Event
+39. Engaged with Your Personal Page
+
+### Category II: Based on History (16 Triggers)
+
+**Demo Pipeline:**
+1. Requested Demo But Didn't Schedule
+2. Agreed to Demo & No-Showed
+3. Prospects Who "Abandoned the Chat"
+
+**Closed-Lost:**
+4. Demoed in the Past (Ghosted/Went Dark)
+5. Went with Competitor & Up on Renewal
+6. You Messed Up (Budget Objection)
+7. Didn't Hit ICC (Size)
+8. Didn't Hit ICC (Criteria DQ)
+
+**Executive Churn (UserGems):**
+9. Customers Who Went to Another Company
+10. Customers Who Changed Roles Internally
+11. New Hires Who Never Used Your Product
+
+**Email Engagement:**
+12. Opened Prospecting Emails
+13. Opened Prospecting Emails (Aggressively)
+14. Received an OOO to Prospecting Emails
+
+**Reciprocity:**
+15. Companies that Sold You THEIR Product
+16. Competitors of Your Current Customers
+
+### Category III: Based on Likely "In Market" (20 Triggers)
+
+**Adjacent Vendors:**
+1-7. Recent purchase, current customers, in-cycle, engagement, followers, mutual connections
+
+**Competitors:**
+8-16. Churned customers (negative review, disintegration), current customers (website, integration), in-cycle, engagement, followers, mutual connections
+
+**Time-Based:**
+17. Annual Event (e.g., Taxes)
+18. Regular Event (e.g., Olympics)
+19. Seasonal Needs (e.g., Summer for HVAC)
+20. Act of God (One-Time Event)
+
+### Category IV: Based on Symptoms & Signs (11 Triggers)
+
+**Has an Overt Negative:**
+1. Output (Business Problem)
+2. Midput (Tactical Problem)
+3. Input (Root Cause)
+
+**Lacks an Overt Positive:**
+4. Output (Business Problem)
+5. Midput (Tactical Problem)
+6. Input (Root Cause)
+
+**Industry Influencers (Unsponsored):**
+7-11. Engagement, Followers, Mutual Connections with Personal/Company Pages
+
+### Category V: Based on "Firmographic" (15 Triggers)
+
+**Financial Events:**
+1. Companies that Went Public (IPO)
+2. Companies that Raised Funding
+3. Companies that Released Financial Reports
+
+**M&A Activity:**
+4. Companies that Acquired Another Company
+5. Companies that Were Acquired
+6. Companies that Merged
+
+**Growth Signals:**
+7. Companies Growing (Hypergrowth)
+8. Companies that Started Hiring
+9. Companies that Moved Headquarters
+10. Companies that Opened New Locations
+
+**Product & Marketing:**
+11. Released a New Product
+12. Released a New Feature
+13. Released a New Integration
+14. Made an Impactful Marketing Move
+15. Competitor Made an Impactful Move
+
+---
+
+## OUTBOUND Triggers (6)
+
+1. CXO Passdown
+2. "Groundswell" for Info
+3. "Groundswell" for Product-Placement
+4. DM Based on "Groundswell" Product-Placement
+5. Multi-Persona (Cross-Departmental)
+6. Typical "Cold Outbound"
+
+---
+
+## Total: 137 Triggers across all categories

--- a/skills/alex-vacca/signal-sourcer/references/tech-changes.md
+++ b/skills/alex-vacca/signal-sourcer/references/tech-changes.md
@@ -1,0 +1,89 @@
+# Tech Stack Change Signals
+
+Tech stack changes are the #4 buying signal by purchase correlation. An active change project indicates openness to new vendors, fresh pain from transition, and new gaps in workflow. This is an active buying window.
+
+## Reference Files
+
+- Read `buying-signals.md` for signal ranking (#4 by purchase correlation)
+- Read `signal-taxonomy.md` for adjacent vendor triggers (Category III, items 1-7) and integration signals
+
+## Why Tech Changes Work
+
+- **Active buying window** - they are already evaluating and switching tools
+- **Fresh pain from transition** - migration creates new gaps
+- **New gaps in workflow** - removed tool leaves unmet needs
+- **Open mindset** - already committed to change, lower switching resistance
+- Technology change = Tier 2 signal (35-45 points depending on relevance)
+
+## Detection Methods
+
+### BuiltWith / Wappalyzer
+- Monitor target accounts for technology additions/removals
+- Clay integration: Enrich company with tech stack data
+- Track changes over time (tech added, tech removed)
+
+### Job Postings
+- Job descriptions mentioning new tools = migration signal
+- "Experience with Salesforce" when they currently use HubSpot = CRM switch
+- Clay: Scrape job postings, extract tool mentions, compare to known stack
+
+### LinkedIn Activity
+- Engineers/admins posting about new tool implementations
+- Company page announcing new partnerships/integrations
+- Trigify: Track engagement on vendor content
+
+### Integration Announcements
+- New integration released (taxonomy trigger #13)
+- Tech ecosystem expansion signals priorities
+- Partner directories and marketplace listings
+
+## Scoring by Change Type
+
+| Tech Change | Points | Rationale |
+|---|---|---|
+| Removed competitor from stack | 45 | Active replacement window |
+| Added adjacent tool | 35 | Stack expansion, integration opportunity |
+| Job posting mentions new tool | 30 | Migration in progress |
+| Added your category competitor | 20 | Already solved, but may be unhappy later |
+| General stack growth (5+ tools added) | 25 | Active buying mode |
+
+## Outreach Templates
+
+**Competitor removed:**
+```
+Noticed {{company}} recently moved away from {{competitor}}.
+The transition usually surfaces gaps in {{function_area}}.
+We have helped {{similar_company}} fill exactly that gap.
+Worth comparing notes?
+```
+
+**Adjacent tool added:**
+```
+Saw {{company}} recently adopted {{new_tool}}.
+Most teams using {{new_tool}} find they also need {{your_category}} to get the full value.
+We integrate natively and helped {{similar_company}} with the same setup.
+```
+
+## Key Rules
+
+- Tech changes are publicly observable (BuiltWith, job postings) - no privacy concerns
+- Competitor removal is the highest-value tech signal (45pts) - they need a replacement NOW
+- Adjacent tool adoption is your integration play - position as the missing piece
+- Stack with hiring signals: new DevOps hire + infra tools changing = strong compound signal
+- Act within 72 hours of detection - buying windows close fast during migrations
+
+## Examples
+
+Example 1: "A target account just removed our competitor from their stack"
+-> 45pts, highest-priority tech signal. Outreach within 72h. Reference the transition gap, not the competitor directly. Position as the smooth alternative. Check for new hires in relevant department for multi-threading
+
+Example 2: "Monitor tech stack changes across my TAM"
+-> Clay: Enrich ICP companies with BuiltWith data, set up monthly delta checks, flag additions/removals of relevant tools, trigger alerts for competitor removals and adjacent tool additions
+
+Example 3: "Job posting mentions migrating from HubSpot to Salesforce"
+-> 30pts signal. CRM migration = 6-12 month project with many tool needs. Reference the migration pain. Position your solution as the tool that makes the transition smoother. Time outreach for early migration phase
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_

--- a/skills/alex-vacca/signal-sourcer/references/tool-setup-guides.md
+++ b/skills/alex-vacca/signal-sourcer/references/tool-setup-guides.md
@@ -1,0 +1,250 @@
+# Signal Tools Setup Guides
+
+## 1. Trigify (formerly Triggery)
+
+### What It Does
+Tracks LinkedIn engagement to identify high-intent B2B prospects. Monitors specific profiles/companies for likes, comments, brand mentions, job changes, and viral posts.
+
+### Key Features
+- **Social Engagement**: Track likes/comments on any profile (not just yours)
+- **Signal Monitoring**: Role changes, viral posts, company growth
+- **Clay Integration**: Direct webhook to Clay tables
+- **Data Export**: Full company data, job titles, engagement type
+
+### Setup Process
+
+1. **Create Trigify account** at trigify.io
+2. **Add LinkedIn URLs** you want monitored (profiles, company pages)
+3. **Configure signals**: Choose Engagement, Social Signals, etc.
+4. **Set up Clay webhook**:
+   - In Clay: Create table with webhook source, copy webhook URL
+   - In Trigify: Select data sources → Enter Clay webhook URL → Test
+5. **Trigify sends to Clay automatically** on each new signal
+
+### What Gets Sent to Clay
+- Person: name, title, company, LinkedIn URL
+- Engagement: post URL, type (like/comment), text
+- Company data: size, industry, domain
+- Signal type: job change, viral post, etc.
+
+### Pricing
+- Plans based on number of tracked profiles and signal volume
+- Free trial available
+- Check trigify.io/pricing for current rates
+
+---
+
+## 2. RB2B
+
+### What It Does
+Person-level website visitor identification. Places a tracking pixel on your site and identifies individual visitors (name, email, LinkedIn, company) — not just companies.
+
+### How It Works
+
+**Person-Level (US Only)**
+- JavaScript pixel in website `<head>`
+- First-party cookies cross-referenced with third-party data
+- Matches visitors to known identities
+- Output: Name, email, LinkedIn profile, company, title
+- Match rate: **40-45%** of US traffic
+
+**Company-Level (Global)**
+- IP-to-company matching
+- Identifies organization of the visitor
+- Match rate: **30-35%**
+
+### Setup
+
+1. **Sign up** at rb2b.com
+2. **Install pixel**: Add JavaScript snippet to website `<head>`:
+   ```html
+   <script>
+     !function(){/* RB2B pixel code */}();
+   </script>
+   ```
+3. **Configure integrations**:
+   - Slack: Real-time visitor alerts
+   - Webhooks: Send to Clay, n8n, or CRM
+   - HubSpot/Salesforce: Direct CRM push
+4. **Set filters**: ICP criteria to only alert on relevant visitors
+
+### Pricing (2026)
+
+| Plan | Price | Features |
+|------|-------|----------|
+| **Free** | $0 | Person-level ID, 1 Slack workspace, basic features |
+| **Pro** | $99/mo | Person + company level, webhooks, advanced filters, integrations |
+| **Scale** | Custom | High-volume, API access, custom |
+
+### Key Limitation
+Person-level identification is **US-only**. For EU/global traffic, only company-level identification is possible (and is GDPR-compliant).
+
+---
+
+## 3. Common Room
+
+### What It Does
+Customer intelligence platform that aggregates signals across 50+ sources into unified profiles. Tracks community engagement, social activity, product usage, website visits, hiring, funding, and more.
+
+### Signal Categories
+
+**First-Party (Owned)**
+- Product usage and feature adoption
+- Website visits and page engagement
+- CRM interactions
+
+**Second-Party (Social & Community)**
+- LinkedIn, GitHub, Reddit, Slack, Discord
+- Twitter/X engagement
+- Community forum activity
+- Stack Overflow questions
+
+**Third-Party (External)**
+- Job changes (150M+ job listings)
+- Company news (8M+ news signals)
+- Hiring activity
+- Funding events
+- Keyword intent data
+
+### Key Features
+- **Person 360**: Every signal mapped to 200M+ B2B contacts
+- **Auto-enrichment**: Company, title, email, social profiles
+- **Signal scoring**: Built-in lead scoring across all sources
+- **Workflows**: Automated actions based on signal combinations
+- **AI Agents**: Auto-research and outreach recommendations
+
+### Integrations (50+)
+Salesforce, HubSpot, Slack, GitHub, Discord, LinkedIn, Twitter/X, Reddit, Stack Overflow, Discourse, Product analytics, Bombora, G2, and many more.
+
+### Pricing (2026)
+
+| Plan | Price | Contacts | Seats |
+|------|-------|----------|-------|
+| **Starter** | From $1,000/mo | 35K | 2 |
+| **Team** | From $2,500/mo | 100K | 5 |
+| **Enterprise** | Custom | 200K+ | 10+ |
+
+Salesforce integration extra on Starter/Team; included in Enterprise.
+
+---
+
+## 4. Bombora
+
+### What It Does
+B2B intent data — measures when companies are actively researching topics related to your products. Core product: **Company Surge** scores.
+
+### How Company Surge Works
+
+1. **Data Co-op**: 5,000+ B2B websites share consumption data (86% exclusive to Bombora)
+2. **NLP Analysis**: Content classified into **19,200+ B2B topics**
+3. **Baseline Comparison**: Measures account consumption over 3 weeks vs 12-week baseline
+4. **Surge Score**: Generated when activity significantly exceeds normal
+
+**What Creates a Surge:**
+- Number of employees from a company researching a topic
+- Frequency of content consumption
+- Depth of research
+- All relative to their normal baseline
+
+### Topic Taxonomy
+- 19,200+ B2B topics (as of 2025, exceeding 17K)
+- Covers every B2B category: cybersecurity, cloud, HR tech, marketing, finance
+- Topics organized in clusters for broader monitoring
+- Select topics relevant to your product → Bombora monitors surge
+
+### Integration Options (100+)
+- **CRM**: Salesforce, HubSpot (surge scores on account records)
+- **ABM**: Demandbase, 6sense, Terminus, RollWorks
+- **Ads**: LinkedIn Ads, programmatic DSPs
+- **Sales Engagement**: Outreach, Salesloft
+- **Data Warehouses**: Snowflake, BigQuery
+- **Custom**: API access
+
+### Pricing (2026)
+
+| Tier | Annual Cost |
+|------|------------|
+| Basic Company Surge | From ~$30,000/yr |
+| Enhanced Intent Data | ~$50,000-$100,000/yr |
+| Full Audience Solutions | $100,000+/yr |
+
+All contracts custom — no self-service or public pricing.
+
+---
+
+## 5. Other Signal Tools (Quick Comparison)
+
+### Koala
+- **Focus**: Product usage + website intent for PLG companies
+- **Signals**: Pricing page visits, product usage patterns, 30+ sources
+- **Best For**: Cross-selling, upselling existing customers
+- **Pricing**: Free (3 seats); Growth: $750/mo; Business: contact sales
+
+### Warmly
+- **Focus**: Website visitor ID + AI sales orchestration
+- **Signals**: 3 de-anonymization engines, job changes, intent
+- **AI Chatbot**: Auto-engages, qualifies, books meetings
+- **Pricing**: Free (500 visitors/mo); Data Only: $599/mo; AI agents: from $10K/yr
+
+### 6sense
+- **Focus**: AI revenue intelligence + predictive analytics
+- **Signals**: 1T+ buyer behaviors daily, Signalverse technology
+- **Best For**: Enterprise ABM with large budgets
+- **Pricing**: ~$35,000-$130,000/yr
+
+### ZoomInfo
+- **Focus**: B2B database + intent + visitor tracking
+- **Database**: 100M+ companies, 500M+ contacts
+- **WebSights**: Anonymous company identification
+- **Pricing**: From $14,995/yr; most pay $25K-$60K/yr; intent add-on: $5-15K extra
+
+### Clearbit Reveal (Breeze Intelligence)
+- **Focus**: Website visitor ID + enrichment (now HubSpot)
+- **Key**: Requires HubSpot subscription post-acquisition
+- **Pricing**: From $45/mo (100 credits)
+
+### Leadfeeder (Dealfront)
+- **Focus**: Company-level visitor ID (IP-to-company)
+- **GDPR**: Fully compliant, EU data hosting
+- **Pricing**: Free (100 companies); Paid: from EUR 99/mo
+
+### Comparison Matrix
+
+| Tool | Level | GDPR | Starting Price | Best For |
+|------|-------|------|---------------|----------|
+| **Koala** | Person + Product | Partial | Free/$750/mo | PLG cross-sell |
+| **Warmly** | Person + Company | Company OK | Free/$599/mo | AI visitor engagement |
+| **6sense** | Account | Yes | ~$35K/yr | Enterprise ABM |
+| **ZoomInfo** | Person + Company | Partial | $14,995/yr | Database + intent |
+| **Clearbit** | Company + Enrich | Yes | $45/mo | HubSpot-native |
+| **Leadfeeder** | Company | Yes | Free/EUR 99/mo | GDPR company ID |
+
+---
+
+## 6. Website Visitor Tracking: Pixel vs IP
+
+### Pixel-Based (Person-Level)
+- JavaScript pixel sets first-party cookies
+- Cross-references with third-party data
+- Output: Individual person (name, email, LinkedIn)
+- Match rate: **30-45%** (US traffic)
+- Tools: RB2B, Warmly
+- Limitation: **US-only** for person-level; cookie-dependent
+
+### IP-Based (Company-Level)
+- Maps visitor IP to company databases
+- Output: Company name, industry, size (NOT individual)
+- Match rate: **35-40%** (GDPR-compliant)
+- Tools: Leadfeeder, Clearbit, Leadinfo, ZoomInfo
+- Limitation: Company-only; shared IPs (VPN, coworking) add noise
+
+### Decision Framework
+
+| Scenario | Approach | Tool |
+|----------|----------|------|
+| US-focused, need person data | Pixel | RB2B + Warmly |
+| Global/EU, need compliance | IP (company) | Leadfeeder, Leadinfo |
+| HubSpot team | IP + enrichment | Breeze Intelligence |
+| Enterprise ABM | Both + intent | 6sense + RB2B |
+| PLG, product signals | Hybrid | Koala or Warmly |
+| Budget, getting started | IP (free tier) | Leadfeeder Free or RB2B Free |

--- a/skills/alex-vacca/signal-sourcer/references/website-visitors.md
+++ b/skills/alex-vacca/signal-sourcer/references/website-visitors.md
@@ -1,0 +1,84 @@
+# Website Visitor Signals
+
+Website visitors are the #3 buying signal by purchase correlation. They show active evaluation - especially pricing page, competitor comparison, and demo pages. Reply rate is 25-30% because they already know you. Act within 24-48 hours.
+
+## Reference Files
+
+- Read `tool-setup-guides.md` for complete setup guides (RB2B, Warmly, Koala, Leadfeeder, 6sense, pixel vs IP comparison)
+
+## Why Website Visitors Work
+
+- **25-30% reply rate** - they already know your brand
+- **Shows active evaluation** - pricing/demo pages = high intent
+- **Act within 24-48 hours** - 10x higher conversion same-day
+- Pricing page visit = 80 points (Tier 1), 5+ visits in 2 weeks = 50 points
+- Multiple stakeholders from same account = 70 points (buying committee forming)
+
+## Pixel vs IP Tracking
+
+| Method | Level | Match Rate | Geography | Tools |
+|---|---|---|---|---|
+| Pixel-based | Person (name, email, LinkedIn) | 40-45% | US only | RB2B, Warmly |
+| IP-based | Company (name, industry, size) | 35-40% | Global, GDPR-safe | Leadfeeder, Clearbit, ZoomInfo |
+
+## RB2B Setup (Recommended Start)
+
+1. **Sign up** at rb2b.com (Free tier available)
+2. **Install pixel**: Add JavaScript snippet to website `<head>`
+3. **Configure Slack**: Real-time visitor alerts to sales channel
+4. **Set ICP filters**: Only alert on relevant visitors (title, company size, industry)
+5. **Connect Clay webhook**: Enrich visitors + route to sequences
+
+### Pricing
+- **Free**: $0 - Person-level ID, 1 Slack workspace
+- **Pro**: $99/mo - Person + company, webhooks, advanced filters
+- **Scale**: Custom - High-volume, API access
+
+### Key Limitation
+Person-level identification is **US-only**. For EU/global traffic, use IP-based tools (Leadfeeder, Dealfront) for GDPR-compliant company-level identification.
+
+## Page-Based Scoring
+
+| Page Visited | Points | Intent Level |
+|---|---|---|
+| Pricing page | 80 | Active evaluation |
+| Competitor comparison | 60 | Vendor comparison |
+| Demo/trial page | 100 | Direct buying intent |
+| Case study | 35 | Research phase |
+| Blog post (single) | 10 | Awareness only |
+| 3+ blog posts | 20 | Early research |
+| 5+ visits in 2 weeks | 50 | Sustained interest |
+
+## Tool Decision Framework
+
+| Scenario | Tool |
+|---|---|
+| US-focused, need person data | RB2B + Warmly |
+| Global/EU, need GDPR compliance | Leadfeeder (Dealfront) |
+| HubSpot team | Breeze Intelligence (Clearbit) |
+| Enterprise ABM | 6sense + RB2B |
+| PLG, product signals matter | Koala or Warmly |
+| Budget-conscious, getting started | RB2B Free or Leadfeeder Free |
+
+## Key Rules
+
+- VP+ on pricing page = Tier 1 signal, respond within 1 hour
+- Do NOT say "I saw you visited our website" - reference their likely pain instead
+- Multiple stakeholders from same company = buying committee forming, map all contacts
+- Stack with intent data for compound scoring: pricing visit (80pts) + Bombora surge (40pts) = 120pts Hot
+
+## Examples
+
+Example 1: "How do I set up RB2B?"
+-> Walk through pixel install, Slack integration, ICP filters, Clay webhook. Free tier for start, Pro at $99/mo for webhooks. US-only for person-level, company-level globally
+
+Example 2: "A VP just visited our pricing page"
+-> Tier 1 signal (80pts). Respond within 1 hour. Personalized email referencing their likely pain, NOT the visit. AE or SDR depending on account tier. Check for other signals to stack
+
+Example 3: "We have EU traffic, what tool should we use?"
+-> IP-based only for GDPR compliance. Leadfeeder (Dealfront) from EUR 99/mo, or Clearbit/Breeze if on HubSpot. Company-level identification, 35-40% match rate. Stack with LinkedIn engagement for person-level context
+
+
+---
+
+_Part of [Frontal](https://frontal.so) — free, open GTM skills for your AI agent. [Browse the library →](https://frontal.so/resources/skills)_


### PR DESCRIPTION
Converted from [Frontal-so/outbound-skills](https://github.com/Frontal-so/outbound-skills) (MIT), submitted by Alex Vacca (Founder & CEO @ Frontal, ex-ColdIQ).

- 4 master skills flattened to the repo's one-level layout (router SKILL.md + references/): clay-expert, cold-email-strategist, list-architect, signal-sourcer
- 33 standalone skills, original slugs kept, bodies byte-faithful (footers and credits intact per Ariel's call)
- clay-expert, cold-email-strategist, list-architect carry `contributors: [ivan-falco]` matching their in-file credits
- `node tools/validate.mjs`: ok — 209 skills across 30 creators

Approved by Ariel 2026-07-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)