### PR TITLE
add amir-baldiga: four agent-run GTM plays

### DIFF
--- a/skills/amir-baldiga/account-research-brief/SKILL.md
+++ b/skills/amir-baldiga/account-research-brief/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: account-research-brief
+title: Build an account brief an AE will actually read
+description: "Use this skill before a first meeting, an ABM push, or a territory review, when you need a defensible account brief instead of a copied About page. Produces firmographics, positioning pillars, an evidence-tagged SWOT, a named exec list, and live hiring signals, with every claim marked as sourced or inferred."
+category: Research
+tags: [ABM, Sales]
+---
+
+Run this before a first meeting or an ABM push. It produces a one-page brief where every claim is tagged as evidence-backed or inference, so the AE knows what they can say out loud.
+
+## The play
+
+1. **Resolve the company to a stable identifier first.** Match on the company's own URL slug rather than its display name. Name search returns near-matches and you will research the wrong entity, which is worse than researching nothing.
+
+2. **Pull firmographics.** Size, industry, headquarters, founding year, description, specialities. This is the skeleton the rest hangs on.
+
+3. **Read composition, not just headcount.** How the employee base splits by function and seniority says more than a total. A company that is 60% engineering sells differently than one that is 60% sales.
+
+4. **Extract positioning pillars.** Cluster the company's own description, tagline, and specialities into three to six themes: product areas, target buyer, stated differentiators. Name each pillar and cite the exact source phrase. These are the words the buyer already uses about themselves.
+
+5. **Build a SWOT where every line is tagged.** Mark each point `evidence` (traceable to something retrieved) or `inference` (your read). An untagged SWOT is opinion wearing a suit, and an AE who repeats an inference as fact in a meeting loses the room.
+
+6. **Ask before you spend on people.** Confirm two things with the requester: which titles matter, and how many employee records to pull. Skipping this is how a routine brief turns into a surprise bill.
+
+7. **Read hiring as a live signal.** Recent joiners, by function, are the most current evidence you have of where budget is moving. A team that added four engineers and no marketers last quarter is telling you something.
+
+8. **Deliver both shapes.** Structured data for the next automation step, and a short human brief for the AE. They have different readers and different lifespans.
+
+## What good looks like
+
+- The best briefs quote the company's own language back. Buyers relax when you describe them the way they describe themselves.
+- The mediocre version is a reformatted About page: no composition, no signal, no tagging, and nothing an AE could not have read themselves in two minutes.
+- Absence is a finding. "No leadership changes in twelve months" is real intelligence. Say it rather than padding the section.
+- You know it is good when the AE walks in able to say which claims are sourced and which are your read, and never has to guess.
+
+## Rules
+
+- MUST tag every SWOT point as evidence or inference.
+- MUST confirm target titles and record counts before pulling people data.
+- MUST state plainly when a data source returned nothing, in the brief itself.
+- NEVER invent a headcount growth trend, an exec, or a job opening to fill a section.
+- NEVER research a company you matched by display name alone without confirming the identifier.

--- a/skills/amir-baldiga/author.md
+++ b/skills/amir-baldiga/author.md
@@ -1,0 +1,9 @@
+---
+name: Amir Baldiga
+title: Founder, Zooq
+linkedinUrl: https://www.linkedin.com/in/amirbaldiga
+companyDomain: zooq.dev
+email: hello@zooq.dev
+---
+
+I build Zooq, an API and MCP server that gives AI agents structured access to LinkedIn data without anyone connecting their own account. Most of what I know about GTM came from watching agents run these plays badly first: lists that could not be explained, personalization that smelled synthetic, account briefs that were reformatted About pages. The skills I contribute here encode the guardrails that fixed those failures, written so they hold up whatever data source sits underneath.

--- a/skills/amir-baldiga/icp-lookalike-expansion/SKILL.md
+++ b/skills/amir-baldiga/icp-lookalike-expansion/SKILL.md
@@ -10,7 +10,7 @@ Use this when a few leads converted and you need more like them. It produces a d
 
 ## The play
 
-1. **Read the seed properly.** Pull the seed's full record and extract three things: current title, current employer, and industry. That triple is the similarity signature. Everything downstream depends on it being right, so read the actual current role rather than the headline, which is often aspirational or stale.
+1. **Read the seed properly.** Pull the seed's full record and extract two things: current title and current employer. That pair is the similarity signature. Everything downstream depends on it being right, so read the actual current role rather than the headline, which is often aspirational or stale.
 
 2. **Decide what "similar" means.** There are two different searches and they answer different questions:
    - **Peers inside the same company** — title plus employer. Use when you are mapping a buying committee or expanding within a won account.

--- a/skills/amir-baldiga/icp-lookalike-expansion/SKILL.md
+++ b/skills/amir-baldiga/icp-lookalike-expansion/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: icp-lookalike-expansion
+title: Expand a target list from one good-fit profile
+description: "Use this skill when you have a handful of accounts or people who converted and need more like them, or when a black-box 'similar profiles' feed gives you a list you cannot explain. Extracts an explicit similarity signature from the seed and searches on it, so you control what 'similar' means and can widen or tighten deliberately."
+category: Prospecting
+tags: [Sales, ICP]
+---
+
+Use this when a few leads converted and you need more like them. It produces a deduplicated target list built on a similarity definition you chose, not one a vendor's feed chose for you.
+
+## The play
+
+1. **Read the seed properly.** Pull the seed's full record and extract three things: current title, current employer, and industry. That triple is the similarity signature. Everything downstream depends on it being right, so read the actual current role rather than the headline, which is often aspirational or stale.
+
+2. **Decide what "similar" means.** There are two different searches and they answer different questions:
+   - **Peers inside the same company** — title plus employer. Use when you are mapping a buying committee or expanding within a won account.
+   - **The same role across the market** — title only, optionally narrowed by geography. Use when you are building a net-new list. Drop the employer filter or you will get nothing.
+
+3. **Search on short titles.** Pass the core role, not the decorated headline. "Chief executive officer" works; "CEO & Founder | Investor | Speaker" returns zero. Most title matching is loose, so a shorter string casts the right net.
+
+4. **Branch deliberately if you need depth.** Depth 1 searches off the seed alone. Depth 2 takes each discovered profile, reads its role and employer, and searches again. Depth 2 is dozens of lookups; depth 3 is hundreds. Cap how many profiles you branch on (top 10 is usually enough) and confirm the spend before going past depth 2.
+
+5. **Deduplicate by handle and drop the seed.** The same person surfaces under many searches, and most search endpoints return the seed itself. Keep a seen-set across the whole run.
+
+6. **Return a clean list**, not the recursion tree: handle, name, headline, location, and which seed it came from.
+
+## What good looks like
+
+- The best operator tightens one filter at a time. Stacking exact title, all-skills-match, and a city filter returns zero rows and reads as "no market" when it is really an over-narrowed query. Start broad, then narrow.
+- The mediocre version trusts a "people similar to this" feed and cannot explain why anyone is on the list. When a rep asks "why him?", there is no answer.
+- Empty results are a signal, not a failure. Widen by dropping the employer filter, shortening the title, or removing geography, and note which loosening produced the hit.
+- You know it is good when every row survives the question "what specifically makes this person like the seed?"
+
+## Rules
+
+- MUST deduplicate by handle across the whole run, not per search.
+- MUST drop the seed from its own results before ranking.
+- MUST confirm the cost with the user before running depth 3.
+- NEVER pass a full headline as the title filter.
+- NEVER re-process a handle already seen. It costs money and adds nothing.

--- a/skills/amir-baldiga/lookalike-candidate-sourcing/SKILL.md
+++ b/skills/amir-baldiga/lookalike-candidate-sourcing/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: lookalike-candidate-sourcing
+title: Source candidates who look like your best hire
+description: "Use this skill when a role worked and you want more of that person, or when you are backfilling someone strong and a job-board post is not going to find them. Takes one exemplar profile and returns a ranked, scored shortlist with the reasoning behind each score visible."
+category: Prospecting
+tags: [Recruiting, Sourcing]
+---
+
+Use this when one hire worked and you want more like them. It produces a ranked shortlist where every score decomposes into title, skills, seniority, and location, so a hiring manager can argue with it.
+
+## The play
+
+1. **Take one exemplar, not a job description.** A JD describes what someone wrote down. A person who is actually good in the role describes what worked. Start from the exemplar's real current title, skills, and location.
+
+2. **Push filters into the search, not into post-processing.** Role family, country, city, and current-role-only belong in the query. Filtering a large result set client-side wastes lookups and hides how narrow you actually were.
+
+3. **Start broad, then tighten once.** Role family plus two skills plus a country is a good opening net. Stacking an exact title, an all-skills-match, and a city returns zero and looks like "nobody exists" when it is really a bad query.
+
+4. **Decide whether to enrich.** Without enrichment you get a cheap keyword-ordered list. With it you get skills, education, and geography per candidate, at one extra lookup each. Enrich 20, not 200, until the shortlist direction is confirmed.
+
+5. **Score transparently out of 100:**
+   - **Title match, 40** — exact title 40, same role family at any seniority 25, different family 0.
+   - **Skills overlap, 30** — shared skills over the exemplar's skill count, times 30, compared on normalized names.
+   - **Seniority, 15** — same level 15, one level off 7, further 0. Infer from title prefix: Senior, Staff, Principal, Head of, VP.
+   - **Location, 15** — same city 15, same metro 10, same country 5.
+
+6. **Drop the exemplar** before ranking. Search returns them, they score 100, and it makes the list look broken.
+
+7. **Return a table**, not JSON. Name, current title, company, location, score, and the one line explaining the score.
+
+## What good looks like
+
+- The strongest sourcers treat a zero-result search as information about the query, not the market, and can say which filter they loosened and why.
+- The mediocre version returns fifty unranked names and calls it a pipeline, leaving the hiring manager to do the actual sourcing work.
+- A score is only useful if it decomposes. "82" means nothing; "82: exact title, 6 of 9 skills, one level junior, same metro" is a conversation.
+- You know it is good when the hiring manager disagrees with a specific score for a specific reason. That means they can see the reasoning.
+
+## Rules
+
+- MUST remove the exemplar from their own results.
+- MUST show the score breakdown, never a bare number.
+- MUST start broad and tighten deliberately, one filter at a time.
+- NEVER infer salary, notice period, or willingness to move. That data is not in a public profile.
+- NEVER present a keyword-ordered list as a ranked one when enrichment was skipped. Say the scores were not computed.

--- a/skills/amir-baldiga/lookalike-candidate-sourcing/SKILL.md
+++ b/skills/amir-baldiga/lookalike-candidate-sourcing/SKILL.md
@@ -32,7 +32,7 @@ Use this when one hire worked and you want more like them. It produces a ranked 
 
 - The strongest sourcers treat a zero-result search as information about the query, not the market, and can say which filter they loosened and why.
 - The mediocre version returns fifty unranked names and calls it a pipeline, leaving the hiring manager to do the actual sourcing work.
-- A score is only useful if it decomposes. "82" means nothing; "82: exact title, 6 of 9 skills, one level junior, same metro" is a conversation.
+- A score is only useful if it decomposes. "77" means nothing; "77: exact title, 6 of 9 skills, one level junior, same metro" is a conversation.
 - You know it is good when the hiring manager disagrees with a specific score for a specific reason. That means they can see the reasoning.
 
 ## Rules

