### PR TITLE
add founder-led-sales by devtool-gtm

### DIFF
--- a/skills/devtool-gtm/author.md
+++ b/skills/devtool-gtm/author.md
@@ -1,0 +1,9 @@
+---
+name: Shane O'Connor
+avatarUrl: https://avatars.githubusercontent.com/u/256833559?v=4
+title: Founder, The DevTool GTM Company
+linkedinUrl: https://www.linkedin.com/in/devtoolgtm
+companyDomain: gtmcofounder.com
+---
+
+Shane builds The GTM Co-Founder, an open-source go-to-market system for early-stage technical founders, and is a GTM advisor at QC Growth. His skills encode the judgment behind taking a developer tool from "nobody came" to real revenue: positioning, pricing, and founder-led sales.

--- a/skills/devtool-gtm/founder-led-sales/SKILL.md
+++ b/skills/devtool-gtm/founder-led-sales/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: founder-led-sales
+title: Founder-led sales
+description: |
+  Use this skill when developers love your tool but nobody pays, you have never sold and freeze on
+  the conversation, or deals stall on "let me think about it." Produces a repeatable first-deal
+  motion you run yourself: finding the champion and the buyer, running discovery, demoing their use
+  case, arming the champion, and closing your first paying customers. Triggers on "founder-led
+  sales", "close first customers", "nobody will pay", "how do I sell this", "let me think about it",
+  "sales discovery", "find the champion", "close the deal", "first paying customer".
+category: Sales
+tags: [Sales]
+---
+
+Applies when developers love your tool and live in the free tier but nobody pays, you have never sold and freeze on the actual conversation, or every deal dies on "let me think about it." Produces a first-deal motion you run yourself, from finding the champion to closing the buyer.
+
+## Do the first deals yourself
+
+Nobody can sell it before you can. Your first ten to twenty deals are not a hire, they are how you learn what you are actually selling and to whom. You cannot outsource a motion you have not cracked; a founder who hires a rep at deal one hires someone to fail at a job that does not exist yet. And it is not slimy: selling a developer tool well is discovery plus helping a champion get budget. You find the people who already have the pain and make it easy for them to say yes.
+
+## Every real deal has four things
+
+If one is missing, it is a conversation, not a deal. Your job is to find which:
+
+- **Champion** — uses it, loves it, and will fight for it inside their company. Usually the developer who adopted you.
+- **Buyer** — has budget. Often not the champion.
+- **Pain with a cost** — a problem costing money, time, or risk now, not "this is nice."
+- **Trigger** — a reason to act now: an incident, an audit, a deadline, a scaling wall.
+
+## The motion
+
+1. **Start with who is already engaged.** Your first customers hide in your usage: the team with three seats on the free tier, the person who filed four issues, the account that hit a limit. They have shown you the pain. Do not cold-blast strangers.
+2. **Reach out like a founder, not a sequence.** One short, human message to a real person about a specific thing you noticed. If it could have gone to a thousand people, do not send it.
+3. **The first call is discovery, not a pitch.** Talk thirty percent, listen seventy. Learn what they use it for, what they did before, what the pain costs, who else feels it, who owns the budget. The person asking the best questions controls the conversation.
+4. **Demo their use case, not your feature list.** Show the product doing *their* job with *their* kind of data and get them to the win. "Here is your exact problem, solved" beats a feature tour.
+5. **Frame value for the buyer.** The developer feels the hours saved; the buyer approves budget for the outcome — a release cycle back, an incident avoided, a compliance box checked. Translate the dev's love into a business result the boss can defend.
+6. **Arm the champion to sell internally.** You are rarely in the room when the yes happens. Hand them the one-paragraph business case, the number, and the answer to "why now," so they can carry it to their boss.
+7. **Always leave with a specific next step and a date.** This kills the stall before it starts.
+
+## "Let me think about it"
+
+Not an objection, a missing next step or an unsurfaced concern. Do not accept it and leave. Ask gently: "Totally fair. What would you need to be sure of to move forward?" Then you learn the real blocker (budget, a stakeholder, a missing feature, timing) and can address it. A vague yes-later is a no you have not diagnosed.
+
+## What good looks like
+
+- You started from your most engaged accounts, not a cold list.
+- In discovery, the customer talked more than you did.
+- You can name all four (champion, buyer, pain-with-a-cost, trigger) for the deal, and you have spoken to the person with budget, not just the fan.
+- The demo showed their problem solved, not a tour of features.
+- Every conversation ended with a specific next step and a date.
+
+## Rules
+
+- MUST run your first ten to twenty deals yourself before hiring a rep.
+- MUST reach the buyer, not only the champion; a deal with only the champion is a fan, not a deal.
+- NEVER end a sales conversation without a specific next step and a date.
+- NEVER treat "let me think about it" as a yes, or discount out of fear at the first price pushback.


### PR DESCRIPTION
## What this skill does

Founder-led sales: how a technical founder closes their first paying customers themselves — finding the champion and the buyer, running discovery, demoing the customer's use case, arming the champion to sell internally, and killing the "let me think about it" stall.

## Note on author.md

This is my second skill. PR #45 (dev-tool-pricing) also adds `skills/devtool-gtm/author.md`, identical to the copy here. I include it so this PR validates standalone; if #45 merges first this add is a clean no-op. Take whichever you merge first.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/devtool-gtm/` only
- [ ] `node tools/validate.mjs` passes locally — node wasn't available in my environment, so I hand-verified against `tools/validate.mjs` (kebab dirs, `name` equals the folder, `title`/`description` present, no forbidden keys, globally-unique slug, allowed extensions). CI will confirm.
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, ...) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
