### PR TITLE
add linkedin-inmail

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/linkedin-inmail/SKILL.md
+++ b/skills/tanyo-gochev/linkedin-inmail/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: linkedin-inmail
+title: LinkedIn InMail
+description: |
+  Use this skill when writing the first cold message a prospect will ever see on LinkedIn — an
+  InMail, a connection-request note, or the opening DM after a connection is accepted. Covers
+  choosing the right vehicle, grounding the message in a real signal, and the character budgets
+  each format allows. Produces one message with the signal it's built on, or a batch where every
+  row is unique. Trigger phrasings: "write an InMail", "cold LinkedIn message", "connection
+  request note", "LinkedIn DM", "reach out on LinkedIn", "LinkedIn outreach sequence".
+category: Outreach
+---
+
+Applies to first contact on LinkedIn, before any relationship exists. Produces the message plus the signal it was grounded in.
+
+## Pick the vehicle first
+
+Three formats, three different budgets. Don't blend them.
+
+| Vehicle | Budget | Use when |
+|---|---|---|
+| Connection note | ~300 characters | Their profile offers connect, not message. One signal, one thought, a light ask or none. |
+| InMail | Short subject + body under ~400 characters | They're open-profile, or they're worth spending a paid credit on. |
+| DM after acceptance | ~600–1,000 characters | They accepted. More room, because they already opted in. |
+
+The character limit is the discipline. A connection note that needs 400 characters is a note that hasn't found its point.
+
+## The four rules every draft passes
+
+**1. Earn the open.** Subject lines carry most of the decision on InMail. Five to seven words, peer-to-peer, referencing something they care about rather than something you sell. "Quick question about your agency growth" is a vendor. "Your last three reviews — a pattern" is a peer.
+
+**2. Show you looked, in line one.** A specific data point only someone who actually examined them would have. "Saw you're the founder of [company]" is a profile skim, not research. Real signals: their service mix, recent hiring, a podcast or article they did, their customer mix, a competitor mention, a location nuance. **If you can't find a real signal, don't send — go find one.**
+
+**3. Give a thought worth reading even if they never reply.** One specific, useful observation about *their* situation: "I noticed X — here's what usually breaks in that spot." Not "we help companies like yours." This is the highest-leverage rule and the most ignored; without it you're polite spam with good formatting.
+
+**4. Make replying easier than ignoring.** One ask. Ask for interest, not for a slot. Give them a graceful no — "or tell me it's not relevant and I'll leave it" — which raises replies rather than lowering them. Never "let me know if you'd like to learn more."
+
+## Sequences
+
+A single touch gets a fraction of what a sequence does. Day 0 message → day 3–5 substantive engagement with something they published → day 7–10 second message tied to a *new* signal → day 14–21 a value drop tied to something fresh.
+
+After that, drop the cadence to monthly, then quarterly, and keep going. No breakup message, ever — no "last call", no "closing the loop", no "door's open if anything changes". A message containing a threat to stop is a message to rewrite. Demotions are silent.
+
+## Batches
+
+Given a list and asked for a hundred messages, produce a hundred messages each grounded in that row's own data — with the signal used recorded alongside. One template with swapped merge fields fails rules 2 and 3 simultaneously, and at LinkedIn's message volumes it is immediately recognisable as such.
+
+## What good looks like
+
+The tell of a good operator: they'll refuse to send rather than send without a signal, and they treat the character limit as the thing that forces the message to be about one real observation.
+
+The mediocre version compliments the prospect's profile, states what the sender does, and asks for fifteen minutes — three sentences that could go to ten thousand people and mean the same thing to all of them.
+
+Good output passes two tests. **Swap test**: could this exact message go to another prospect by changing only the name and company? If yes, rule 2 failed. **Standalone test**: if they read it and decide not to reply, did they still get something useful? If no, rule 3 failed.
+
+## Rules
+
+- MUST ground every message in a specific, verifiable signal about that person or company.
+- MUST stay inside the character budget for the chosen vehicle.
+- MUST keep it to one ask, for interest rather than a slot.
+- NEVER send a breakup or announce that you'll stop messaging.
+- NEVER produce a batch by swapping merge fields in a single template.


### PR DESCRIPTION
## What this skill does

Writes the first cold LinkedIn touch, matched to the character budget of the vehicle and grounded in a real signal rather than a merge field.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

_Note: `author.md` is repeated across my open PRs because it is not on `main` yet — identical content, safe to take from whichever merges first._