### PR TITLE
add citation-gap-outreach

### DIFF
--- a/skills/huxley-peckham/author.md
+++ b/skills/huxley-peckham/author.md
@@ -1,0 +1,9 @@
+---
+name: Huxley Peckham
+avatarUrl: "https://www.gtmskills.com/authors/huxley-peckham.jpg"
+title: Founder, Tech Horizon Labs
+linkedinUrl: "https://www.linkedin.com/in/huxley-peckham"
+companyDomain: areyoufoundbyai.com
+---
+
+Founder at Tech Horizon Labs on Australia's Sunshine Coast. Builds Are you found by AI?, an AI-visibility scanner that measures whether answer engines name a business when its buyers ask — thousands of live-measured businesses feeding a public index. These skills encode that measurement discipline: sample the answers, keep the receipts, track the movement.

--- a/skills/huxley-peckham/citation-gap-outreach/SKILL.md
+++ b/skills/huxley-peckham/citation-gap-outreach/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: citation-gap-outreach
+title: Citation gap outreach
+description: |
+  Use this skill when the sources behind AI answers are known and the brand needs to get
+  into them — "AI keeps citing these directories and the brand is not there," "turn the
+  citation analysis into an outreach plan," "get named where the engines already read."
+  Converts cited-source gaps into a ranked get-listed plan with the right ask per source
+  type and a re-measure loop proving each placement moved answers.
+category: AEO
+tags: [Marketing]
+---
+
+Use when the sources feeding AI answers in a category are known and the brand needs to get into them. Produces a ranked get-listed plan with the right ask per source and a re-measure loop that proves each placement landed.
+
+## Rank by answers fed, not authority
+
+Order target sources by how many category answers each one fed. Domain authority, traffic, and prestige all mislead here: a modest directory feeding nine answers outranks a famous publication feeding one. The citation count is the value of the placement; everything else is habit carried over from link building.
+
+## Match the ask to the source
+
+Each source type gets updated a different way, and the ask must match it. A directory or listing site wants a submission or a claimed profile. A comparison or review page wants inclusion with evidence — real differentiators, pricing, proof — not a pitch. A community thread is entered honestly, with a real answer from a real account, or left alone. A publication wants the data or story its page is missing. Write the ask so the person who maintains that page can act on it in one sitting.
+
+## Run it like pipeline
+
+Track each target as a row: source, page, answers it fed, whether it mentions the brand today, ask type, the human contact, status. Work the top of the list first; small placements land fastest and compound.
+
+## Verify the placement landed in answers
+
+After a placement goes live, re-ask the questions that source was feeding and compare. If the answers do not move within a re-measure cycle, either the source mattered less than the count suggested, or the mention lacks the substance engines quote — specifics, numbers, and comparisons get cited; adjectives do not. Fix the mention before adding new targets.
+
+## What good looks like
+
+The best operators notice the shape of what engines quote from each source — a comparison table, a price, a spec — and ask for that placement, not a logo on a partner wall. The mediocre version is generic link-building outreach re-sent with new words in the subject line, ordered by domain authority, never re-measured. Good output attaches evidence to every target — the answers that source fed — so each outreach message writes itself, and every closed row has a before-and-after answer pair proving it mattered.
+
+## Rules
+
+- MUST rank targets by answers fed.
+- MUST re-measure the affected questions after each placement.
+- NEVER astroturf community threads.
+- NEVER present paid placements as organic mentions.


### PR DESCRIPTION
## What this skill does

Turns known cited-source gaps into placements: targets ranked by answers fed (not domain authority), the ask matched to how each source type actually gets updated, run as pipeline, and every placement verified by re-asking the questions that source was feeding. Picks up where citation analysis stops.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/huxley-peckham/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

Note on the avatar: `avatarUrl` follows the `/authors/<slug>.jpg` convention every current profile uses — happy to supply the image file, or it can be taken from the LinkedIn profile linked in `author.md`. The identical `author.md` is included in each of my three first-contribution PRs so they merge in any order.