### PR TITLE
add founder-post-triggers-24

### DIFF
--- a/skills/danni-chen/author.md
+++ b/skills/danni-chen/author.md
@@ -6,4 +6,6 @@ linkedinUrl: "https://www.linkedin.com/in/dannichen1/"
 companyDomain: gendigital.com
 ---
 
-Fifteen years running marketing and growth for high-growth SaaS — VP Growth at Yellow.ai ($35M→$75M ARR), Growth Director at LeanTaaS ($70M→$120M), GTM at Payoneer through exit — and then 0→1 on an AI-native product holding the product decisions and the go-to-market decisions at the same time. That seam is what my skills encode: organizations can still specialize, but product and market decisions can no longer be made by separate people handing work down a funnel. I advise early-stage AI companies on exactly that.
+Yellow.ai, $35M→$75M ARR. LeanTaaS, $70M→$120M. Payoneer, through exit. Then 0→1 on an AI-native product, holding the product decisions and the go-to-market decisions at the same time.
+
+I advise early and mid-stage companies on both halves of that problem: proving the PMF is real, then building the engine that scales it. Most GTM advice fails because it comes from one side of the line — marketers who can't change the product, product people who can't sell it. These skills are what I run from both sides.

--- a/skills/danni-chen/author.md
+++ b/skills/danni-chen/author.md
@@ -1,0 +1,9 @@
+---
+name: Danni Chen
+avatarUrl: "https://media.licdn.com/dms/image/v2/D5603AQFBs_mUQ28V7w/profile-displayphoto-scale_400_400/B56ZicmS_xHUAo-/0/1754973942146?e=1786579200&v=beta&t=wHamTAtiaqwQFSEP4zq_o2euFymMUvnZ-dxPjeXe_qo"
+title: "Head of Product & GTM, AI"
+linkedinUrl: "https://www.linkedin.com/in/dannichen1/"
+companyDomain: gendigital.com
+---
+
+Fifteen years running marketing and growth for high-growth SaaS — VP Growth at Yellow.ai ($35M→$75M ARR), Growth Director at LeanTaaS ($70M→$120M), GTM at Payoneer through exit — and then 0→1 on an AI-native product holding the product decisions and the go-to-market decisions at the same time. That seam is what my skills encode: organizations can still specialize, but product and market decisions can no longer be made by separate people handing work down a funnel. I advise early-stage AI companies on exactly that.

--- a/skills/danni-chen/author.md
+++ b/skills/danni-chen/author.md
@@ -1,6 +1,6 @@
 ---
 name: Danni Chen
-avatarUrl: "https://media.licdn.com/dms/image/v2/D5603AQFBs_mUQ28V7w/profile-displayphoto-scale_400_400/B56ZicmS_xHUAo-/0/1754973942146?e=1786579200&v=beta&t=wHamTAtiaqwQFSEP4zq_o2euFymMUvnZ-dxPjeXe_qo"
+avatarUrl: "https://avatars.githubusercontent.com/yihan108"
 title: "Head of Product & GTM, AI"
 linkedinUrl: "https://www.linkedin.com/in/dannichen1/"
 companyDomain: gendigital.com

--- a/skills/danni-chen/author.md
+++ b/skills/danni-chen/author.md
@@ -6,6 +6,6 @@ linkedinUrl: "https://www.linkedin.com/in/dannichen1/"
 companyDomain: gendigital.com
 ---
 
-Yellow.ai, $35M→$75M ARR. LeanTaaS, $70M→$120M. Payoneer, through exit. Then 0→1 on an AI-native product, holding the product decisions and the go-to-market decisions at the same time.
+Yellow.ai, $35M→$75M ARR. LeanTaaS, $70M→$120M. Payoneer, through exit. Now building an AI-native product 0→1 at Gen Digital — the Fortune 500 parent of Norton LifeLock — where I run product and GTM, both sides, at the same time.
 
 I advise early and mid-stage companies on both halves of that problem: proving the PMF is real, then building the engine that scales it. Most GTM advice fails because it comes from one side of the line — marketers who can't change the product, product people who can't sell it. These skills are what I run from both sides.

