### PR TITLE
add never-guess-an-email, auto-reply-is-not-a-reply, inbox-warm-up-ramp by lucas-godtfredsen

### DIFF
--- a/skills/lucas-godtfredsen/author.md
+++ b/skills/lucas-godtfredsen/author.md
@@ -1,0 +1,15 @@
+---
+name: Lucas Godtfredsen
+avatarUrl: ""
+title: Founder, GTM Now
+linkedinUrl: "https://www.linkedin.com/in/lucas-godtfredsen-b9a19614/"
+companyDomain: gtmnow.app
+email: lucasgodt@gmail.com
+---
+
+Lucas is the founder of GTM Now, an AI-native sales engine that sources
+companies, writes the outreach, sends it from the user's own mailbox and books
+the meeting — with a switch the user can turn off at any point. He builds it
+by running it on his own pipeline, which is where these skills come from: each
+one is a rule written the day the honest version of the product cost him
+something.

--- a/skills/lucas-godtfredsen/auto-reply-is-not-a-reply/SKILL.md
+++ b/skills/lucas-godtfredsen/auto-reply-is-not-a-reply/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: auto-reply-is-not-a-reply
+title: An auto-reply is not a reply
+description: |
+  Use this skill when classifying inbound responses to outbound — out-of-office, vacation and
+  parental-leave auto-responders, delivery notices, and other machine-generated mail that looks
+  like engagement. Produces a triage decision that keeps the sequence alive, keeps the metrics
+  clean, and reschedules the next touch to when the human is actually back.
+category: Outreach
+tags: [Sales, RevOps]
+---
+
+An out-of-office arrives in the same inbox, in the same thread, as a real
+answer. Filed as one, it corrupts three things at once. This is how to file it.
+
+## The play
+
+1. **Classify machine mail as its own outcome**, alongside interested,
+   question, referral, not now, not interested and unsubscribe. A triage
+   vocabulary without this bucket does not skip the auto-responder — it files
+   it under the nearest wrong label.
+2. **Read the return date if the message states one; never infer one.** "Back
+   on the 20th" is a date. "Away for a while" is not, and a guessed date is a
+   send at the wrong time dressed as intelligence.
+3. **Reschedule instead of advancing.** The touch was never spent: nobody read
+   the message. Move the next one to one working day *after* they return —
+   landing on their first morning, behind four hundred emails, wastes the
+   sequence you just protected.
+4. **Record nothing.** Not a reply, not a positive, not a stage change. This
+   is the step everyone forgets, and it is the expensive one.
+5. **Keep the account in the sequence.** Automatic mail must never mark an
+   account worked, closed or exhausted.
+6. **File delivery notices separately from auto-responders.** "Temporarily
+   deferred, will retry for 47 hours" is the mail system, not the person: no
+   date, no reschedule, no bounce. A hard failure is a different outcome with
+   a different consequence — suppression.
+
+## What good looks like
+
+- The tell: it is not the vacation message that hurts, it is the *metric* it
+  writes. One auto-responder counted as a reply inflates the reply rate of
+  whichever template earned it, and every downstream decision — which
+  sequence to scale, which segment to keep — is then made on a number a robot
+  wrote. On low volume it is the difference between 2% and 4%.
+- The mediocre version treats any inbound as engagement: the follow-up stops,
+  the account moves to "in conversation", and someone drafts a reply to a
+  robot. Six weeks later that account is in the "already worked, no answer"
+  pile, having never once been read by a human.
+- You know the output is good when auto-responders are visible and boring: a
+  named outcome you can count, a next touch dated after the return, and no
+  movement in your reply rate when a wave of holiday mail arrives.
+
+## Rules
+
+- **MUST** give machine mail its own outcome, never the nearest human label.
+- **MUST** leave the sequence active and the touch unspent.
+- **MUST** exclude it from reply, positive and engagement metrics.
+- **MUST** use a stated return date, and only a stated one.
+- **NEVER** draft or send an answer to an auto-responder.
+- **NEVER** mark an account worked, replied or closed on machine mail.
+- **NEVER** treat a temporary delivery notice as a bounce — retry-language
+  means the address may be fine, and suppressing on it kills a good contact
+  permanently over a server hiccup.