--- a/skills/amir-baldiga/personalized-outbound-ab-test/SKILL.md
+++ b/skills/amir-baldiga/personalized-outbound-ab-test/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: personalized-outbound-ab-test
+title: Prove personalization beats your baseline
+description: "Use this skill when someone claims AI personalization lifts reply rates, or before you let an agent write outbound at scale. Runs a control/personalized/holdout split on your connection list, enforces a safety gate on every generated message, and returns a defensible read on whether personalization actually beat the generic baseline."
+category: Outreach
+tags: [Sales, SDR]
+---
+
+Run this before you let an agent write outbound at scale. It produces a measured answer to "does personalization actually beat our generic message?" and a holdout that receives the winner.
+
+## The play
+
+1. **Split the list into three.** Control (e.g. 100) gets the generic baseline. Personalized (e.g. 100) gets researched messages. Holdout (the rest) waits for the result, then gets the winner. Without a control you are not testing, you are just spending.
+
+2. **Build the do-not-contact list first.** Exclude anyone already in an open thread, in the CRM as an active deal, or recently sequenced. Skipping this is how you send a "nice to meet you" to a customer. Do this before enrichment so you never pay to research someone you cannot contact.
+
+3. **Enrich only the Personalized arm.** Pull current role, headline, employer, and recent activity per lead. The control arm needs nothing, so half your enrichment spend disappears.
+
+4. **Write one message per lead, then gate it.** Every message must pass all six checks or it silently drops to the baseline:
+   - **Account-safe** — no links, no phone numbers, no mass-template feel.
+   - **Factually grounded** — every personal reference traces to retrieved data. Zero invented facts.
+   - **Human** — no AI tells, in the sender's own rhythm.
+   - **Respectful** — warm, no creepy over-familiarity.
+   - **Rule-compliant** — length cap, CTA placement, banned vocabulary, whatever the sender set.
+   - **Recognizably theirs** — the hook is something only that person would recognize as about them.
+
+5. **Re-verify programmatically.** Do not trust the model's self-report. Recompute length, dash counts, CTA position, name casing, and banned phrases after generation. Anything that fails gets fixed or dropped to baseline.
+
+6. **Ship with a fallback.** Set the generic message as the fallback for the personalized variable, so a missing field degrades to proven copy instead of sending `{PERSONAL_MSG}` to a prospect.
+
+7. **Read replies, not opens.** Compare reply rate and positive-reply rate between the two arms. Send the winner to the holdout.
+
+## What good looks like
+
+- A message that "smells like AI" or misattributes a fact costs more than sending nothing. It burns the relationship and the sender's reputation, and neither shows up in your open rate.
+- The mediocre version personalizes the first line and leaves the rest a template. Prospects read the seam instantly.
+- The gate is the deliverable, not decoration. Expect to drop 10-30% of generated messages to baseline. A gate that never rejects anything is not being enforced.
+- You know it worked when you can state the lift as a number, with the control that produced it, and defend the exclude list you used.
+
+## Rules
+
+- MUST run a control arm. A personalized-only send produces no evidence.
+- MUST build the exclude list before enriching.
+- MUST re-verify constraints programmatically after generation.
+- NEVER let a message reference a fact the research did not return.
+- NEVER send at full volume before the A/B result is in. That is what the holdout is for.


### PR DESCRIPTION
Four plays from running GTM workflows through AI agents, where the failure modes are specific and expensive: lists nobody can explain, personalization that reads synthetic, account briefs that are reformatted About pages, shortlists that are really just search results.

| Skill | Category | What it produces |
|---|---|---|
| `personalized-outbound-ab-test` | Outreach | A defensible read on whether personalization beat your baseline, with a safety gate that drops failing messages to the control copy |
| `icp-lookalike-expansion` | Prospecting | A target list built on a similarity signature you chose and can explain |
| `account-research-brief` | Research | An account brief where every SWOT line is tagged evidence or inference |
| `lookalike-candidate-sourcing` | Prospecting | A ranked shortlist whose 100-point score decomposes into title, skills, seniority, location |

All four are written tool-agnostically in GTM verbs, target the ~600 word bar, and carry the mandatory "What good looks like" section.

First submission, so `author.md` is included. I build Zooq (an API and MCP server for LinkedIn data), and these encode guardrails learned from watching agents run these plays badly before they ran them well.

`node tools/validate.mjs` passes: *ok — 267 skills across 44 creators, all checks passed*.

One note for maintainers, unrelated to this submission: `tools/validate.mjs` fails on Windows because `new URL(import.meta.url).pathname` yields `/C:/...`, which `fs.existsSync` rejects, so it reports `skills/: directory is missing`. Switching to `fileURLToPath(import.meta.url)` fixes it. Happy to open a separate PR if useful.