### PR TITLE
add cold-offer-architect

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/cold-offer-architect/SKILL.md
+++ b/skills/tanyo-gochev/cold-offer-architect/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: cold-offer-architect
+title: Cold offer architect
+description: |
+  Use this skill when the thing being sold to strangers isn't landing, or before writing a single
+  line of cold copy — to build a new cold-traffic offer, audit an existing one against a hard bar,
+  or diagnose why one that reads fine gets no replies. Covers cold email, cold DM, cold ads, and
+  cold mail: any audience with zero trust and no reason to believe you. Produces an architected
+  offer plus a pass/fail score against eight binary criteria. Trigger phrasings: "my offer isn't
+  converting", "low reply rate", "nobody's booking", "fix my offer", "what should I offer", "score
+  this offer", "is this offer any good", "we changed the copy and nothing happened".
+category: Outreach
+---
+
+Applies before copy, not after. Produces an offer architected as a deal, plus a pass/fail score against the eight-criterion gate below.
+
+## Fix in this order, or you'll rewrite copy forever
+
+**Market → offer → copy → list → volume.** When something isn't working, work down that list and stop at the first thing that's broken. Almost every "our cold email isn't working" problem is an offer problem being treated as a copy problem, which is why the rewrite never helps.
+
+On cold traffic the offer moves more than copy, personalization, and volume combined. A strong offer with plain copy beats a weak offer with brilliant copy, every time.
+
+## An offer is not an opener
+
+"Worth a quick call?" · "Can I send it over?" · "Open to a chat?" — those ask for interest in exchange for nothing the reader can value yet. They are openers.
+
+An **offer** is a complete value-for-value deal: a specific outcome they already want, a mechanism that makes it believable, the risk moved off them, and the terms. **Architect the deal first. The message is only the vehicle that delivers it.** Write the email before the deal exists and you will produce a polite opener every single time.
+
+## The gate — eight binary criteria, all must pass
+
+Any "no" means not shippable. Score honestly; do not average.
+
+| # | Criterion | A "no" looks like |
+|---|---|---|
+| 1 | Specific, quantified, time-bound outcome | "more pipeline", "better data" — no number, no clock |
+| 2 | Believable mechanism | A skeptic can't see why this works, or why *you* |
+| 3 | Risk sits on the seller | The buyer spends money, time, or face to find out |
+| 4 | Near-zero effort for the prospect | **A meeting before any value lands — that meeting *is* the effort** |
+| 5 | A reason why it's this good | Generosity with no explanation reads as a trick |
+| 6 | Proof embedded, not deferred | "Happy to send a case study" — deferring the one thing that earns belief |
+| 7 | Leads with them | The first line contains "we are / we do / we help" |
+| 8 | Uncomfortable to make | If you're perfectly comfortable offering it, it's too small |
+
+A soft "want it?" opener typically fails 1, 3, and 8 at once. That's why it feels weak even when the writing is clean.
+
+When a criterion fails, pull its lever and re-score — the ladders for risk, proof, effort, and specificity are in `references/amplification-ladders.md`. To find which criterion is causing a live campaign to die, work the symptom table in `references/diagnose-a-dead-offer.md`.
+
+## The forcing loop
+
+Architect the deal → score all eight → fix the lowest one → re-score. Repeat until every criterion passes. Never present an offer that hasn't cleared the gate; a 6/8 shipped is a month of sending burned to learn something the gate already told you.
+
+## What good looks like
+
+The tell of a good operator: they can name which of the eight is currently weakest without being asked, and they treat offers like ad creative — many, tested, killed fast — rather than as a brand decision made once.
+
+The mediocre version is a well-written email around a hollow deal: correct structure, real personalization, a polite ask, and a value proposition the reader has no reason to believe or care about. It gets praised internally and produces nothing.
+
+Good output makes a *fitting stranger* think one of: "this is a no-brainer", "I'd be an idiot to pass", or "what's the catch?" — and the catch is answered inside the offer. If your ideal prospect could comfortably ignore it, it isn't done.
+
+## Rules
+
+- MUST architect the deal before writing any message.
+- MUST embed a specific proof point inside the offer — a real number, and a named comparable where naming is permitted.
+- MUST deliver value before asking for a meeting, never the reverse.
+- NEVER present an offer that fails any of the eight criteria.
+- NEVER promise an outcome you can't defend, and never invent a number to pass criterion 1.

