### PR TITLE
add required email to tanyo-gochev author profile

### DIFF
--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -4,6 +4,7 @@ avatarUrl: https://www.gtmskills.com/authors/tanyo-gochev.jpg
 title: "Co-Founder & Head of GTM, The Demand Department"
 linkedinUrl: https://www.linkedin.com/in/tanyo/
 companyDomain: demanddept.com
+email: tanyo@copytg.com
 ---
 
 Co-Founder and Head of GTM of The Demand Department. We build go-to-market engines for funded B2B startups and founder-led service businesses — the list, the offer, the sequences, the content, and the pipeline discipline that holds them together.


### PR DESCRIPTION
## What this changes

One line. Adds the now-required `email` field to `skills/tanyo-gochev/author.md`.

The profile landed with #30, before `email` became a required field in the author spec. Mirrors #53 for nadav-david — bringing an existing profile into line ahead of the first repo→DB sync rather than after it.

Note on the domain: `companyDomain` stays `demanddept.com` (The Demand Department, where the skills come from); `tanyo@copytg.com` is my monitored work address and the best way to reach me about them. Happy to switch it to a demanddept.com address if maintainers would rather the two match.

Nothing else in the file changes, and no skill files are touched.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/tanyo-gochev/` only
- [x] `node tools/validate.mjs` passes locally (`ok — 255 skills across 40 creators`)
- [ ] First contribution — n/a, profile already exists; this is a field addition to it
- [x] Body speaks in GTM verbs — zero vendor tool names (no body change)
- [x] Has a `## What good looks like` section — n/a, no skill in this PR
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile, and with this work address being public in an open repo