--- a/skills/lucas-godtfredsen/inbox-warm-up-ramp/SKILL.md
+++ b/skills/lucas-godtfredsen/inbox-warm-up-ramp/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: inbox-warm-up-ramp
+title: Warm up a sending inbox before you need it
+description: |
+  Use this skill when a new mailbox, domain or seat is about to start cold outreach, or when
+  replies and deliverability drop after volume was raised. Produces a per-inbox daily send
+  ceiling that rises on a schedule, the rules that keep it rising, and the honest way to tell a
+  user why today's limit is low.
+category: Outreach
+tags: [Sales, RevOps]
+---
+
+A new mailbox at full volume is a spam complaint with a countdown. This sets
+the ceiling, per inbox, and the conditions to raise it.
+
+## The play
+
+1. **Ramp by the age of the inbox, not the age of the campaign.** Week one at
+   a handful of sends a day; roughly double each week; reach full volume at
+   about four weeks. Every seat runs its own clock — a new person joining a
+   mature team starts at week one.
+2. **Get volume from more inboxes, never from one working harder.** Two or
+   three mailboxes on a domain, more domains when you need more volume. A
+   single inbox pushed past its ceiling is the failure everyone repeats.
+3. **Send inside the recipient's working hours, on working days.** Mail
+   arriving at 3am local time reads as automation to a person and to a filter.
+4. **Keep the first touch plain.** No links, no images, no tracking pixel, no
+   attachment. Add them once a thread has a human in it.
+5. **Watch the three numbers that end a ramp**: hard bounces (stop and clean
+   the list well before 3%), spam complaints (any is a lot), and the share of
+   sends that reach zero engagement over a week. A ramp is paused by evidence,
+   not by feel.
+6. **Never warm up on the account you cannot lose.** If cold volume must grow,
+   put it on a separate sending domain and keep the primary one for real
+   conversation.
+7. **Tell the user why the cap is low, in their words.** A silent limit reads
+   as a broken tool, and the person will raise it blindly to make the silence
+   stop. Say the number, say the schedule, and if you offer a skip, spell out
+   what it risks before they choose it.
+
+## What good looks like
+
+- The tell: reputation is per *sending identity*, and it is earned by
+  behaviour that looks like a person's — modest volume, replies coming back,
+  activity inside a working day. Volume without replies is the pattern
+  filters are built to catch, which is why the ramp exists at all and why a
+  sequence that gets answers can climb faster than one that does not.
+- The mediocre version warms up by mailing seed accounts in a warming network
+  and calls the inbox ready on day three. The metric moves; the reputation
+  does not. Nothing detectable happens until real volume starts landing in
+  spam, and by then the domain is spent.
+- You know the output is good when raising the cap changes nothing except the
+  count — same bounce rate, same complaint rate, same reply rate. If replies
+  fall as volume rises, the ceiling was already correct.
+
+## Rules
+
+- **MUST** hold a per-inbox daily cap that increases with that inbox's own
+  sending age.
+- **MUST** pause the ramp on rising bounces or any complaint, and clean the
+  list before resuming.
+- **MUST** show the current cap and its reason wherever the user sees the
+  send happening.
+- **NEVER** run cold volume from the domain your business depends on.
+- **NEVER** raise a cap silently, and never raise it without stating what a
+  cold inbox at full volume risks.
+- **NEVER** treat a warming-network score as evidence that a real list can be
+  mailed.

