### PR TITLE
Update shane-oconnor author profile (title + bio)

### DIFF
--- a/skills/shane-oconnor/author.md
+++ b/skills/shane-oconnor/author.md
@@ -1,9 +1,9 @@
 ---
 name: Shane O'Connor
 avatarUrl: https://www.gtmskills.com/authors/shane-oconnor.jpg
-title: Founder, The DevTool GTM Company
+title: Founder, The GTM Co-Founder
 linkedinUrl: https://www.linkedin.com/in/devtoolgtm
 companyDomain: gtmcofounder.com
 ---
 
-Shane builds The GTM Co-Founder, an open-source go-to-market system for early-stage technical founders, and is a GTM advisor at QC Growth. His skills encode the judgment behind taking a developer tool from "nobody came" to real revenue: positioning, pricing, and founder-led sales.
+Shane builds The GTM Co-Founder, an open-source go-to-market system for early-stage technical founders, and is a GTM advisor at QC Growth. His skills encode the judgment behind taking a developer tool from "nobody came" to real revenue: finding the ICP who actually pays, positioning around the problem instead of a feature list, pricing on value instead of a guess, and running the founder-led sales conversations that turn free users into paying customers. It is the commercial half of the job, written for founders who can build anything but stall on who it's for and why they would pay.

--- a/skills/shane-oconnor/author.md
+++ b/skills/shane-oconnor/author.md
@@ -4,6 +4,7 @@ avatarUrl: https://www.gtmskills.com/authors/shane-oconnor.jpg
 title: Founder, The GTM Co-Founder
 linkedinUrl: https://www.linkedin.com/in/devtoolgtm
 companyDomain: gtmcofounder.com
+email: shane@devtool-gtm.com
 ---
 
 Shane builds The GTM Co-Founder, an open-source go-to-market system for early-stage technical founders, and is a GTM advisor at QC Growth. His skills encode the judgment behind taking a developer tool from "nobody came" to real revenue: finding the ICP who actually pays, positioning around the problem instead of a feature list, pricing on value instead of a guess, and running the founder-led sales conversations that turn free users into paying customers. It is the commercial half of the job, written for founders who can build anything but stall on who it's for and why they would pay.


### PR DESCRIPTION
Profile update for the existing `shane-oconnor` author. Touches only `skills/shane-oconnor/author.md`, no skill files change.

- **Title:** "Founder, The DevTool GTM Company" to "Founder, The GTM Co-Founder" (matches the companyDomain, gtmcofounder.com)
- **Bio:** expanded to spell out the specific GTM judgment the skills encode (ICP, positioning, pricing, founder-led sales)
- Avatar, LinkedIn, and companyDomain unchanged

Person-first voice, within the 2 to 4 sentence guideline, all claims verifiable via the linked LinkedIn and gtmcofounder.com.