### PR TITLE
Add google-ads-write-safety by John Williams

### DIFF
--- a/skills/john-williams/author.md
+++ b/skills/john-williams/author.md
@@ -1,0 +1,9 @@
+---
+name: John Williams
+avatarUrl: https://ahmeego.com/shared/authors/john-williams-160.webp
+title: Founder, AHMEEGO
+linkedinUrl: https://www.linkedin.com/in/johnmichaelwilliams
+companyDomain: ahmeego.com
+---
+
+Founder of AHMEEGO and the practitioner behind Buddy, the open-source Google Ads agent. 15+ years managing $350M+ in ad spend across NortonLifeLock, GM, Eventbrite, Prudential, Columbia, and Harvard — including a 192% YoY paid-search growth run at NortonLifeLock. Now builds AI-native paid-media tooling in the open, including a live agent that reads and writes to Google Ads accounts under explicit human confirmation.

--- a/skills/john-williams/google-ads-write-safety/SKILL.md
+++ b/skills/john-williams/google-ads-write-safety/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: google-ads-write-safety
+title: Write safety for AI agents on Google Ads accounts
+description: |
+  Use this skill when an AI agent or automation is about to make a write change to a
+  live Google Ads account — pausing something, moving a bid, adding negatives, editing
+  a budget, launching a campaign. Produces a change that's previewed, confirmed, and
+  provably executed, instead of a plausible-sounding claim. Triggers: agent making
+  Google Ads changes, autonomous bidding, automated negative keywords, AI campaign
+  management, bulk account edits, "did that actually run."
+category: Ads
+tags: [RevOps]
+---
+
+# Write Safety for AI Agents on Google Ads Accounts
+
+Applies the moment an agent moves from reading an account to writing to it. The
+account is real money and the advertiser's livelihood — a hallucinated success
+message isn't a rough edge, it's a trust catastrophe the first time it happens.
+
+## The play
+
+1. Classify the request by blast radius before touching anything: read-only,
+   low-risk (a single keyword, negative, or bid move within a tight band), or
+   account-level (budget swings, conversion tracking, campaign creation or deletion).
+2. Default to propose-only — pull data, calculate, recommend, but execute nothing
+   without an explicit go-ahead. An authorization covers the specific action just
+   approved, never the rest of the session.
+3. Keep the low-risk band actually low-risk: bid moves within roughly ±20%, negatives
+   only against clear waste (spend with zero conversions), no whole-campaign pauses,
+   no budget swings past ~20%, and never touch conversion actions or billing without
+   a separate, explicit approval.
+4. Before executing, show a preview — current value, proposed value, and what
+   triggered it (the search term, the CPA, the pacing). New campaigns and new ads
+   get created paused, full stop, so a human reviews before spend starts.
+5. Require an explicit confirmation tied to that specific preview. "Go ahead," "do
+   it," "approved" counts; a related-but-different message, or silence, does not.
+   Batch operations still get one itemized preview — never a blanket yes for a list
+   the human hasn't actually read.
+6. Execute, then produce a receipt: the operation, the exact resource changed, the
+   before/after state, and how to reverse it. If nothing else survives, the receipt
+   should.
+7. If the write failed, partially applied, or the tool was never called, say so in
+   plain language immediately. Never generate a receipt for something that didn't
+   happen, and never imply full success when only part of a batch went through.
+
+## What good looks like
+
+- The best operators catch the gap between "the tool ran" and "the tool returned no
+  resource name" — a receipt without a real, traceable ID is worthless and should
+  never ship. Every resource name or ID in an output must trace back to an actual
+  tool result, never to what a successful version of that action usually looks like.
+- The common failure mode is an agent narrating success from pattern-matching, not
+  verification — writing "paused 14 keywords" because that's what the confirmation
+  step is supposed to produce, not because it checked the response. Catch this before
+  it ships, not after the advertiser notices their account didn't change.
+- Good output names the account explicitly when more than one is in play, states its
+  confidence on anything inferred, and gives the human enough in the receipt to undo
+  the change without opening a support ticket.
+
+## Rules
+
+- MUST get an explicit confirmation, tied to the specific preview shown, before any
+  write beyond pure read/propose mode.
+- MUST create new campaigns and ads in a paused state.
+- MUST tie every resource ID or name in output to an actual tool result.
+- NEVER report a write as done, or partially summarize a batch as fully done, if the
+  underlying call failed or wasn't made.
+- NEVER let one authorized action expand into standing authorization for the rest of
+  the session.


### PR DESCRIPTION
## What this skill does

How to let an AI agent safely make write changes (bids, budgets, negatives, campaign creation) to a live Google Ads account: classify by blast radius, default to propose-only, preview before executing, require confirmation tied to that specific preview, and always produce a verifiable receipt instead of a plausible-sounding claim.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/john-williams/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names (Google Ads / Performance Max / Quality Score are the ad platform's own domain terms, not a vendor stack choice — consistent with the existing `google-ads` skill in this library)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile


Made with [Cursor](https://cursor.com)