--- a/skills/tanyo-gochev/cold-offer-architect/references/amplification-ladders.md
+++ b/skills/tanyo-gochev/cold-offer-architect/references/amplification-ladders.md
@@ -1,0 +1,52 @@
+# Amplification ladders
+
+Read this when a gate criterion scores "no". Each ladder runs weakest to strongest. Climb until the criterion bites, then re-score.
+
+## Risk (criterion 3)
+
+The buyer should not be able to lose. Climb until that's literally true:
+
+1. A bare claim — "we get results"
+2. Money back if unhappy
+3. Pay only on results
+4. Work free until the first win lands
+5. The value is delivered free, in full, before any commitment
+
+Rungs 4 and 5 are the only ones that reliably work when you have no brand. If guarantees are contractually banned, rung 5 is the answer: the free asset must be so complete that judging it costs the prospect nothing.
+
+## Proof (criterion 6)
+
+1. No proof
+2. A vague claim — "we get great results for teams like yours"
+3. A hard number, anonymized — "a lender doing $100k/mo: 5–10 booked demos a month"
+4. A hard number attached to a named company
+5. A named company that visibly resembles the prospect, plus a number, plus a way to verify it
+
+The closer the comparable resembles the reader, the more it converts. Put it **inside** the offer. "Happy to send a case study" defers the single element that earns belief, and the reply that would have asked for it never comes.
+
+If naming clients is contractually banned, rung 3 is your ceiling — still concrete, still a real number, never "we get great results."
+
+## Effort (criterion 4)
+
+1. They have to learn something, or wait
+2. Do-it-yourself with your guidance
+3. Done with you
+4. Done for you
+5. Already done, sitting there, one reply away
+
+A meeting is a cost you charge the prospect, not a gift you give them. Pre-build the value from public data or from data they can send asynchronously, deliver it, and *earn* the meeting afterward.
+
+## Specificity (criteria 1, 2, 6)
+
+Vague reads as unbelievable on cold traffic, because a stranger has no context to fill the gaps with goodwill.
+
+- "more replies" → "32% more replies in 47 days"
+- "faster ramp" → "new reps productive in 5 weeks instead of 11"
+- Odd numbers and stated timeframes read as measured; round numbers read as marketing.
+- Every claim should be traceable to something you could show if challenged.
+
+## Mechanism (criterion 2)
+
+Name it. Tie it to something others structurally can't copy — a data source you built, a process only you run, an insight from work only you have done. Then answer the skeptic's two questions plainly: *why does this work* and *why hasn't it worked for me before?*
+
+A mechanism that could be claimed verbatim by three competitors isn't a mechanism.

--- a/skills/tanyo-gochev/cold-offer-architect/references/diagnose-a-dead-offer.md
+++ b/skills/tanyo-gochev/cold-offer-architect/references/diagnose-a-dead-offer.md
@@ -1,0 +1,34 @@
+# Diagnose a dead offer
+
+Read this when a campaign is live and underperforming. Work the symptom, not the vibe. The most common error is rewriting copy when the offer or the market is the leak.
+
+## Locate the leak first
+
+| Where it dies | Symptom | Almost always |
+|---|---|---|
+| Nothing arrives | Bounces high, opens implausibly low | Infrastructure, not offer. Fix before judging anything else. |
+| Read, no replies | Delivery healthy, replies near zero | The offer. Copy rewrites will not save it. |
+| Replies, all negative | "Not relevant", "wrong person" | The segment. The offer may be fine for someone else. |
+| Positive replies, no meetings | Interest, empty calendar | The ask, or a meeting demanded before value landed. |
+| Meetings, no deals | Calls happen, nothing closes | Offer/price mismatch, or the offer attracted people who can't buy. |
+
+## Then find the failing criterion
+
+Match the reaction you're actually getting to the gate criterion behind it:
+
+- **Silence** → criteria 1, 3, or 8. There's nothing specific enough to want, or nothing at stake for you.
+- **"Sounds interesting, send me info"** → criterion 6. Proof was deferred, so they're asking for the belief you didn't supply.
+- **"How much is it?" and then gone** → criterion 2. No mechanism, so price has nothing to attach to and becomes the only variable.
+- **"What's the catch?" with no reply to your answer** → criterion 5. The generosity has no credible reason behind it.
+- **"We already do this in-house"** → criterion 2 again. The mechanism isn't distinguishable from what they already have.
+- **Polite interest that never converts to a booking** → criterion 4. You asked for the meeting before anything of value landed.
+
+## Change one thing
+
+Change the offer, hold the list and copy constant, and re-run. Changing offer and segment together produces a result you can't attribute, and you'll carry the wrong lesson into the next campaign.
+
+Give each variant enough volume to be readable before calling it. Killing an offer on a sample too small to distinguish from noise is how teams end up cycling through six good offers and concluding the channel is dead.
+
+## Know when it's the market
+
+If three well-architected offers into the same segment all die, stop rewriting offers. You are selling to a market that doesn't have the problem urgently enough, can't pay for it, or can't be reached where you're reaching them. That's a targeting decision, not a copy decision, and no offer will fix it.


### PR DESCRIPTION
## What this skill does

Architects and audits cold-traffic offers — the deal you put in front of a stranger with zero trust. Scores an offer against eight binary criteria, and diagnoses which one is causing a live campaign to die.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile