### PR TITLE
add campaign-benchmarking

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/campaign-benchmarking/SKILL.md
+++ b/skills/tanyo-gochev/campaign-benchmarking/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: campaign-benchmarking
+title: Campaign benchmarking
+description: |
+  Use this skill when someone needs to know whether a campaign's numbers are actually good — before
+  setting targets for a launch, when reporting performance to someone who needs context rather than
+  raw figures, or when comparing across clients, segments, and time periods. Produces a verdict with
+  the comparison layer named, plus what to do about it. Trigger phrasings: "is this reply rate
+  good", "what should we expect", "set targets for this campaign", "how do we compare", "benchmark
+  this", "our numbers dropped", "is 3% good", "what's a normal reply rate".
+category: RevOps
+---
+
+Applies when a number needs a verdict. Produces the verdict, the layer it was judged against, and the action it implies.
+
+## A number without a comparison is not a result
+
+A 5% reply rate is exceptional cold to enterprise executives and poor for warm re-engagement with existing users. The number alone tells you nothing. Benchmarking supplies the missing half — whether to celebrate, optimise, or stop.
+
+## Three layers, in order of usefulness
+
+**Layer 1 — external averages.** Published figures aggregated across platforms and agencies. Use these as a sanity check only: they average across wildly different offers, segments, and levels of competence, so they're a floor for "is something catastrophically wrong", never a target.
+
+**Layer 2 — your own history.** What the same motion produced for you before. This is the layer that actually drives decisions, and it's the one most teams don't keep. Building it costs nothing but the discipline of recording every campaign's outcome next to its offer, segment, and volume.
+
+**Layer 3 — like-for-like within your own book.** The same offer to a different segment, or the same segment with a different offer. This is the only layer that isolates a variable well enough to be causal.
+
+Always name which layer you judged against. "Below benchmark" means nothing until you say whose.
+
+## Compare like with like, or don't compare
+
+A comparison is only valid when the offer, the segment, the channel, and the relationship temperature are held roughly constant. Campaign A beating campaign B tells you nothing if A went to a warmer list — which is how most internal "winning variant" conclusions get made.
+
+Volume matters as much as the rate. A 12% reply rate on 40 sends is not a result, it's noise wearing a percentage sign. State the denominator every time; a rate quoted without its sample size should be treated as unreported.
+
+## Set targets from your own floor
+
+For a new campaign, take your own median for the closest comparable motion as the expected case, your own best as the ceiling, and set the kill threshold below the floor — not from a published industry figure. Decide the kill threshold *before* launch, in writing. Deciding it afterwards is how a campaign gets kept alive on hope.
+
+## What good looks like
+
+The tell of a good operator: they keep their own history, and they trust it over any published figure — because their median across their own campaigns is the only benchmark that already accounts for their offer, their market, and their execution.
+
+The mediocre version quotes an industry average from a vendor's blog post to justify a result that's actually mediocre for that team. It's the most common way a declining campaign gets defended for another month.
+
+Good output states the number, the layer it was compared against, the sample size, the verdict in one word, and the single action it implies. A benchmark that doesn't change what you do next was a decoration.
+
+## Rules
+
+- MUST state the sample size alongside every rate.
+- MUST name which layer a comparison was made against.
+- MUST set the kill threshold before launch, not after the numbers arrive.
+- NEVER compare campaigns that differ in offer, segment, channel, or temperature.
+- NEVER present an external average as a target.


### PR DESCRIPTION
## What this skill does

Gives a campaign number an actual verdict by naming which comparison layer it was judged against, with the sample size stated every time.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

_Note: `author.md` is repeated across my open PRs because it is not on `main` yet — identical content, safe to take from whichever merges first._