### PR TITLE
Add website-to-signals skill (Peter Cools)

### DIFF
--- a/skills/peter-cools/author.md
+++ b/skills/peter-cools/author.md
@@ -1,0 +1,9 @@
+---
+name: Peter Cools
+avatarUrl: https://144687585.fs1.hubspotusercontent-eu1.net/hubfs/144687585/Photo-Peter.jpg
+title: Founder, Rodz
+linkedinUrl: https://www.linkedin.com/in/coolspeter/
+companyDomain: rodz.io
+---
+
+Founder of Rodz, an intent-data platform for outbound. My skills encode a producer's view of intent-led GTM — turning real buying signals (competitor engagement, hiring, funding, social) into timed, differentiated outreach that reaches buyers while they're in-market.

--- a/skills/peter-cools/website-to-signals/SKILL.md
+++ b/skills/peter-cools/website-to-signals/SKILL.md
@@ -2,33 +2,48 @@
 name: website-to-signals
 title: Website to signals
 description: |
-  Use this skill when you have a company's website and need to decide which intent
-  signals are actually worth running for them — "which buying signals fit this business,"
-  "turn this site into a targeting strategy," "what triggers should we track." Produces a
-  shortlist of 3-5 detectable signals, each tied to a concrete why-now for that company.
+  Use this skill when you have a company's website and need a shortlist of intent signals
+  worth running for them — "which buying signals fit this business," "turn this URL into a
+  signal plan." Given a website, it returns 3-5 detectable intent signals, each tied to a
+  concrete why-now, with where to detect it and who to target.
 category: Signals
 tags: [Signals, Prospecting]
 ---
 
-A website tells you what a company sells and who buys — but the useful question is what has to change in a buyer's world before they need it. This skill turns a site into a short, operable list of intent signals, starting from triggers, not from a menu of signal types.
+An agent that turns a company's website into a short, operable set of intent signals. It reasons from what the company sells to what has to change in a buyer's world for them to need it now, then keeps only the changes it can actually observe in public data.
 
-## The play
+## Input
 
