### PR TITLE
add stage-aware-follow-up

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/stage-aware-follow-up/SKILL.md
+++ b/skills/tanyo-gochev/stage-aware-follow-up/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: stage-aware-follow-up
+title: Stage-aware follow-up
+description: |
+  Use this skill when a live deal needs its next touch and the right move isn't obvious — a prospect
+  replied warm but never booked, a call happened and the thread went quiet, a proposal or agreement
+  is out and unsigned, a booked meeting was a no-show, or the deal has gone cold. Produces the exact
+  next message plus the date and hook of the touch after it, so no warm thread is left un-dated.
+  Trigger phrasings: "follow up with", "they replied but never booked", "chase the booking", "they
+  ghosted", "agreement sent, no response", "what do I send next", "the thread went quiet",
+  "post-call email", "they no-showed", "re-engage this deal".
+category: Outreach
+---
+
+Applies to any deal that has already produced a reply and now needs its next touch. Produces one message, plus the date and hook of the touch after it.
+
+## Name the stage first
+
+The stage determines the message. Get it wrong and every draft is wrong.
+
+| Stage | Where the deal is | Touch cadence |
+|---|---|---|
+| 0 | Replied warm, nothing on the calendar | day 0 → 2 → 4 → 7, then demote |
+| 1 | Between booked meetings | same day → day before → meeting day |
+| 2 | Decision pending, no agreement | same day → 2 → 4 → 7 → 14 |
+| 3 | Agreement out, unsigned | hour 0 → 24h → day 2 → 4 → 7 → 14 |
+| 4 | Proposal sent in writing, no meeting held | same day, ask for the meeting → then Stage 2 |
+| 5 | Long-term nurture | every 30–45 days, indefinitely |
+
+If it's earlier than the cadence allows, say so and offer to draft anyway.
+
+## Stage 0 is where most pipeline dies
+
+Warm replies accumulate and nobody walks them onto the calendar. The reply gets a good answer, the thread gets orphaned, and the yes decays. The goal here is a meeting — not more conversation, not more free value for its own sake. Value is the vehicle; the booking is the destination.
+
+- **Every touch does two jobs at once**: earns the meeting with a *new, concrete* reason — something found while building their asset, how the scoring worked, which segment looks strongest, a benchmark, a quick win spotted — *and* carries the booking ask. Never one without the other.
+- **The ask is direct.** Banned soft-asks, all of which hand them an exit: "when you surface", "whenever works", "no rush", "happy to chat sometime", "feel free to grab time".
+- **A buying question is a buy signal.** Answer it in one line, then ask for the meeting in the same message. Never let it open into unpaid Q&A.
+- **If a promised asset is the reason for the meeting, present it live.** Sending it ahead spends the reason and the meeting evaporates. Deliver it standalone only after two explicit refusals — then gracefully, with the offer left standing.
+- **Hot buyer: send the link and stop selling.** When they say "let's set up a call" or "send me a time", the only correct move is the booking link plus what you'll bring. Banned replies: "which day works?", "send me your email", "send me a few times", "I'll have someone coordinate." Each hands control back, and the yes evaporates in the gap.
+- **A no-show is hot, not lost.** Same day, no blame, fresh link — it's usually a calendar miss. Never end a thread on an unanswered "are you joining?"
+
+## Never break up
+
+No "closing the loop", "last note from me", "won't keep pinging", "door's open if anything changes". Cap active touches inside a stage at seven — then the prospect **demotes to nurture, not to silence**. Demotion is silent: slow the cadence, never announce it. Follow up less often rather than not at all.
+
+## Every touch earns its send
+
+Before output, ask: *would this be worth sending even if they never buy?* If no, rewrite.
+
+Never generate: "just checking in", "circling back", "did you see my last email", "hope this finds you well", invented deadlines, guilt, weekend sends, "when's a good time?" (propose windows or send the link), or any message to an un-booked warm replier that contains no ask.
+
+Close every draft with `NEXT-TOUCH: [date] — [specific hook]`. That line is the mechanism that stops warm threads from being orphaned.
+
+## What good looks like
+
+The tell of a good operator: they treat a positive reply as an unfinished job, not a win. The mediocre version answers warmly, feels productive, and never asks again — the thread reads friendly and produces nothing.
+
+Good output is a message whose reason for existing is information the prospect doesn't have yet, with the ask attached, that could not have been sent to anyone else this week — plus a dated next touch already written down before this one goes out.
+
+## Rules
+
+- MUST carry a booking ask in every touch to a warm replier with nothing on the calendar.
+- MUST end every draft with the date and hook of the next touch.
+- NEVER state the meeting's duration in the copy.
+- NEVER send a breakup, or announce a change in cadence.
+- NEVER send the same value drop to the same prospect twice.


### PR DESCRIPTION
## What this skill does

Produces the exact next touch for a deal at any stage, and closes the reply-to-booked-call gap where most warm pipeline quietly dies.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

_Note: `author.md` is repeated across my open PRs because it is not on `main` yet — identical content, safe to take from whichever merges first._