### PR TITLE
add positioning-and-story by devtool-gtm

### DIFF
--- a/skills/devtool-gtm/author.md
+++ b/skills/devtool-gtm/author.md
@@ -1,0 +1,9 @@
+---
+name: Shane O'Connor
+avatarUrl: https://avatars.githubusercontent.com/u/256833559?v=4
+title: Founder, The DevTool GTM Company
+linkedinUrl: https://www.linkedin.com/in/devtoolgtm
+companyDomain: gtmcofounder.com
+---
+
+Shane builds The GTM Co-Founder, an open-source go-to-market system for early-stage technical founders, and is a GTM advisor at QC Growth. His skills encode the judgment behind taking a developer tool from "nobody came" to real revenue: positioning, pricing, and founder-led sales.

--- a/skills/devtool-gtm/positioning-and-story/SKILL.md
+++ b/skills/devtool-gtm/positioning-and-story/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: positioning-and-story
+title: Positioning and story
+description: |
+  Use this skill when your messaging describes what the product does instead of the problem it
+  kills, sounds interchangeable with three competitors, or creates no urgency to act now. Produces
+  a positioning where the developer is the hero and a real trend is the villain, plus a
+  differentiation level you can defend. Triggers on "positioning", "messaging", "our story", "we
+  sound like everyone", "homepage headline", "value narrative", "category", "differentiation", "why
+  now", "nobody feels urgency".
+category: Positioning
+tags: [Marketing]
+---
+
+Applies when your homepage explains what the product does before it names the problem, your positioning is interchangeable with three competitors, or nobody feels urgency to act now. Produces a hero-and-villain story and a differentiation level you can actually defend.
+
+## Get the roles right
+
+Developers do not buy features; they hire a tool to defeat something making their work worse. Assign the roles:
+
+- **Hero** — the developer. Never the vendor, never the product.
+- **Villain** — the undeniable trend making the pain worse every day.
+- **Wise advisor** — you, arriving with a gift (the product).
+- **Inciting event** — the change in the world that forces the hero to act now.
+
+No villain, no urgency, no story, no conversion.
+
+## The three-part story
+
+1. **Inciting event** — introduce the hero and the villain; the world changed and the hero cannot stay put.
+2. **Obstacles** — specific challenges, each solved with your help, told as mini before-and-afters: "Before, we had [problem]. Now, [measured result]."
+3. **Resolution** — villain defeated for now, specific results, and the hero shares the wisdom. That is your testimonial.
+
+A benchmark shape, three lines: "Slow builds waste your time. Standard build tools can't handle today's codebases. Speed up builds now to keep engineers in flow." Pain, villain, hero, urgency.
+
+Good villains are trends, not competitors: cloud-cost sprawl, tool fragmentation, compounding tech debt, flaky pipelines, observability gaps, manual deploys, agents you cannot trust in production.
+
+## The four levels of differentiation
+
+Compete as high up this ladder as you can. Feature wars are a race to the bottom.
+
+1. **Feature** — "we have X, they don't." Weakest.
+2. **Benefit** — "we save you time." Every competitor says it.
+3. **Segment** — "for teams under release pressure with compliance." Stronger.
+4. **Problem** — "the only fix for a problem no one else has named." Strongest, and the road to owning a category.
+
+To reach level four, talk to enough real users to surface a problem competitors have not named, then name it so precisely your product is the obvious answer. When rivals adopt your vocabulary, they have already lost the position.
+
+## Decide where you stand
+
+- Can you state a problem only you solve, in the user's own words? → Level 4. Lead with the problem and name the category.
+- If not, can you name a specific segment with a compelling reason to care? → Level 3. Lead with the segment and their trigger.
+- If neither → you are stuck at feature or benefit. Go talk to users until a problem or a segment surfaces.
+
+## What good looks like
+
+- The developer is the subject of the sentence, and the problem comes before the product.
+- There is a named villain (a real trend), so the story carries urgency instead of listing features.
+- You are competing at the problem or segment level, not trading feature checklists.
+- The story could not be pasted onto a competitor's site unchanged.
+- Wins are shown as before-and-after with a real number and a named user, not adjectives.
+
+## Rules
+
+- MUST make the developer the hero and the product the tool, never the reverse.
+- MUST name a villain (a real trend) so the story has urgency.
+- NEVER lead with "platform," "powerful," or "pleased to announce"; a feature is not a story, a customer win is.
+- NEVER position on a feature checklist; it keeps you at the bottom of the differentiation ladder forever.


### PR DESCRIPTION
## What this skill does

Positioning and story for a developer tool: casting the developer as the hero and a real trend as the villain, building the three-part narrative, and climbing the four levels of differentiation (feature → benefit → segment → problem) toward owning a category.

## Two notes for the reviewer

- **Category:** none of the existing categories fit positioning/messaging, so I used a new `Positioning` category (tag `Marketing`). Happy for you to recategorize or rename it if you'd rather fold it into an existing bucket.
- **author.md:** my creator profile is also added by PRs #45 and #46 (identical copy). I include it here so this PR validates standalone; whichever merges first makes the others a clean no-op.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/devtool-gtm/` only
- [ ] `node tools/validate.mjs` passes locally — node wasn't available in my environment, so I hand-verified against `tools/validate.mjs` (kebab dirs, `name` equals the folder, `title`/`description` present, no forbidden keys, globally-unique slug, allowed extensions). CI will confirm.
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, ...) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