-1. **Read the site for three things.** What they sell, who actually buys (economic buyer vs. daily user), and — the one that matters most — what has to become true in an account for them to need this *now*. The why-now is where signals come from.
-2. **Turn each why-now into an observable proxy.** A trigger is only a signal if you can see it in public data. "They just hired their first RevOps lead" is observable; "they're frustrated with their current tool" usually isn't. Start from the trigger, then find its public tell.
-3. **Draw from the signal families.** People moves (job changes, new leadership, hiring for a role), company moves (funding, expansion, a new market or entity), competitive engagement (they're evaluating an alternative), social and behavioral (posting or reacting on the problem), technographic (a tool added or dropped). Pick the families that map to *this* business's why-nows.
-4. **Cut to 3-5.** Rank by fit × intent strength × volume. Drop anything you can't operationalize at scale, and anything that's really inbound.
+- `website_url` — the company to plan signals for (read the homepage, product, pricing, customers, blog).
+- `icp_constraints` *(optional)* — known segment / geo / size limits.
+- `sales_motion` *(optional)* — PLG / sales-led / hybrid; shifts which signals matter.
+
+## Procedure
+
+1. **Extract three things from the site:** what they sell, who buys (economic buyer vs. daily user), and — the pivot — what has to become true in an account for them to need this *now*.
+2. **Turn each why-now into an observable proxy.** A trigger is a signal only if it is visible in public data. "Just hired their first RevOps lead" is observable; "frustrated with their tool" is not. Keep the observable ones.
+3. **Map to signal families:** people moves (job changes, new leadership, hiring a role), company moves (funding, expansion, new market or entity), competitive engagement (evaluating an alternative), social and behavioral (posting or reacting on the problem), technographic (a tool added or dropped).
+4. **Rank and cut to 3-5** by fit × intent strength × volume. Drop anything undetectable, low-volume, or really inbound.
+
+## Output
+
+`signals[]` — 3 to 5 items, each:
+
+- `signal` — the observable event
+- `why_this_company` — one line linking it to what they sell / who buys
+- `detect_in` — where it is observed in public data
+- `target` — the persona + firmographic filter to apply
+- `rank` — 1-5 (fit × intent × volume)
 
 ## What good looks like
 
-- **Start from the buyer's why-now, never a signal menu.** The tell of a weak version: twelve signal types picked because they sound good, half of them inbound-only or unobservable.
-- **Detectability is the gate.** Every signal passes one test — *can I see this in public data, at volume, today?* If not, it is a theory, not a signal.
-- **Intent strength beats novelty.** A boring signal that reliably precedes a purchase beats a clever one that rarely does.
-- **You know it is good when** each signal carries a one-line "why this business, why now," and you could pull fifty matching accounts this afternoon.
+- **Starts from the buyer's why-now, never a signal menu.** The weak version: a dozen signal types picked because they sound good, half inbound-only or unobservable.
+- **Detectability is the gate** — every item passes "can I see this in public data, at volume, today?"
+- **Intent strength beats novelty** — a boring signal that reliably precedes a purchase beats a clever one that rarely does.
+- Good output: each signal has a concrete why-now, and you could pull fifty matching accounts this afternoon.
 
 ## Rules
 
-- MUST tie every signal to a specific trigger for *this* business — never hand over a generic menu.
-- MUST keep it to a handful (3-5); coverage is not the goal, precision is.
-- NEVER recommend a signal you cannot detect from public data at volume.
-- NEVER dress an inbound-only intent up as an outbound signal.
+- MUST return 3-5 signals, never a long menu.
+- MUST tie each signal to a specific trigger for *this* business.
+- NEVER include a signal you cannot detect from public data at volume, or one that is really inbound.

--- a/skills/peter-cools/website-to-signals/SKILL.md
+++ b/skills/peter-cools/website-to-signals/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: website-to-signals
+title: Website to signals
+description: |
+  Use this skill when you have a company's website and need to decide which intent
+  signals are actually worth running for them — "which buying signals fit this business,"
+  "turn this site into a targeting strategy," "what triggers should we track." Produces a
+  shortlist of 3-5 detectable signals, each tied to a concrete why-now for that company.
+category: Signals
+tags: [Signals, Prospecting]
+---
+
+A website tells you what a company sells and who buys — but the useful question is what has to change in a buyer's world before they need it. This skill turns a site into a short, operable list of intent signals, starting from triggers, not from a menu of signal types.
+
+## The play
+
+1. **Read the site for three things.** What they sell, who actually buys (economic buyer vs. daily user), and — the one that matters most — what has to become true in an account for them to need this *now*. The why-now is where signals come from.
+2. **Turn each why-now into an observable proxy.** A trigger is only a signal if you can see it in public data. "They just hired their first RevOps lead" is observable; "they're frustrated with their current tool" usually isn't. Start from the trigger, then find its public tell.
+3. **Draw from the signal families.** People moves (job changes, new leadership, hiring for a role), company moves (funding, expansion, a new market or entity), competitive engagement (they're evaluating an alternative), social and behavioral (posting or reacting on the problem), technographic (a tool added or dropped). Pick the families that map to *this* business's why-nows.
+4. **Cut to 3-5.** Rank by fit × intent strength × volume. Drop anything you can't operationalize at scale, and anything that's really inbound.
+
+## What good looks like
+
+- **Start from the buyer's why-now, never a signal menu.** The tell of a weak version: twelve signal types picked because they sound good, half of them inbound-only or unobservable.
+- **Detectability is the gate.** Every signal passes one test — *can I see this in public data, at volume, today?* If not, it is a theory, not a signal.
+- **Intent strength beats novelty.** A boring signal that reliably precedes a purchase beats a clever one that rarely does.
+- **You know it is good when** each signal carries a one-line "why this business, why now," and you could pull fifty matching accounts this afternoon.
+
+## Rules
+
+- MUST tie every signal to a specific trigger for *this* business — never hand over a generic menu.
+- MUST keep it to a handful (3-5); coverage is not the goal, precision is.
+- NEVER recommend a signal you cannot detect from public data at volume.
+- NEVER dress an inbound-only intent up as an outbound signal.


### PR DESCRIPTION
## What this skill does

Turns a company's website into a shortlist of 3–5 **detectable** intent signals worth running, each tied to a concrete "why now" — start from buyer triggers, not a menu of signal types. First contribution, so it includes my `author.md`.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/peter-cools/` only
- [x] `node tools/validate.mjs` — my files report zero problems. (The stock script hits a Windows-only `import.meta.url` path bug locally; I ran a ROOT-pinned copy to verify. CI will confirm on Linux.)
- [x] First contribution: `author.md` included with real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile