### PR TITLE
Add google-ads-pmax-asset-groups by John Williams

### DIFF
--- a/skills/john-williams/author.md
+++ b/skills/john-williams/author.md
@@ -1,0 +1,9 @@
+---
+name: John Williams
+avatarUrl: https://ahmeego.com/shared/authors/john-williams-160.webp
+title: Founder, AHMEEGO
+linkedinUrl: https://www.linkedin.com/in/johnmichaelwilliams
+companyDomain: ahmeego.com
+---
+
+Founder of AHMEEGO and the practitioner behind Buddy, the open-source Google Ads agent. 15+ years managing $350M+ in ad spend across NortonLifeLock, GM, Eventbrite, Prudential, Columbia, and Harvard — including a 192% YoY paid-search growth run at NortonLifeLock. Now builds AI-native paid-media tooling in the open, including a live agent that reads and writes to Google Ads accounts under explicit human confirmation.

--- a/skills/john-williams/google-ads-pmax-asset-groups/SKILL.md
+++ b/skills/john-williams/google-ads-pmax-asset-groups/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: google-ads-pmax-asset-groups
+title: Performance Max asset group structure and hygiene
+description: |
+  Use this skill when structuring or troubleshooting a Performance Max campaign —
+  asset groups, ad strength, audience signals, or suspected cannibalization of brand
+  search. Produces a structural fix list, not just "add more assets." Triggers:
+  Performance Max, PMax, asset groups, ad strength, audience signals, PMax
+  cannibalizing brand, PMax negative keywords, low ad strength.
+category: Ads
+---
+
+# Performance Max Asset Group Structure and Hygiene
+
+Applies when a campaign is serving across the automated inventory Performance Max
+covers, and delivery quality depends on the inputs you gave it, not just its own
+targeting.
+
+## The play
+
+1. Split asset groups by product line or audience segment before doing anything
+   else. One asset group trying to speak to every product or every buyer can't be
+   coherent to any of them — that's a structural problem no amount of extra copy
+   fixes.
+2. Fill every slot the platform gives you, not just the minimum required — headlines,
+   long headlines, descriptions, and a real image and video mix across horizontal,
+   square, and vertical orientations. Ad strength is a direct readout of how much of
+   that room you've actually used, and a group short on assets or asset variety caps
+   its own performance ceiling regardless of targeting quality.
+3. Upload real video. If a group has none, the platform will assemble one from your
+   other assets automatically — treat that as a fallback you're accepting by default,
+   not a feature, and replace it with something you'd choose deliberately.
+4. Give a new or heavily-changed asset group real time before judging it — check ad
+   strength and asset performance again after a couple of weeks, not a couple of
+   days, and don't restructure on day-three volatility.
+5. Watch for brand cannibalization specifically: if branded queries are converting
+   through Performance Max at a worse cost than a dedicated brand search campaign
+   already covering them, that's not incremental reach — it's the same demand at a
+   worse price. Exclude your own brand once you can see that pattern.
+6. Read search term insights the same way you'd read a search terms report anywhere
+   else — clicks with cost and no conversions are negative-keyword candidates, even
+   though applying them here usually takes a different path than a standard search
+   campaign.
+
+## What good looks like
+
+- The best operators treat "Low" performance labels on individual assets as a
+  standing queue to clear, not a one-time cleanup — replacing the weakest asset in a
+  group is cheaper than restructuring the whole group later.
+- The common mistake is judging a fresh asset group on its first few days of
+  volatility and restructuring it before it's had a real chance to settle — that
+  resets the very learning period the impatience was trying to fix.
+- A good structure is legible from the outside: you can point to any asset group and
+  say which product or segment it exists for, and every low performer in it has a
+  named replacement candidate, not just a general sense that "creative could be
+  better."
+
+## Rules
+
+- MUST split asset groups by product line or audience segment rather than serving
+  everything from one group.
+- MUST provide at least one deliberately-chosen video per asset group rather than
+  relying on auto-generated video by default.
+- NEVER judge or restructure a new asset group before giving it a real settling
+  period — treat early-days volatility as expected, not diagnostic.
+- NEVER leave brand cannibalization unexamined if a dedicated brand search campaign
+  already covers the same queries at a better cost.


### PR DESCRIPTION
## What this skill does

How to structure and maintain Performance Max asset groups for delivery quality: splitting groups by product/audience segment, filling asset slots deliberately (including real video instead of relying on auto-generated fallback), giving new groups a real settling period before judging them, and catching brand-cannibalization once Performance Max is winning branded queries at a worse cost than a dedicated brand campaign.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/john-williams/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names (Google Ads / Performance Max / Quality Score are the ad platform's own domain terms, not a vendor stack choice — consistent with the existing `google-ads` skill in this library)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile


Made with [Cursor](https://cursor.com)