### PR TITLE
add cold-email-first-touch

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/cold-email-first-touch/SKILL.md
+++ b/skills/tanyo-gochev/cold-email-first-touch/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: cold-email
-title: Cold email
+name: cold-email-first-touch
+title: Cold email first touch
 description: |
-  Use this skill when writing a cold email to someone who has never heard of you — a first touch, a
-  follow-up inside a cold sequence, a subject line, or a batch of messages off a list. Produces
+  Use this skill when writing the first cold email to someone who has never heard of you — that
+  opening touch, its subject line, the follow-ups threaded behind it, or a batch of first touches
+  off a list. Produces
   copy built to earn a reply rather than close a deal, with the deliverability constraints treated
   as writing rules rather than an infrastructure problem. Trigger phrasings: "write a cold email",
   "cold outreach", "prospecting email", "outbound email", "email these leads", "SDR email",

--- a/skills/tanyo-gochev/cold-email/SKILL.md
+++ b/skills/tanyo-gochev/cold-email/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: cold-email
+title: Cold email
+description: |
+  Use this skill when writing a cold email to someone who has never heard of you — a first touch, a
+  follow-up inside a cold sequence, a subject line, or a batch of messages off a list. Produces
+  copy built to earn a reply rather than close a deal, with the deliverability constraints treated
+  as writing rules rather than an infrastructure problem. Trigger phrasings: "write a cold email",
+  "cold outreach", "prospecting email", "outbound email", "email these leads", "SDR email",
+  "nobody's replying to my emails", "write the sequence", "subject line for".
+category: Outreach
+---
+
+Applies to first contact with a stranger. Produces one message, or a batch where every row is grounded in that row's own data.
+
+## Sell the reply, not the product
+
+You are not closing in the inbox. You are earning one small "tell me more." Everything below follows from that.
+
+Two things do most of the work before a word is written: **the offer and the list**. Copy is the delivery vehicle. A great email carrying a weak offer to the wrong segment still loses, and rewriting it is the most common way teams waste a month. If the offer is soft, fix the offer. If the segment is generic, fix the segment.
+
+## The skeleton
+
+```
+Subject: 1–3 words, neutral, reads like internal mail
+Line 1 — TRIGGER:  one true, specific thing about THEM. No "I / we / our."
+Line 2 — TENSION:  the problem that trigger implies, in their language
+Line 3 — PROOF:    one outcome, with a real number and a real comparable
+CTA — one soft question asking for interest, not for time
+```
+
+- **Under 75 words**; 25–50 is better. Corpus studies of tens of millions of sends put short, plain, low-reading-grade emails far ahead of long ones.
+- **Exactly one question.** A second CTA lowers replies.
+- **"You" outweighs "I/we."** Count them if unsure.
+- **Tentative beats certain** — "looks like", "I could be off", "guessing". Certainty from a stranger reads as a pitch.
+- **Formatted for a phone.** Most of these are read on one. One-line sentences, white space, no walls.
+
+## Relevance comes from the segment, not the merge field
+
+A first name and "saw your post" is not personalization. Relevance means the message would only make sense sent to *this* kind of company, for *this* reason, right now. Personalize the first sentence or two; templatize the rest — the alternative doesn't survive contact with volume.
+
+The test that settles it: **could this exact email go to a different company and still make sense?** If yes, the trigger is decoration. Rebuild around a real business event, not a piece of trivia.
+
+## The ask
+
+Ask for interest, not for time. No calendar link on touch one. "Worth a look?" · "Is this a priority right now?" · "Want the two-minute version?" · "…or does this sit with someone else?" An easy-out — "if it's not a priority, no worries" — removes the neediness that kills replies. The meeting is earned in reply two or three.
+
+## Deliverability is a copy constraint
+
+The best copy dies in spam, so the writing itself has to obey:
+
+- **No links, images, or tracking pixels on touch one.** A reply-ask outperforms a link by a wide margin, and the pixel costs you placement.
+- **Vary the copy at volume** so no two sends are identical.
+- **Plain text with a real signature.** A bare, signature-less email reads *less* legitimate, not more.
+- **Cap sends per inbox** at a conservative daily number and scale by adding inboxes — never by raising the per-inbox limit. This is the single most common self-inflicted deliverability wound.
+- **Send only to verified addresses.** Bounce rate above a couple of percent damages the domain faster than any content mistake.
+
+## Follow-up
+
+One email is a coin flip; the sequence is the system. Four to five touches over two to three weeks, each adding something genuinely new — a different angle, a proof point, a useful asset. Never an empty bump. Thread follow-ups as replies so the original personalization stays visible.
+
+## What good looks like
+
+The tell of a good operator: they can name the segment-level reason the email exists before they write a line of it, and they fix offers and lists before they touch copy.
+
+The mediocre version is fluent and forgettable — correct structure, a merge field in the opener, a polite ask, and nothing a stranger has any reason to answer. It reads fine to the team and produces nothing.
+
+Good output survives the deletion test: strike the opening line, and the email still makes sense — because the relevance was in the substance, not the decoration.
+
+## Rules
+
+- MUST pass the "could this go to anyone else?" test before shipping.
+- MUST keep exactly one ask, for interest rather than for time, on the first touch.
+- NEVER put a link, image, or tracker in a first touch.
+- NEVER invent a signal, a statistic, or a customer to make a line land.
+- NEVER raise the per-inbox send limit to scale volume.


### PR DESCRIPTION
## What this skill does

Writes the first cold touch to earn a reply rather than close a deal, and treats deliverability as a constraint on the copy itself, not just on the infrastructure.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

_Note: `author.md` is repeated across my open PRs because it is not on `main` yet — identical content, safe to take from whichever merges first._