--- a/skills/danni-chen/founder-post-triggers-24/SKILL.md
+++ b/skills/danni-chen/founder-post-triggers-24/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: founder-post-triggers-24
+title: Founder post triggers
+description: |
+  Use this skill when a founder has no results to point at and needs something to publish — "I have
+  nothing to post about", "what do I write when we haven't launched", "who would even listen to me",
+  "should I build a personal brand", "our CAC is climbing and we have no budget". Twenty-four things
+  that already happened this week and are publishable, in five categories, plus the play selector,
+  copy-paste opening lines, and the pre-publish check.
+category: Influencers
+tags: [Marketing, Leadership]
+---
+
+# 24 Founder Post Triggers
+
+Credibility before traction comes from the specificity of the problem you work on, not the size of your wins. Every trigger below already happened — pick one and publish it.
+
+## Customer Evidence (6)
+
+1. **The surprising sentence** — a customer line that changed your view. Verbatim.
+2. **The real no** — the actual reason a prospect declined, not the polite one.
+3. **The exit reason** — why someone churned, plus your read.
+4. **The recurring question** — asked three times in support. Answer it publicly.
+5. **Their words, not yours** — how a customer described you to someone else.
+6. **The unintended use** — someone using it for something you never designed.
+
+## Numbers You Can Stand Behind (5)
+
+7. **Before and after** — one conversion rate, one change, both figures.
+8. **The retention read** — a churn number plus your honest diagnosis.
+9. **Channel cost direction** — what a channel costs, and whether that is rising.
+10. **The failed experiment** — what you tried, what it returned, what you concluded.
+11. **The expectation gap** — forecast versus what landed.
+
+## Decisions and Reversals (5)
+
+12. **What you cut** — a feature removed, and what removing it cost.
+13. **The reversal** — a decision your team argued you out of.
+14. **The thing nobody used** — built, shipped, ignored.
+15. **The pricing change** — what moved, and why.
+16. **The deliberate no** — a customer, segment, or feature you turned down.
+
+## Product as Demonstration (4)
+
+17. **Raw output** — what it just produced, unedited.
+18. **Before and after artifact** — the same task with and without it.
+19. **The hard part** — a genuinely difficult problem, and your solution.
+20. **What it refuses to do** — a constraint you built on purpose.
+
+## Position and Category (4)
+
+21. **The real comparison set** — who buyers actually weigh you against.
+22. **The disagreed belief** — category orthodoxy you think is wrong.
+23. **The loose term, defined** — a vague word, made precise.
+24. **The unpriced change** — a market shift most have not adjusted to.
+
+## Play Selector
+
+Pick one and hold it — they train different expectations and combine badly. Cases: [references/plays.md](references/plays.md).
+
+| Play | Run when | Triggers |
+|---|---|---|
+| Publish real numbers | You have data and tolerate exposure | 7–11 |
+| Content on audience pain | You serve a specific, badly-served group | 1–6, 24 |
+| Speaking is showing | The product's output is visible | 17–20 |
+| Position alignment | The company's claim is already clear | 21–23 |
+
+## Opening Lines (Lowest-Effort Tier)
+
+Share something already circulating, add one sentence of real judgment:
+
+- "This matches what we see with our own users: …"
+- "Most people read this as X. The more useful takeaway is Y."
+- "The part everyone skips: …"
+- "We tried this. It worked / it didn't, because …"
+- "I believed this a quarter ago. What changed my mind: …"
+
+Ramp and cadence: [references/first-four-weeks.md](references/first-four-weeks.md).
+
+## Pre-Publish Check
+
+- [ ] Contains one first-hand fact — a quote, a number, a reversal
+- [ ] Could NOT have been written by someone who read the same articles
+- [ ] Inside your one chosen topic (hold ~70% of output there)
+- [ ] States a process, not an opinion
+- [ ] Any number in it, you can stand behind unedited
+
+## What good looks like
+
+- Strong founders write from one specific thing that happened; weak ones write from a general position. A draft with no first-hand fact is noise wearing the costume of insight.
+- The common mistake is waiting for results. The second is posting announcements — they answer "what shipped" instead of "what this means for you".
+- It is working when strangers engage and what they say back names your topic. Scattered replies mean the topic has not landed.
+- Track inbound that names your specific problem. Better signal than follower count, and earlier.
+
+## Rules
+
+- MUST anchor every post in a first-hand event from the work.
+- MUST hold ~70% of output inside one topic.
+- NEVER publish a number you cannot stand behind, or dress up a bad one.
+- NEVER wait for results to start.
+
+## Example prompts
+
+```
+Give me 3 post triggers I can write today from this week's customer calls.
+```
+
+```
+Which play fits a product whose output is a generated document?
+```
+
+```
+Turn trigger #8 into a draft — our 90-day retention is 22%.
+```

--- a/skills/danni-chen/founder-post-triggers-24/references/first-four-weeks.md
+++ b/skills/danni-chen/founder-post-triggers-24/references/first-four-weeks.md
@@ -1,0 +1,68 @@
+# Ramp: Three Tiers and Four Weeks
+
+Start below the comfortable level. All the return is in consistency; the standard failure is an ambitious burst followed by silence.
+
+## Three Tiers
+
+| Tier | Effort | What you publish | Use when |
+|---|---|---|---|
+| 1 | One reaction a week | Something already circulating + one sentence of real judgment | Writing publicly feels impossible |
+| 2 | One short post a week | A real conversation, turned into 100–200 words | You have customer contact |
+| 3 | Drafting workflow | Dictated opinion, adapted to register, hand-edited | Your natural register is too formal, or you write in a second language |
+
+### Tier 1 — react, don't author
+
+No long-form, no original argument. The only discipline: the added sentence contains a first-hand view, not a summary. Opening lines are in the main skill.
+
+### Tier 2 — conversations become posts
+
+Fix 3–4 recurring subjects. Draw material only from what actually happened:
+
+- a surprising sentence from a customer call
+- the real reason a prospect said no
+- a mistake made and what it cost
+- a decision reversed after an argument
+
+This is where the compounding happens. Requires no writing talent — only the habit of noticing that an ordinary working moment is publishable.
+
+### Tier 3 — the drafting workflow
+
+1. Speak the real opinion aloud; draft from the transcript
+2. Adapt toward the register of 3–5 reference posts whose tone fits
+3. Edit by hand: verify every fact, delete phrasing that does not sound like you
+4. **Add one detail only you could know**
+
+Step 4 is the one that matters. A drafted post without a private detail reads as generic no matter how clean the prose. The detail is the proof of authorship.
+
+## Where to Publish
+
+| Surface | Job | Best for |
+|---|---|---|
+| Professional network | Credibility and reputation — buyers, operators, investors check it | Tiers 1 and 2 |
+| Open public feed | Reach into founder and practitioner circles; faster, tolerates rougher posting | Demonstrations, in-progress thinking |
+
+Do not paste the same text into both. Registers differ, and people who follow you in both places notice.
+
+## The Four-Week Ramp
+
+| Week | Action |
+|---|---|
+| 1 | Rewrite your profile to state the problem you work on, not your job title. Publish one tier-1 reaction. |
+| 2 | Fix your 3–4 recurring subjects. Publish one tier-2 post from a real conversation. |
+| 3 | Second tier-2 post — use a mistake and what it cost. Adapt one post for the second surface. |
+| 4 | Try the tier-3 workflow once. Review which post drew the most substantive replies; that subject goes deeper. |
+
+After four weeks you do not have an audience. You have a cadence, one validated subject, and evidence about which register lands — the only things worth having at this stage.
+
+## Failure Modes
+
+| Failure | What it looks like | Fix |
+|---|---|---|
+| Over-promotion | Every post arrives at the product | Let the product appear as the thing that produced a number, never as the subject |
+| Irregular frequency | Silent a month, five posts in a week | Weekly rhythm beats the quality of any single post |
+| Verbatim cross-posting | Same text pasted to both surfaces | Same idea, rewritten per surface |
+| Waiting for a milestone | "Once we launch" / "once we hit the number" | The only asset that compounds on a timescale longer than your runway |
+
+## When to Hand Off
+
+This is a founder motion. It stops being one when your topic is established and inbound consistently names it. The question then becomes whether to add employee or creator distribution alongside — decided on saturation signals, not on effort.

