### PR TITLE
add local-ai-visibility

### DIFF
--- a/skills/huxley-peckham/author.md
+++ b/skills/huxley-peckham/author.md
@@ -1,0 +1,9 @@
+---
+name: Huxley Peckham
+avatarUrl: "https://www.gtmskills.com/authors/huxley-peckham.jpg"
+title: Founder, Tech Horizon Labs
+linkedinUrl: "https://www.linkedin.com/in/huxley-peckham"
+companyDomain: areyoufoundbyai.com
+---
+
+Founder at Tech Horizon Labs on Australia's Sunshine Coast. Builds Are you found by AI?, an AI-visibility scanner that measures whether answer engines name a business when its buyers ask — thousands of live-measured businesses feeding a public index. These skills encode that measurement discipline: sample the answers, keep the receipts, track the movement.

--- a/skills/huxley-peckham/local-ai-visibility/SKILL.md
+++ b/skills/huxley-peckham/local-ai-visibility/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: local-ai-visibility
+title: Local AI visibility
+description: |
+  Use this skill when a business serves specific towns or suburbs and needs to know where
+  AI recommends it — "do we show up in this suburb," "named in one city and invisible in
+  the next," "which service areas are the gap." Measures AI answers town by town, records
+  map-pack and written-answer presence separately, and produces a ranked gap map of where
+  rivals get named instead.
+category: AEO
+tags: [Marketing]
+---
+
+Use when a business serves specific towns, suburbs, or service areas and needs to know where AI recommends it. Produces a town-by-engine presence grid and a ranked list of the gaps where rivals get named instead.
+
+## Build the town matrix
+
+List every town the business genuinely serves, not just the head city. Phrase each test question the way a local buyer types it — the service plus the place, in plain words. Ask per town, per engine. Results from the head city predict nothing about the suburb next to it: answer engines assemble local answers from thin, hyper-local evidence, and a brand can be the answer in one postcode and absent one over.
+
+## Record the local pack separately
+
+For engines that lean on map results, capture presence in the map pack and presence in the written answer as two signals. They move for different reasons: the pack follows profile completeness, reviews, and proximity; the prose follows mentions, citations, and content. A brand can hold one and not the other, and the fix for each is different work.
+
+## Make the gap map
+
+For every town-and-engine cell where the brand is absent, record who is named instead, in the engine's own words. Rank the gaps by demand — the search volume behind the question where it is known, population as the proxy where it is not. The output is a ranked list: town, question, who wins it now, and the quoted evidence.
+
+## What good looks like
+
+The expert's tell is the visibility cliff: named consistently across the service area except two towns where one competitor dominates every engine — those two towns are the quarter's work, and the quoted answers explain why. The mediocre version checks the head city once, averages everything into a single local score, and hides exactly the gaps that matter. Good output names towns, names the rivals winning them, quotes the answers, and orders the list so the first row is the most valuable fix.
+
+## Rules
+
+- MUST test each served town separately, in buyer phrasing.
+- MUST record map-pack presence and written-answer presence as separate signals.
+- NEVER average towns into one score.
+- NEVER assume traditional local rankings imply presence in AI answers.


### PR DESCRIPTION
## What this skill does

Town-by-town AI visibility for businesses that serve specific suburbs and service areas: buyer-phrased questions per town per engine, map-pack and written-answer presence recorded as separate signals, and a demand-ranked gap map of where rivals get named instead. There is currently no local-focused skill in the library.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/huxley-peckham/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

Note on the avatar: `avatarUrl` follows the `/authors/<slug>.jpg` convention every current profile uses — happy to supply the image file, or it can be taken from the LinkedIn profile linked in `author.md`. The identical `author.md` is included in each of my three first-contribution PRs so they merge in any order.