### PR TITLE
Fix abm-on-meta: Ivan's corrected playbook

### DIFF
--- a/skills/ivan-falco/abm-on-meta/SKILL.md
+++ b/skills/ivan-falco/abm-on-meta/SKILL.md
@@ -1,244 +1,131 @@
 ---
 name: "abm-on-meta"
 title: ABM on Meta
-description: "Use this skill when running account-based marketing on Meta — 1:1 and 1:few ABM plays, matched-audience setup, and personalization for named B2B accounts."
+description: "Use this skill when running Meta Ads for B2B qualified pipeline — enriched custom audiences from a tiered TAM, Conversion Leads feedback via CAPI, segment personalization, and SQL-level reporting."
 category: ABM
 ---
 
-# ABM on Meta - Account-Based Marketing Playbook for B2B SaaS
+# Scale B2B Qualified Pipeline on Meta
 
-How to run Account-Based Marketing on Meta for B2B SaaS and B2B tech companies. Covers the full workflow: data enrichment, audience building, campaign structure, acceleration campaigns, cross-channel coordination with LinkedIn, and measurement.
-
----
-
-## When ABM on Meta Makes Sense (And When It Doesn't)
-
-### Use ABM on Meta When:
-- Target account list (TAL) has 1,000+ companies (minimum for Meta's algorithm)
-- You have enrichment tools (Primer, Metadata.io) to boost match rates
-- You're already running LinkedIn ABM and want omnichannel coverage at lower CPM
-- Sales cycle is 60+ days (enough time for ad exposure to influence)
-- Deal value is $25K+ (justifies ad spend per account)
-
-### Don't Use ABM on Meta When:
-- TAL is < 500 companies with no enrichment (audience too small for Meta)
-- No first-party data or CRM data (nothing to build audiences from)
-- Budget is < $3,000/month (can't exit learning phase)
-- Sales cycle < 7 days (ads can't influence a fast transaction)
-- No Sales-Marketing alignment (ads create awareness that sales never follows up on)
-
-**When to choose LinkedIn over Meta for ABM:** TAL < 1,000 accounts, need exact job title targeting, cold outreach to net-new accounts, single decision maker. LinkedIn costs 3-4x more but offers precision Meta can't match natively.
+A step-by-step playbook for turning Meta Ads spend into **qualified pipeline (SQLs)** for B2B, not cheap lead volume. This is the end-to-end system written at full depth.
 
 ---
 
-## The Match Rate Problem (And How to Solve It)
+## The core idea (read first)
 
-**The challenge:** Most B2B databases have business emails. Meta users sign up with personal emails. Result: < 5% match rate uploading raw CRM data.
+Most B2B teams run a Meta campaign, get a pile of low-quality leads, decide "Meta doesn't work for B2B," and move their budget somewhere else. In almost every case the setup was the problem, not the campaign.
 
-**The solution:** Third-party enrichment tools that map business identity to personal identity.
+**Meta is extremely good at finding exactly what you ask it to find.** If you optimise for "Lead" and give it nothing else to go on, it does its job perfectly and brings you the cheapest form-fills it can. They are real leads, they just never turn into pipeline.
 
-| Tool | Match Rate | What It Does | Best For |
-|------|-----------|-------------|----------|
-| **Metadata.io (MetaMatch)** | ~40% | Firmographic/technographic audience to identity graph to uploads to Meta | LinkedIn-like targeting on Meta |
-| **Primer.io** | High persona accuracy | CRM sync to champion persona filtering to identity graph to multi-channel activation | Multi-channel ABM (Meta + LinkedIn + YouTube + Reddit) |
-| **ZoomInfo** | Enrichment (not direct upload) | 260M+ profiles, appends personal emails/phones to CRM records | CRM data enrichment, then upload to Meta |
-| **Clearbit (HubSpot Breeze)** | Enrichment | Real-time CRM enrichment, firmographic updates | HubSpot users, CRM-first enrichment |
-| **Demandbase** | Native DSP | Account-centric data, daily LinkedIn/Meta audience sync | Enterprise ABM with advertising built in |
+The whole game is to change what you are asking for. When you (1) give Meta the right data so it understands your actual ICP, and (2) feed back which leads become qualified pipeline, Meta learns to go and find more of those. It is the same optimisation engine, now working toward qualified pipeline instead of cheap volume.
 
-### Primer to Meta Workflow (Step by Step)
-
-1. **Sync account list** from CRM (Salesforce/HubSpot) - Primer ingests company domains, employee lists, firmographic data
-2. **Define champion personas** - filter by role (VP, Director, C-suite), department, seniority
-3. **Identity graph matching** - Primer maps corporate identity to personal social profiles across devices
-4. **Multi-channel activation** - upload matched audiences to Meta, LinkedIn, YouTube, Reddit simultaneously
-5. **Measurement** - Conversion maps, website reveal (which accounts visit pre-form fill), incrementality via holdout groups
-
-### Metadata.io to Meta Workflow
-
-1. **Build audience** in Metadata using firmographic + technographic criteria (industry, size, tech stack, role)
-2. **MetaMatch** matches against 1.5B email identity graph to find personal profiles
-3. **Upload** matched audience to Meta as Custom Audience
-4. **Target directly** (if large enough) or build **1% lookalike** from matched list
-5. **Activate** across Meta + LinkedIn simultaneously from one platform
-
-### Manual Workflow (Without Tools)
-
-1. Export CRM account list with all available data (company name, website domain, employee emails, phone numbers)
-2. Upload as Meta Custom Audience (Audiences > Create > Customer List > CSV)
-3. Accept low match rate (< 5-10% with business emails)
-4. Build 1-3% lookalike from the matched portion to expand reach
-5. Use creative specificity to filter non-ICP within the lookalike
+Everything below is how you do that.
 
 ---
 
-## Campaign Structure for ABM on Meta
+## Step 1 - Map the market & build the audience targeting
 
-**Critical rule:** Keep ABM and broad prospecting in SEPARATE campaigns. Never mix audiences.
+**Goal: give Meta a high-quality, matchable audience built from your real target market.**
 
-### Architecture
+- Map your **TAM**. Tier every company **Tier 1 -> Tier 4** by fit. Decide where you want to go.
+- Pull the **contacts** at those companies. That is your **Tier 1-4 contact list** - this list is the audience targeting.
+- Enrich the list. Raw B2B / work-email lists match badly on Meta. Enrich for **personal email + mobile numbers** to lift the match rate, or the custom audience lands too small to run. (Mobile advertiser IDs / MAIDs are a minor assist only - iOS App Tracking Transparency degraded them; personal email + mobile number do the heavy lifting.)
+  - Enrichment data: **Contact Level**.
+  - Enrich + auto-sync audiences into Meta: **Clay / Freckle**.
+- Push the enriched list to Meta as a **custom audience**.
 
-```
-Campaign 1: ABM - Top of Funnel (Awareness)
-  Ad Set: Tier A Accounts - Decision Makers
-  Ad Set: Tier B Accounts - Decision Makers
-  Budget: ABO (equal per ad set for fair testing)
-  Objective: Awareness or Video Views (NOT Leads - prevents cheap junk fills)
-
-Campaign 2: ABM - Retargeting (Engaged Accounts)
-  Ad Set: Website visitors from target accounts (30-day)
-  Ad Set: Content consumers (video viewers 50%+, ad engagers)
-  Budget: ABO or CBO
-  Objective: Traffic or Leads
-
-Campaign 3: ABM - Acceleration (Open Pipeline)
-  Ad Set: High-value opps ($100K+)
-  Ad Set: Stalled deals (30+ days in stage)
-  Budget: ABO (control spend per segment)
-  Objective: Awareness (reinforce, don't push conversion)
-
-Campaign 4: Broad Prospecting (Non-ABM, separate)
-  Ad Set: CRM Lookalike 1%
-  Ad Set: Interest + Job Title Targeting
-  Objective: Leads or Conversions
-```
-
-### Minimum Audience Sizes
-
-| Audience Type | Minimum | Optimal |
-|---------------|---------|---------|
-| ABM custom audience (account list) | 1,000 accounts | 5,000-10,000 |
-| ABM retargeting (website visitors) | 100 accounts | 1,000-5,000 |
-| Lookalike expansion (seed) | 500 accounts | 1,000+ |
-| Broad prospecting | 500K people | 1-2M |
-
-**If your TAL is under 1,000:** Use Meta only for retargeting accounts that engage on LinkedIn. Don't run cold ABM on Meta - the audience is too small for the algorithm.
+**Why:** Meta builds audiences from people (not company names), so you need the real contacts. Tiering tells you where budget goes first. Match rate decides how big and usable the audience is - work emails barely match, personal email + mobile number are what Meta actually matches on.
 
 ---
 
-## Acceleration Campaigns (Ads Against Open Pipeline)
+## Step 2 - Structure the audiences (one campaign per audience)
 
-**Purpose:** Target accounts with open opportunities in CRM to influence close rate and shorten sales cycle.
+**Goal: give Meta room to scale off your data, cleanly, without losing control of who it targets.**
 
-### When to Use
-- Deal value > $25K (makes ad spend ROI-positive)
-- Sales cycle > 30 days (enough time for ads to influence)
-- Multi-stakeholder buying committee (ads reach people sales can't)
-- Competitive evaluation (reinforce differentiation)
+Push three audiences to Meta:
+1. Your full **Tier 1-4 contact list** (all your TAM).
+2. A **lookalike** of that list.
+3. A **lookalike of your closed-won contacts** (the decision-makers who actually signed).
 
-### Setup
+Structure:
+- **One campaign per audience** (or per segment - see Step 5).
+- Inside each campaign, run **multiple ad sets - one per creative angle / approach / personalisation**.
+- Run **CBO** and set a **30% minimum spend per ad set while validating new angles**, so CBO does not dump everything into one angle and starve the others before they are tested. (Use this sparingly and only during validation. A two-campaign testing/scaling split is an alternative to permanent per-ad-set floors; both are valid, pick one deliberately per account.)
 
-1. **Build segment in CRM:** Opportunities with Stage = "Proposal Sent" OR "Negotiation" OR "Evaluation"
-2. **Filter by value:** Prioritize deals > $50K
-3. **Export:** Company name, website domain, decision maker emails, opportunity stage
-4. **Upload as Custom Audience** in Meta (refresh weekly)
-5. **Creative:** Case studies from same industry, ROI calculators, competitive comparison, executive thought leadership
-6. **Objective:** Awareness (reinforce brand) - NOT conversion (don't push demos to people already in pipeline)
+**Tight targeting, controlled expansion.** Keep the targeting tight and do not turn on Meta's audience expansion. The **lookalike is the controlled way you open the audience** - it gives Meta room to find more people like your market without letting it wander off your ICP. That balance (tight seed + lookalike) is the sweet spot.
 
-### Budget
-- High-value opps ($100K+): $100-200/day
-- Mid-value opps ($25-100K): $50-100/day
-- Stalled deals: $50/day
+**Exclusions (hygiene):**
+- Exclude existing customers and open pipeline from cold prospecting audiences.
+- Exclude Audience Network placements - they are low quality for B2B.
 
-### Measurement
-- **Primary:** Win rate (test group vs. holdout)
-- **Secondary:** Days in stage (did exposed accounts close faster?)
-- **Holdout:** 80% see ads, 20% don't - compare outcomes after 21+ days
+**Why:** the contact list reaches your exact market; the two lookalikes let Meta find more people like your TAM and like your best buyers, with room to scale. One campaign keeps that audience's budget and learning together.
 
 ---
 
-## Cross-Channel ABM: Meta + LinkedIn
+## Step 3 - Optimise by funnel event (feed the Lead signal)
 
-### Channel Roles
+**Goal: teach Meta what a QUALIFIED lead looks like, so it optimises for pipeline, not form-fills.**
 
-| Channel | Role | Strength | CPM |
-|---------|------|----------|-----|
-| **LinkedIn** | Precision targeting, cold outreach to named accounts | Company + job title exact match | $40-70 |
-| **Meta** | Reach, frequency, retargeting, buying committee warming | Lower cost, cross-device coverage | $10-25 |
+This uses Meta's **Conversion Leads** feature (Conversions API CRM integration), not just sending arbitrary events to a plain Leads objective.
 
-### Coordination Framework
+- Set your funnel up as **conversion events / funnel stages in Meta**: Lead, MQL, SQL. Mark the qualified stages (MQL, SQL) as positive.
+- Send the qualified stages back from your CRM (HubSpot) to Meta **via CAPI**, on a **daily upload cadence**.
+- A **funnel event** tells Meta how your funnel works. Feeding MQL/SQL back tells Meta which form-fills became real pipeline, so it optimises toward buyers, not cheap leads.
+- **Optimise for the highest-quality event you get ~10+/wk on (per ad set).** As volume grows, **move up the funnel** (Lead -> MQL -> SQL) to a higher-quality conversion.
+  - **~10/wk per ad set** = the practical floor to start optimising on an event reliably (rule of thumb from experience).
+  - **~50/wk per ad set** = Meta's documented threshold to fully exit the learning phase. Only the optimised event counts toward it.
+- Even while you optimise on **Lead** (because SQL volume is still low), because MQL + SQL are configured as funnel stages, Meta favours the leads that progress down-funnel. (Meta may also silently shift which stage it optimises toward if it finds better performance.)
 
-1. **Same account list** - Export identical TAL to both platforms from CRM
-2. **Sequential activation** - LinkedIn (awareness/cold outreach) then Meta (reinforcement/retargeting)
-3. **Message alignment** - Same value proposition, same visual identity, persona-specific copy
-4. **Offer consistency** - Don't run conflicting offers simultaneously (free trial on LinkedIn, demo on Meta)
-5. **UTM consistency** - Same account_id parameter across channels for attribution
-6. **Combined reporting** - Dashboard showing account-level touches across both channels
+**Non-negotiable setup requirements for this to actually work:**
+- **Capture and store the Meta click ID (fbclid) / Lead ID at lead creation, and pass it through every CRM stage change.** Meta's click attribution window is ~7 days, but MQLs/SQLs land weeks later. Without the stored click/Lead ID, Meta cannot attribute the downstream event back to the ad and the entire "feed the funnel back" premise silently breaks.
+- **Keep Event Match Quality (EMQ) high (target 6+/10)** on the CAPI events - send hashed email, phone, and external_id. Low EMQ silently degrades Meta's ability to use the MQL/SQL signal.
+- **Conversion Leads gates:** roughly **200 leads/month minimum**, and the optimised stage must convert at **1%-40%** (if your SQL rate is below 1%, it is out of range for direct optimisation - which is exactly why you optimise on Lead and feed SQL back).
 
-### Budget Split (ABM Across Channels)
-- LinkedIn: 60% of ABM budget (precision, higher intent)
-- Meta: 30% of ABM budget (reach, frequency, lower cost)
-- Other (email, direct mail): 10%
-
-### The Cross-Channel Retargeting Play
-Use LinkedIn to validate audience quality (precise targeting), then retarget that validated traffic on Meta at lower cost:
-1. Run LinkedIn ABM campaigns - traffic lands on website with LinkedIn UTMs
-2. Create Meta Custom Audience: website visitors where URL contains `utm_source=linkedin`
-3. Retarget LinkedIn-validated audience on Meta at 50-70% lower CPM
-4. Result: LinkedIn-quality audience at Meta-level costs
-
-**Why it works:** Multi-channel ABM tends to generate meaningfully higher engagement than single-channel, and running LinkedIn and Meta together typically lifts sales conversions versus either channel alone.
+**Why:** Meta optimises for exactly what you ask it for. Give it the right data and a clear definition of a qualified lead / qualified pipeline, and it will go and find that.
 
 ---
 
-## ABM Creative Strategy
+## Step 4 - Creative process (one process feeds video AND static)
 
-### ABM vs Broad Prospecting Creative
+**Goal: creative that speaks the buyer's language, produced fast enough to keep testing.**
 
-| Element | ABM Creative | Broad Prospecting Creative |
-|---------|-------------|---------------------------|
-| **Personalization** | Industry-specific, role-specific insights | Generic ICP pain points |
-| **Messaging** | "How [industry] companies solve [specific problem]" | "B2B SaaS teams struggle with X" |
-| **Social proof** | Logos from same industry/company size | Broad customer count |
-| **Content type** | Thought leadership, executive-level content | Educational, top-of-funnel guides |
-| **CTA** | "See how companies like yours solved this" | "Download the guide" |
+- **Research** where buyers talk: sales calls, Reddit, forums (research sources/tools include X, Reddit, HubSpot, Medium). Pull their real **pains, jargon, and vocabulary**.
+- Map **angles + hooks**. The same research feeds **both video and static** - it is one creative process, not two.
+  - Video: testimonials, quick product demos, founder videos, real UGC.
+  - Static: angle/hook creatives, product UI, data/proof, personalised.
+- **Cadence is budget-dependent.** At a **~$30k/month budget, ~10 new creatives every 2 weeks** is the optimal baseline. Scale the volume up or down with the budget. Use **AI creative workflows** to sustain that output.
+- Split the account into a **testing campaign** (always fed the new creatives) and a **scaling campaign** (proven winners only).
 
-### Creative by ABM Stage
-
-**TOF (Awareness):** Industry trends, thought leadership, problem education. Not product-focused.
-**MOF (Engagement):** Case studies, product comparisons, customer testimonials from same vertical.
-**BOF (Conversion):** Custom assessments, ROI analysis, competitive comparison, demo (only here).
-**Acceleration:** Social proof from similar companies, executive content, deal-stage-appropriate messaging.
+**Why:** buyers act on their own pains and words, not your feature list. Creative fatigues, so a constant test feed keeps surfacing winners, and keeping test spend separate from scale protects proven spend.
 
 ---
 
-## Measuring ABM on Meta
+## Step 5 - Test & personalise by segment
 
-### ABM-Specific KPIs (Different from Standard Lead Gen)
+**Goal: find segments where personalised messaging beats broad all-TAM messaging.**
 
-| Metric | What It Measures | Target |
-|--------|-----------------|--------|
-| **Account penetration rate** | % of TAL that engaged with ads | 40-60% |
-| **Cost per engaged account** | Spend / accounts with 3+ interactions | $100-300 |
-| **Account-to-opportunity rate** | Opps created / engaged accounts | 10-20% |
-| **Pipeline influenced** | $ value of opps where account saw ads | 3-5x ad spend |
-| **Win rate lift** | Test group win % vs. holdout group | +10-30% |
-| **Deal velocity** | Reduction in sales cycle days | -10-20% |
+- From your all-TAM contact list, **filter down to a specific segment** (per strategy) and export those contacts.
+- Upload each segment as its **own audience (list + lookalike, same structure as Step 2)**.
+- Build **ads + a landing page personalised to that segment** - written in its own reality and jargon.
+- Do not only run all-TAM. **Test specific segments** to see if they beat the broad audience.
+- A/B test the landing pages: split the ad set's traffic **50/50** between two pages and keep the winner. Run this across all your TAM.
 
-### Attribution for Long Sales Cycles
-- Meta only sees Meta's touches - use CRM for the full picture
-- Set attribution window to 7-day click minimum (28-day if available)
-- Use W-shaped or full-path attribution in CRM to credit Meta appropriately
-- Don't rely on last-touch (Meta wins retargeting credit, which is misleading for ABM)
-- Send closed-won events back to Meta via CAPI to train the algorithm on revenue
-
-### Incrementality Testing (Holdout Groups)
-- Split TAL: 80% see ads (test), 20% don't (holdout)
-- Compare: engagement, opportunity creation, win rate, deal velocity
-- Don't evaluate before 21+ days (need meaningful activity in both groups)
-- Tools that automate this: Primer (built-in), 6sense, Demandbase
+**Why (segment example):** the CFO of a private-equity-owned company has different jargon and a different reality than one at a non-PE company. Speak their language and show you understand it, and the campaign will often perform far better than a non-personalised one. Testing tells you which segments to scale, and A/B testing shows what resonates at the ad level AND the landing-page level.
 
 ---
 
-## Exclusion Strategy
+## Step 6 - Report on real SQLs (always up to date)
 
-Always exclude:
-- **Closed-won customers** (waste of ABM budget)
-- **Recent converters** (7-30 day suppression)
-- **Employees and internal traffic**
-- **Disqualified accounts** from CRM
+**Goal: see what is actually driving qualified pipeline, so you can steer Meta manually.**
 
-Keeps attribution clean, prevents annoying existing customers, and focuses budget on accounts that matter.
+- Connect **Meta and your CRM (HubSpot, Attio, etc.)** into a **live report** that tracks **MQL + SQL trends against spend** and shows **which ads drive SQLs**.
+
+**Why:** while Meta is still optimising per Lead, it pushes budget toward whatever gets the most leads, not the most SQLs. This report shows which ads actually drive SQLs, so you can manually shift Meta's budget toward real pipeline. Read the trend over time, not a single week.
 
 ---
 
-> By Ivan Falco - Frontal
+## The payoff
+
+Set up this way, Meta produces **qualified pipeline and efficient cost per qualified deal**, not a pile of cheap form-fills that never convert. The optimisation engine is now pointed at the outcome that matters: revenue, not lead count.
+
+---


### PR DESCRIPTION
Ivan Falco flagged that the live `abm-on-meta` body was the wrong file (a generic ABM-on-Meta playbook, not his). This replaces it with his corrected source: https://github.com/ivangfalco/curated-abm-skills/blob/main/meta-ads/abm-on-meta.md — byline stripped, description updated to match the new content. Validator passes.

Note: the production DB row was already hot-fixed directly on 2026-07-28 (Ariel-approved, Ivan's request), so this PR makes the repo match and prevents the next sync from reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)