### PR TITLE
Add nadav-david: earned-autonomy

### DIFF
--- a/skills/nadav-david/author.md
+++ b/skills/nadav-david/author.md
@@ -1,0 +1,12 @@
+---
+name: Nadav David
+avatarUrl: https://avatars.githubusercontent.com/u/59076508?v=4
+title: Strategic Partnerships Manager, Kidoz
+linkedinUrl: https://www.linkedin.com/in/nadavdvd/
+companyDomain: kidoz.net
+---
+
+Strategic partnerships in advertising technology, selling media into brand and agency
+buying teams. My skills encode the outbound discipline I run daily: find the real bridge
+into an account before spending a cold touch, and refuse to ship a message that is clean
+but gives a stranger no reason to answer.

--- a/skills/nadav-david/earned-autonomy/SKILL.md
+++ b/skills/nadav-david/earned-autonomy/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: earned-autonomy
+title: Earned autonomy
+description: |
+  Use this skill when deciding how much a GTM agent may do without a human looking, when a
+  workflow is ready to run on a schedule, when outreach should stop requiring per-item approval,
+  and when something has gone wrong and autonomy needs pulling back. Produces a level per task
+  with the evidence required to move up and the triggers that drop it automatically. Trigger
+  phrasings: "can I let the agent send", "when do I stop reviewing every draft", "how much should
+  I automate", "the agent made a mistake, now what", "is this workflow ready to run unattended".
+category: RevOps
+---
+
+Produces a level per task, the evidence needed to raise it, and the triggers that lower it without asking.
+
+## The one-line law
+
+Autonomy is granted per task, not per agent, and only against logged evidence. New tasks start at full review.
+
+One agent can be trusted to qualify accounts unattended while its enrichment is still spot-checked. Granting autonomy to an agent rather than a task is how a good record on the easy work buys freedom on the risky work.
+
+## The four levels
+
+| Level | What ships | What reaches the human |
+|---|---|---|
+| **L0 Draft** | nothing with wording in it | every worded item, before it goes |
+| **L1 Spot-check** | items that passed the quality gate | a random sample, plus every low-confidence item |
+| **L2 Exception-only** | items that passed the gate | flagged, edge and high-risk items only |
+| **L3 Auto** | runs on schedule, ships on gate pass | a periodic digest, plus any guardrail trip |
+
+The distinction that keeps L0 honest is copy risk versus click risk. Wordless actions carrying no claim, a connection request with no note, a profile visit, can move at L0 inside their rate limits, because nothing in them can misstate, leak, or embarrass. Anything with words waits.
+
+## Promotion needs evidence, not confidence
+
+Set your own numbers; these are the defaults worth starting from. Full criteria in `references/promotion-evidence.md`.
+
+- **L0 to L1:** at least 30 items reviewed, human edit or reject rate under 10%.
+- **L1 to L2:** at least 50 items at L1, sampled gate-pass rate at or above 95%, no guardrail breach in the window.
+- **L2 to L3:** the task's outcome metric holds at or above target for four consecutive weeks, zero breaches.
+
+Two rules matter more than the thresholds.
+
+**Judgment steps are trusted separately, and a credibility-costing miss resets the count to zero.** Clearing "picked a good angle" does not clear "picked the right person." Within each, a weak-but-harmless output costs nothing, while a miss that advertises you did no homework sends the count back to zero. The gate guards against embarrassing misses, not stylistic ones.
+
+**No refusal in the window means hold the promotion.** The evidence has to include at least one logged case where the agent declined or flagged something inside its own authority because it looked wrong. An agent that has never refused anything has demonstrated obedience, not judgment, and autonomy is a grant of judgment. This is a hold rather than a demotion, and a manufactured refusal ticked to clear the gate is itself a breach.
+
+## Demotion is automatic
+
+No approval needed to pull back. Any one of these drops the task:
+
+- gate pass rate falls below 90% over the trailing 20 items,
+- the outcome metric misses target two weeks running,
+- any guardrail breach, which drops the task straight to L0 with a notification.
+
+## Guardrails no level crosses
+
+These bind an L3 task exactly as hard as an L0 one. Autonomy buys you out of review, never out of the rubric.
+
+- **Volume limits.** Every channel's caps hold regardless of level.
+- **Suppression.** Never contact anyone on the no-contact list, however good the lead looks.
+- **Claims.** No unverified or stale claim ships. Anything needing legal or compliance sign-off routes to a human first.
+- **Quality rules.** The automatic-fail rules of your review rubric apply at every level.
+- **A kill switch.** Any task, or everything, freezes to L0 instantly.
+- **The live-reply floor.** Responding to a live inbound conversation never runs above L0, whatever the task has earned. No agent free-types a reply to a real person unattended. On a reply, the sequence stops and routes to a human.
+
+## What good looks like
+
+Two failure modes, opposite directions, equally common.
+
+The cautious one leaves everything at L0 forever because no promotion gate was written down, so autonomy becomes a mood rather than a decision and the system never gets faster however well it performs.
+
+The reckless one promotes on a good feeling after a strong week, outcome metric unmeasured, and finds out at scale. Promoting on volume alone is the specific trap: a task can hit its item count while producing a disproportionate share of risky output, which is why risk is logged per item and read at promotion rather than averaged away.
+
+It is working when you can name every task's current level, point at the evidence behind it, and show a demotion that fired without anyone deciding to allow it. If nothing has ever been demoted automatically, the triggers are decoration.
+
+## Rules
+
+- MUST record the level per task, with the evidence, where the next reviewer will read it.
+- MUST start new tasks at L0 and let evidence move them, never a launch decision.
+- MUST demote on trigger without waiting for approval.
+- NEVER promote a task on volume alone, or on a window containing no logged refusal.
+- NEVER let an earned level cross a guardrail, and never let a live conversation run unattended.

--- a/skills/nadav-david/earned-autonomy/references/promotion-evidence.md
+++ b/skills/nadav-david/earned-autonomy/references/promotion-evidence.md
@@ -1,0 +1,46 @@
+# Promotion evidence
+
+Read this when proposing a level change, and when setting up the record that promotions will be argued from.
+
+A promotion is an argument from a log. If the log does not exist, the answer is no, and the work is to start logging rather than to decide.
+
+## Who proposes, who approves
+
+Never the same party, and never the agent itself. The agent produces the evidence, a reviewer proposes the change against these criteria, and the person carrying the consequences approves it. Self-promotion turns the gate into a formality.
+
+## What has to be in the window
+
+| Criterion | L0 to L1 | L1 to L2 | L2 to L3 |
+|---|---|---|---|
+| Volume | 30 items reviewed | 50 items at L1 | continuous |
+| Quality | edit or reject rate under 10% | sampled gate-pass at or above 95% | gate-pass holds |
+| Outcome | not yet required | not yet required | metric at or above target, 4 consecutive weeks |
+| Breaches | none | none in window | zero |
+| Logged refusal | not required | at least one | at least one |
+
+Volume and quality are cheap to measure and easy to game. The outcome metric is the one that decides whether autonomy is deserved, which is why it gates the last step rather than the first.
+
+## Judgment steps are separate trust accounts
+
+Any step resting on taste rather than a checkable rule gets its own count: choosing the angle, choosing the contact, deciding an account is a fit. Ten examples reviewed, nine or ten of which would ship untouched, is a reasonable bar per account.
+
+Then the asymmetry that makes it work: a weak-but-harmless output costs nothing, and a credibility-costing miss resets the count to zero. Wrong person, or a premise so off-base it advertises that no homework happened, is a reset. A soft line worth a tweak is not. Scoring both the same way either freezes every task forever or teaches the reviewer to wave through the misses that actually matter.
+
+## Refusal as evidence
+
+Look for a skipped send, a held draft, a flagged edge case, something the agent could have done inside its own authority and chose not to. It counts only if the reviewer judges it substantive on the merits.
+
+For a narrow mechanical task where the window plausibly offered no refusal-worthy moment, the criterion can be waived, but the waiver gets logged on the record so it never becomes a silent default.
+
+## Risk is logged per item, read at promotion
+
+Tag each output low, medium or high risk as it ships. The tag does three things and no more: it sorts the review queue while a human is still reading everything, it defines the exception that surfaces at L2, and it exposes a task that is hitting its numbers while emitting a disproportionate share of risky output. Such a task gets scrutinized or split before promotion rather than waved up on the average.
+
+What the tag must never do is quietly reinstate review on work a task already earned the right to ship. A high-risk tag that always holds is a second gate wearing a triage costume, and it cancels the ladder it was meant to sharpen.
+
+## What good looks like
+
+- Every level has a date, the numbers it cleared, and the name of whoever approved it.
+- Demotions appear in the record as often as promotions. A log with only promotions is a log of one direction of evidence.
+- The outcome metric is defined before the task reaches L2, not invented when someone asks for L3.
+- A waived criterion is visible as a waiver, never as a pass.


### PR DESCRIPTION
## What this skill does

`earned-autonomy` answers the question every builder in this library is currently answering by feel: how much may the agent do without me looking, and what has to be true before it may do more.

Autonomy is granted per task rather than per agent, starts at full review, moves up only against a log, and drops automatically on trigger. Four levels, promotion gates with default numbers, and guardrails that bind an unattended task exactly as hard as a supervised one.

## Why I think it belongs here

I grepped all 220 skills for `autonomy`, `unsupervised`, `human-in-the-loop` and `supervision`. Six files matched and none is about this: they are human-team autonomy in RevOps org design, or agent autonomy as an input to a SaaS pricing model.

Two rules in here are the ones I would keep if I could only keep two:

**Refusal as evidence.** A promotion window has to contain at least one logged case where the agent declined or flagged something inside its own authority. An agent that has never refused anything has demonstrated obedience, not judgment, and autonomy is a grant of judgment.

**The live-reply floor.** Responding to a live inbound conversation never runs unattended, whatever the task has earned. Autonomy buys you out of review on staged outbound, never on a live conversation with a real person.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/nadav-david/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for review

- `author.md` also appears in #10, #11 and #12 with identical content, for the same standalone-validation reason.
- The threshold numbers (30 items under 10% edits, 50 at 95%, 4 weeks on outcome) are stated as defaults to tune, not as findings.
- Pairs with #12 `inbound-is-data`: that one gates the content boundary, this one gates the supervision boundary, and each names the other where they meet.
- ~820 words. Promotion criteria detail is in `references/promotion-evidence.md`.
