### PR TITLE
Add google-ads-ppc-math by John Williams

### DIFF
--- a/skills/john-williams/author.md
+++ b/skills/john-williams/author.md
@@ -1,0 +1,9 @@
+---
+name: John Williams
+avatarUrl: https://ahmeego.com/shared/authors/john-williams-160.webp
+title: Founder, AHMEEGO
+linkedinUrl: https://www.linkedin.com/in/johnmichaelwilliams
+companyDomain: ahmeego.com
+---
+
+Founder of AHMEEGO and the practitioner behind Buddy, the open-source Google Ads agent. 15+ years managing $350M+ in ad spend across NortonLifeLock, GM, Eventbrite, Prudential, Columbia, and Harvard — including a 192% YoY paid-search growth run at NortonLifeLock. Now builds AI-native paid-media tooling in the open, including a live agent that reads and writes to Google Ads accounts under explicit human confirmation.

--- a/skills/john-williams/google-ads-ppc-math/SKILL.md
+++ b/skills/john-williams/google-ads-ppc-math/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: google-ads-ppc-math
+title: PPC forecasting and unit-economics math
+description: |
+  Use this skill when someone asks for a budget projection, a ROAS or CPA target, an
+  impression-share opportunity estimate, or any paid-search math from numbers they
+  already have — no live account access needed. Produces a shown-work table with a
+  sensitivity check, not just a final number. Triggers: budget projection, ROAS
+  calculation, CPA target, conversion forecast, impression share opportunity,
+  break-even ROAS, "what would happen if."
+category: Ads
+---
+
+# PPC Forecasting and Unit-Economics Math
+
+Applies any time the question is really arithmetic wearing a strategy question's
+clothes — someone wants to know what a number implies before committing spend to it.
+
+## The play
+
+1. Work from whatever inputs are actually given, and state which core rates you
+   derived them from: CPA (spend ÷ conversions), ROAS (revenue ÷ spend), CTR (clicks
+   ÷ impressions), CPC (spend ÷ clicks), CVR (conversions ÷ clicks). Every downstream
+   projection is built from these five.
+2. For a budget or conversion forecast, chain the rates forward explicitly: daily
+   clicks from budget and CPC, daily conversions from clicks and CVR, then scale to a
+   monthly figure using an average month length (roughly 30.4 days) rather than a
+   flat 30 — the drift compounds over a full year of planning.
+3. For a target gap (hitting a CPA or ROAS goal), show the distance three ways: where
+   the account is now, what's required to hit the target, and the specific delta in
+   conversions or revenue needed to close it — not just "you're below target."
+4. For impression share opportunity, translate the missed share into missed clicks
+   and missed conversions using the account's own CTR and conversion rate, not an
+   assumed industry rate — the whole point is showing what the account's actual
+   funnel would produce with more visibility.
+5. Always run the sensitivity check nobody asked for: "if CPC rises 20%, your CPA
+   becomes X." A single-point forecast without a stress case invites false confidence
+   the moment reality drifts from the input.
+6. Flag inputs that don't pass a sanity check before running them forward — a CTR
+   above what's plausible for the format, or a CPA implausibly low for a non-branded
+   term, will just launder into an equally implausible forecast if you don't stop and
+   ask about it first.
+
+## What good looks like
+
+- The best version of this always shows the formula and the inputs next to the
+  result — a table with just a final number invites "how did you get that" and
+  erodes trust the first time someone tries to reproduce it.
+- The common mistake is running a forecast on inputs that were never sanity-checked,
+  producing a precise-looking number built on an impossible assumption. Catch the
+  impossible input, don't just compute through it.
+- Good output pairs every headline number with its sensitivity — a forecast that
+  can't say what happens if one input moves 20% isn't a forecast, it's a guess with
+  extra decimal places.
+
+## Rules
+
+- MUST show the formula and inputs alongside every calculated result, not the result
+  alone.
+- MUST use a full-year average (≈30.4 days/month) for monthly projections, not a
+  flat 30.
+- NEVER present a single-point forecast without at least one stated sensitivity case.
+- NEVER silently run an implausible input through a formula — flag it and ask before
+  projecting from it.


### PR DESCRIPTION
## What this skill does

A PPC forecasting and unit-economics math skill for budget projections, ROAS/CPA targets, and impression-share-opportunity estimates from numbers a user already has — always showing the formula and inputs, sanity-checking implausible inputs before projecting from them, and pairing every forecast with a stated sensitivity case.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/john-williams/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names (Google Ads / Performance Max / Quality Score are the ad platform's own domain terms, not a vendor stack choice — consistent with the existing `google-ads` skill in this library)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile


Made with [Cursor](https://cursor.com)