--- a/skills/lucas-godtfredsen/never-guess-an-email/SKILL.md
+++ b/skills/lucas-godtfredsen/never-guess-an-email/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: never-guess-an-email
+title: Never guess an email address
+description: |
+  Use this skill when you have a target company but no verified contact address and you are
+  tempted to infer one from a pattern — first.last@, f.last@, firstinitiallast@. Produces a
+  routing decision per account: send, route to another channel, or leave unreachable and say so.
+  Covers pattern-guessing, role inbox selection, dead-domain checks, and what to do when no
+  address exists at all.
+category: Prospecting
+tags: [Sales]
+---
+
+A guessed address is a bounce you paid for with your sender reputation. This
+decides, per account, whether an address may be sent to at all.
+
+## The play
+
+1. **Take only what was published.** An address found on their site, in a
+   registry, on a verified data source, or given by a person is a contact. An
+   address you assembled from a name and a domain is a hypothesis.
+2. **Check the domain can receive mail before you queue anything.** A lookup
+   for mail records — falling back to the address record — costs nothing and
+   catches the dead domain that a scraper happily handed you. A lookup that
+   fails to answer is not a dead domain: retry later, never suppress on a
+   timeout.
+3. **Rank the role inboxes you did find.** Sales-flavoured first
+   (`comercial@`, `vendas@`, `sales@`, `partnerships@`), then neutral
+   (`contato@`, `contact@`, `hello@`), then support (`sac@`, `atendimento@`,
+   `support@`, `faleconosco@`). The first is a door; the last is a ticket
+   queue.
+4. **Write differently to a reception desk.** With no named human, open by
+   asking to be routed to whoever owns this, in one line, and make the note
+   easy to forward. Pitching a shared inbox as though it were the decision
+   maker is how a real company marks you as spam.
+5. **When there is no address, route, don't invent.** A public LinkedIn,
+   WhatsApp or Instagram profile is a channel; a person you can name and reach
+   through a colleague is a channel; silence is a channel too. Mark the
+   account unreachable by email and move it to the queue a human works.
+6. **Suppress permanently on a hard bounce and on a dead domain**, before the
+   next send, and keep the record so no future campaign resurrects it.
+
+## What good looks like
+
+- The tell an experienced operator reads first: whether the address was
+  *published* or *assembled*. Everything else — pattern confidence scores,
+  verification vendors, catch-all detection — is downstream of that one
+  question, and no confidence score turns a hypothesis into a contact.
+- The mediocre version guesses, verifies with a checker that says "accept
+  all", counts that as valid, and ships. Two weeks later the domain's
+  reputation is spent and nobody can point at the day it broke, because
+  no single send looked wrong.
+- You know the output is good when the unreachable pile is *large and
+  honest*. Coverage below 100% is the normal state of the world; a list where
+  every row has an address is a list with invented rows in it. Bounce rate
+  under 2% is the real number to defend, not coverage.
+
+## Rules
+
+- **MUST** treat an assembled address as unreachable, not as low confidence.
+- **MUST** check domain deliverability before the first send, and again if the
+  address sat unused for weeks.
+- **MUST** distinguish "this domain does not exist" from "the lookup failed" —
+  only the first one suppresses.
+- **NEVER** send to a role inbox with copy written for a named decision maker.
+- **NEVER** retry a hard bounce, on any campaign, ever.
+- **NEVER** report an account as reachable because a verification tool
+  returned "accept all" — that is the domain refusing to answer, not a yes.


### PR DESCRIPTION
Three skills from running an AI-native sales engine on my own pipeline — each one is a rule written the day the honest version cost me something.

- **never-guess-an-email** — the line between a *published* address and an *assembled* one, role-inbox ranking (sales > neutral > support), dead-domain checks that never suppress on a lookup timeout, and what to do when no address exists at all. The quality bar is deliberately uncomfortable: a list where every row has an address is a list with invented rows in it.
- **auto-reply-is-not-a-reply** — the outcome bucket most triage vocabularies are missing. An out-of-office filed as a reply stops the sequence, credits the template with a robot's answer, and can mark an account worked that no human ever read. Includes the separation between a temporary delivery notice and a hard bounce.
- **inbox-warm-up-ramp** — a per-inbox ceiling that rises with that inbox's own sending age, volume from more inboxes rather than one working harder, the three numbers that end a ramp, and the rule that a silent cap reads as a broken tool.

All three are tool-agnostic, validator-clean, and `author.md` is included (first submission).