--- a/skills/danni-chen/founder-post-triggers-24/references/plays.md
+++ b/skills/danni-chen/founder-post-triggers-24/references/plays.md
@@ -1,0 +1,87 @@
+# The Four Plays
+
+Each converts something already true into distribution. None require budget, fame, or results. Pick one — they train different expectations and combine badly.
+
+| # | Play | The truth it converts | One line |
+|---|---|---|---|
+| 1 | Publish real numbers | Operating data, flaws included | Publishing honestly *is* the differentiation |
+| 2 | Content on audience pain | What the group actually struggles with | Talk about their problem, not your features |
+| 3 | Speaking is showing | What the product visibly does | Every post is a live demo |
+| 4 | Position alignment | What the company claims | Founder topic and company position point one way |
+
+---
+
+## Play 1 — Publish Real Numbers
+
+**Run when:** you have usable data and can tolerate exposure.
+
+**The moves:**
+
+- Break down each acquisition channel and what it actually returned
+- Publish a churn figure that is not good, with your read on why
+- Use real product decisions as material — especially cutting rather than adding
+
+**Why it works:** in a market where every founder claims their product is excellent, verifiable numbers — particularly bad ones — are the differentiation. Subtext: this person is honest and knows the details. Those are the two things an early audience most wants to confirm and can least easily verify.
+
+**Case:** a solo-founded academic writing tool. Started from the founder's parents' house, pivoted out of a services business, monthly revenue collapsed from ~$7k to ~$2k and stuck for two years, under $1M raised. The founder built in public throughout — every channel broken down, a ~16% churn rate discussed openly. Reached ~$12M ARR and millions of users.
+
+**Borrow:** do not wait for a good number. Publish one real figure now — churn, acquisition cost, a failed experiment's conversion rate — with your read on the cause. It outperforms ten posts asserting the product is good.
+
+---
+
+## Play 2 — Content on Audience Pain
+
+**Run when:** you serve a specific group whose problems are badly covered elsewhere.
+
+**The moves:**
+
+- Publish nothing about the product
+- Answer the questions that keep the group awake — especially counterintuitive ones insiders know and outsiders get wrong
+- Be first to interpret rule or policy changes affecting them
+- Go into the communities where they already gather and answer directly, with real data
+
+**Why it works:** topics grow out of the audience's pain, not the product's feature list. A founder who repeatedly gives a specific group help nobody else can give *becomes* that group's trusted entry point. Distribution then happens on its own.
+
+**Case:** an AI job-search assistant aimed not at "job seekers" but at international students and visa-sponsorship candidates in a foreign labour market — a group systematically ignored by mainstream hiring products, drowning in information asymmetry. Near-zero marketing budget, ~50,000 registered users.
+
+**Borrow:** define the group far more narrowly than is comfortable. List the 3–5 questions it is most anxious and least well-informed about. Answer them repeatedly. The more it reads like an insider talking and the less like a product advertising, the faster trust accrues.
+
+---
+
+## Play 3 — Speaking Is Showing
+
+**Run when:** the product's output is visible in the medium where you publish.
+
+**The moves:**
+
+- Produce every public post using the product, and say so
+- Write about specific product thinking — why a capability works a particular way, what you deliberately threw away — not general industry commentary
+
+**Why it works:** content and product stop being two workstreams. Every post is simultaneously an opinion, a zero-cost demo, and evidence of how deeply you have thought about the problem. No gap between what is claimed and what is shown.
+
+**Case:** a dictation tool whose founder ended essentially every public post with a note that it had been written using the product. ~$3.8M ARR, ~80% six-month retention.
+
+**Borrow:** if the product generates something visible — writing, design, analysis, media — make each post an artifact of it. If not, fall back one step: write about specific product decisions and their reasoning. Specific decisions read as expertise; general industry takes read as filler.
+
+---
+
+## Play 4 — Position Alignment
+
+**Run when:** the company already knows the position it intends to own.
+
+**The moves:**
+
+- Converge public content on the territory the company wants to occupy in buyers' minds
+- Personal material is fine — a career change, an unusual path in — as long as it lands back on the company's central claim
+
+**Why it works:** most founders run personal brand and company brand as separate projects. The person posts feelings, the company posts features, and the two dilute each other. Aligned, every personal post reinforces the company's claim and every company mention strengthens the founder's authority.
+
+**Case:** a customer-engagement platform built on a messaging API, founded outside the major startup hubs, serving small businesses across 75 countries with substantial venture backing. Both co-founders published consistently, both stayed inside the territory the company was working to own.
+
+**Borrow:** before publishing, answer one question — *what is the topic where someone should think of this founder and this company together?* Then hold at least 70% of output inside it.
+
+---
+
+## The Shared Engine
+
+None relied on fame or spending. None waited until the company was large. Do not manufacture content: take something that already exists — a number, a pain, an output, a claim — and make it visible.


### PR DESCRIPTION
## What this skill does

Twenty-four things that already happened this week and are publishable, in five categories, for a founder who needs distribution before the company has results to point at. Plus a play selector mapping triggers to the four founder-IP plays, copy-paste opening lines for the lowest-effort tier, and a pre-publish check.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/danni-chen/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

---

Two notes for the reviewer:

- `avatarUrl` points at a LinkedIn CDN link carrying an expiry token (~12 Aug). Happy to supply a different permanent URL if you'd prefer to host it.
- The four case studies in `references/plays.md` are described without company names, to keep the file from dating. Glad to name them if the house style prefers it.