### PR TITLE
add objection-mining

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -1,0 +1,9 @@
+---
+name: Tanyo Gochev
+avatarUrl: https://iili.io/CvhNfBj.png
+title: "Co-Founder & Head of GTM, The Demand Department"
+linkedinUrl: https://www.linkedin.com/in/tanyo/
+companyDomain: demanddept.com
+---
+
+Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.

--- a/skills/tanyo-gochev/objection-mining/SKILL.md
+++ b/skills/tanyo-gochev/objection-mining/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: objection-mining
+title: Objection mining
+description: |
+  Use this skill when the same pushback keeps arriving and nobody has written it down — mining call
+  recordings and reply threads for recurring objections, classifying them, and building the answer
+  into the outreach so it stops coming up. Produces a ranked objection catalogue with what each one
+  actually means and where to pre-handle it. Trigger phrasings: "why do we keep losing", "common
+  objections", "they said it's too expensive", "handle this objection", "build a battlecard",
+  "what do we say when they ask", "mine the call transcripts", "our reps keep getting stuck on".
+category: Sales
+---
+
+Applies to accumulated call recordings, reply threads, and lost-deal notes. Produces a ranked catalogue with a pre-handle location for each objection.
+
+## Objections are data, not rejection
+
+People who aren't interested don't object — they ignore you. An objection means someone engaged enough to tell you their buying criteria out loud.
+
+The goal is not to get better at overcoming objections in the moment. It's to understand them well enough that they stop arriving, because the message already answered them. Every objection you hear repeatedly is a gap in your outreach that you're paying a rep to patch by hand on every call.
+
+## Six categories, and what each one is really saying
+
+| Category | Sounds like | Usually means |
+|---|---|---|
+| **Timing** | "Not this quarter", "check back later" | Real interest, not urgent enough to displace current work |
+| **Budget** | "Too expensive", "no budget" | Hasn't been prioritised, or the price is anchored to the wrong comparison |
+| **Authority** | "I need to run it past…" | They're the champion, not the buyer — arm them |
+| **Trust** | "How do I know this works?" | Interested and skeptical; needs proof of fit, not more features |
+| **Fit** | "We're different", "too small for this" | They can't see themselves in your messaging |
+| **Competition** | "We're looking at X too" | Active evaluation — you're being compared right now |
+
+Classify before you respond. The same words carry different categories: "too expensive" from someone who hasn't seen value is a fit objection wearing a budget costume, and answering it with a discount loses the deal twice.
+
+## Timing objections are the best ones you get
+
+They're deferrals, not rejections — and they're the most commonly discarded. Record the stated reason and the stated date, then come back at that date with something new. A "not now" that gets worked converts at a rate that embarrasses most cold sequences.
+
+Which means: **"not interested" is not "stop contacting me."** It's a signal that the buying window is shut, not an exit. Slow the cadence and keep going. The only exits are an explicit request to stop and a hard unsubscribe.
+
+## Pre-handle upstream
+
+For each objection in the catalogue, name where it should have been answered — in the offer, in the first touch, on the website, or in qualification. Then move it there. An objection handled on a call is a cost you pay every time; the same objection handled in the message is paid once.
+
+## What good looks like
+
+The tell of a good operator: they can rank their objections by frequency from memory and name which stage each one should have been killed at. Most teams can list objections; almost none know which is most common, because nobody logs them.
+
+The mediocre version is a battlecard of clever rebuttals — the sales equivalent of treating symptoms. It makes reps better at arguing and does nothing about why the argument keeps happening.
+
+Good output is ranked by how often the objection actually occurs, quotes the prospect's real language rather than a paraphrase, states what each objection means underneath, and names one upstream change per objection. If it doesn't change the outreach, it was a note-taking exercise.
+
+## Rules
+
+- MUST classify each objection by category before writing any response.
+- MUST rank by observed frequency, using real quotes.
+- MUST name where each objection should be pre-handled upstream.
+- NEVER treat a soft "no" as an exit from follow-up.
+- NEVER answer a fit or trust objection with a discount.

--- a/skills/tanyo-gochev/objection-mining/SKILL.md
+++ b/skills/tanyo-gochev/objection-mining/SKILL.md
@@ -36,7 +36,9 @@ Classify before you respond. The same words carry different categories: "too exp
 
 They're deferrals, not rejections — and they're the most commonly discarded. Record the stated reason and the stated date, then come back at that date with something new. A "not now" that gets worked converts at a rate that embarrasses most cold sequences.
 
-Which means: **"not interested" is not "stop contacting me."** It's a signal that the buying window is shut, not an exit. Slow the cadence and keep going. The only exits are an explicit request to stop and a hard unsubscribe.
+Which means: **"not interested" is not "stop contacting me."** It's a signal that the buying window is shut, not an exit. Slow the cadence and keep going.
+
+A direct opt-out is the opposite case and gets no interpretation. "Stop", "unsubscribe", "remove me", "take me off your list" — that contact comes out of every sequence on the spot and goes onto the suppression list permanently. It is not a cadence to slow, not an objection to classify, and not a thread to close with one last message.
 
 ## Pre-handle upstream
 
@@ -55,5 +57,6 @@ Good output is ranked by how often the objection actually occurs, quotes the pro
 - MUST classify each objection by category before writing any response.
 - MUST rank by observed frequency, using real quotes.
 - MUST name where each objection should be pre-handled upstream.
+- MUST honour a direct opt-out — "stop", "unsubscribe", "remove me" — immediately and permanently: suppression-list the contact and remove them from every sequence. Never slow the cadence instead, never send a closing message.
 - NEVER treat a soft "no" as an exit from follow-up.
 - NEVER answer a fit or trust objection with a discount.


### PR DESCRIPTION
## What this skill does

Turns recurring objections into a ranked catalogue — what each one actually means underneath, and where upstream it should have been answered.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

_Note: `author.md` is repeated across my open PRs because it is not on `main` yet — identical content, safe to take from whichever merges first._