### PR TITLE
add required email to nadav-david author profile

### DIFF
--- a/skills/nadav-david/author.md
+++ b/skills/nadav-david/author.md
@@ -4,6 +4,7 @@ avatarUrl: https://www.gtmskills.com/authors/nadav-david.jpg
 title: Strategic Partnerships Manager, Kidoz
 linkedinUrl: https://www.linkedin.com/in/nadavdvd/
 companyDomain: kidoz.net
+email: nadav@kidoz.net
 ---
 
 Strategic partnerships in advertising technology, selling media into brand and agency


### PR DESCRIPTION
## What this changes

One line. Adds the now-required `email` field to `skills/nadav-david/author.md`.

The profile landed with #10, before `email` became a required field in the author spec. `AGENTS.md` now lists it as required and notes that a submission without a contact email gets sent back before review, so this brings the existing profile into line. Nothing else in the file changes, and no skill files are touched.

Not folded into #52 (`recent-discourse-sweep`) because the spec says `author.md` belongs in the first PR only, and editing it on a skill branch invites a conflict.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/nadav-david/` only
- [x] `node tools/validate.mjs` passes locally (`ok — 255 skills across 40 creators`)
- [ ] First contribution — n/a, profile already exists; this is a field addition to it
- [x] Body speaks in GTM verbs — zero vendor tool names (no body change)
- [x] Has a `## What good looks like` section — n/a, no skill in this PR
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile, and with this work address being public in an open repo
