### PR TITLE
add give-first-cold-email

### DIFF
--- a/skills/dima-bilous/author.md
+++ b/skills/dima-bilous/author.md
@@ -6,7 +6,6 @@ companyDomain: anfloy.com
 email: dimabilous@anfloy.com
 ---
 
-Dima is the founder of Anfloy, an AI engineering studio that designs and builds
-AI agents and GTM systems companies own forever. He runs Anfloy's own outbound
-founder-led; the skills he publishes here are the playbooks behind his real
-campaigns.
+Dima is the founder of Anfloy, where he builds AI agentic systems for GTM and
+internal ops. He shares real breakdowns of tested systems he delivered to
+clients or runs inside his own company.

--- a/skills/dima-bilous/author.md
+++ b/skills/dima-bilous/author.md
@@ -1,0 +1,12 @@
+---
+name: Dima Bilous
+title: Founder, Anfloy
+linkedinUrl: https://www.linkedin.com/in/dima-bilous
+companyDomain: anfloy.com
+email: dimabilous@anfloy.com
+---
+
+Dima is the founder of Anfloy, an AI engineering studio that designs and builds
+AI agents and GTM systems companies own forever. He runs Anfloy's own outbound
+founder-led; the skills he publishes here are the playbooks behind his real
+campaigns.

--- a/skills/dima-bilous/give-first-cold-email/SKILL.md
+++ b/skills/dima-bilous/give-first-cold-email/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: give-first-cold-email
+title: Give-first cold email
+description: |
+  The skill for writing a proper cold email, for any product or service. Use
+  it whenever a cold email needs writing and the usual asks are getting
+  ignored. Triggers: "write my cold email", "nobody books from my outbound", "what
+  should my CTA be", "make this email give value", "turn my offer into a cold
+  email", "make my offer stronger". Takes the sender's actual offer and
+  produces casual, founder-signed emails that earn the reply one of two ways:
+  give the prospect a piece of the result up front (a finding, a mini tool, a
+  done-for-them artifact), or make the offer so good that saying yes is the
+  prospect's only job. Never just a call ask.
+category: Outreach
+tags: [Sales]
+---
+
+The tool for writing a proper cold email. Produces a first email plus follow-ups where the reply costs the prospect nothing. It starts after the list: if the list is wrong, nothing here saves you.
+
+## The one rule: the reply must cost them nothing
+
+There are two ways to earn a cold reply. Either you deliver value up front, or the offer is so good that the only thing left for the prospect to do is say yes. Everything else asks them to work: to imagine the value, to schedule, to act before receiving.
+
+What this kills:
+
+- "Worth a quick call?" asks for their time in exchange for nothing.
+- "Can I send you a custom PDF?" is what everyone else in their inbox is already doing, with nothing concrete behind it. The moment they read it, you are filed with the other fifty.
+- Any CTA where the prospect has to do more than say yes.
+
+Promising more after the yes is fine on both paths. The difference between an offer and an empty tease is that the offer is specific, backed by proof, and costs nothing to accept.
+
+## First, pick the goal
+
+- **Building awareness:** send the value directly and end. No ask at all; the impression is the goal. A useful email with no CTA is remembered precisely because nobody does it.
+- **Getting on a call:** the full shape below. The value lands before the call, so the call is a walkthrough, not a pitch.
+
+## If the real offer is high-ticket, sell the free step
+
+The bigger the engagement, the less the first email should mention it. Nobody buys a five-figure build off one cold email, and naming it puts the price in their head before any value has landed.
+
+So the outcome you sell is the free step's outcome: what the audit tells them, what the artifact does for them, what the mini tool saves them. Never what the engagement would do for them.
+
+That includes the version dressed up as a benefit. "Teams we build this for add $2M in pipeline" still asks them to imagine buying something. "Here are the 40 accounts hiring for this right now" asks them to say yes to something that costs nothing.
+
+The engagement is what the free step earns you the right to talk about later, on the call, once the value has already landed.
+
+## Then pick the path
+
+**Path one: give value up front.**
+
+1. **Start from the result.** What does a client walk away with after paying you? The give is that, in miniature: one section of the audit, the smallest working piece of the system, your data pointed at their specific case. A segment stat with nobody's business attached is not a give; nobody cares about your data until it explains their problem.
+2. **Do it for this prospect before writing.** The email reports what you found, never what you would find.
+3. **Spend by tier, and let agents do the spending.** The time is worth it for a good account, but the work should not be manual: AI agents run the test, pull the data, and produce the artifact and key variables per account before you write a word. Best accounts get the deepest gives; lighter tiers get the borrowed lens: your data pointed at their case.
+
+**Path two: the offer they can't reasonably refuse.** When you cannot hand out a piece of the product, sell the outcome and stack proof until refusing feels unreasonable:
+
+- **Lead with the outcome**, specific and sized to them. Not what you do; what they end up with. On a high-ticket offer that is the free step's outcome, per the section above.
+- **Prove you can deliver it**: named clients, real numbers, your volume or track record.
+- **Take all the risk and effort yourself.** They see results before committing to anything.
+- **The ask is a yes, nothing else.** No scheduling, no forms, no homework. "Should I send it?" and you handle the rest.
+
+## Write it like a human, from your own name
+
+- **Send as the founder, not the company.** "I", never "we at Acme" or "our team". People answer people; nobody answers a logo.
+- **Extremely casual.** Subject line all lowercase, a few words, reading like a colleague's note about their thing. A plain offer subject works too when the offer is real. Body written the way you talk, like you typed it on the train. Under 85 words, one idea, one ask.
+- **Personal beats personalized.** You do not always have to research every company. A good offer, kept concise, can land for a whole industry. What matters is that the email feels like you wrote it yourself; one real specific beats three flattering researched ones.
+- **No AI tells, no cold-email cliches.** Read it aloud; if a line would not come out of your mouth, cut it. Instant giveaways: "here's the thing", "here's the part most people miss", "the truth is", "let that sink in", "in today's fast-paced world", "I hope this finds you well", "I wanted to reach out", "game-changer", "unlock", any strawman opener ("most agencies get this wrong"), and the tired subject lines every inbox has seen: "quick one", "quick question".
+
+## The email shape
+
+1. **Open with the test you ran.** One line, plain words, their name in it.
+2. **Show what came back and where they lose.** Named specifics. The gap should sting a little.
+3. **Make it solvable, with proof.** One line: fixable, and the exact work you have done for named clients.
+4. **The CTA: give the whole thing away**, delivered before any call. The meeting becomes the natural next step instead of the price of entry.
+
+On the offer path the same shape holds: the outcome replaces the test, the proof replaces the gap, and the CTA is a yes that costs nothing.
+
+**The about-them test.** Reread the draft: every sentence should contain them. Their company, their number, their competitor, their gap, their outcome. You, your data, your clients get one line total, as proof or as the lens that produced their finding, never as the subject of the email. "Across our clients, 62% of X happens" fails; "your line went to voicemail both times I called after six" passes.
+
+One deliverability note: attachments and links are the two classic spam triggers. Low volume to good accounts from a warmed domain, attach it, worth it. At volume, describe the artifact and let the yes trigger the send.
+
+Example emails across different products, plus the give menu, are in `references/give-menu.md`.
+
+## Follow-ups
+
+When the yes lands, send within minutes, send it complete, and aim them at one spot. Only then propose the time.
+
+Each follow-up delivers the next piece: a second finding, one page of the artifact, the mini tool link. At most one message per sequence may just nudge; the last offers a clean exit in a friendly line.
+
+## What good looks like
+
+- On the give path, the prospect gets something useful even if they never reply. On the offer path, they were handed a decision needing nothing but a yes.
+- It reads like one person typed it to another. If every sentence stays true with another company's name swapped in, that is fine, as long as it still sounds like you and the value is real.
+- The weak version sounds polished and asks politely. The strong version is almost plain, and the reader forwards it with "look at this".
+
+## Rules
+
+- MUST either create the give before writing, or make the offer so complete that yes is the prospect's only job.
+- MUST send from the founder's name, first person, with a lowercase subject line of a few words.
+- MUST keep the first email under 85 words with one ask.
+- MUST sell the free step's outcome when the real offer is high-ticket. The engagement, its outcome, and its price stay out of the first email.
+- MUST use real client names and real numbers as proof, never "companies like yours". Never claim work that was not done.
+- MUST pass the about-them test: the finding, the gap, and the outcome belong to the prospect. Your data appears only as the lens or the proof, one line total.
+- NEVER make a call the price of the value in a first email. Propose a time only when something real is already in their hands.
+- NEVER use em or en dashes, corporate filler, generic openers ("saw your post", "noticed you're hiring"), or any line from the AI-tell list above. When in doubt, say it plainer.

--- a/skills/dima-bilous/give-first-cold-email/references/give-menu.md
+++ b/skills/dima-bilous/give-first-cold-email/references/give-menu.md
@@ -1,0 +1,118 @@
+# The give menu, and example emails
+
+Ways to turn an offer into something the prospect receives up front, then a
+set of example emails across product types. Prospect and client names are
+fictional; well-known platforms named as search results are real. The last
+example is a real send from the author's own outbound. Replace all specifics
+with your own, and keep them true.
+
+## The four gives
+
+1. **The run test** (services that find problems): run your actual diagnostic
+   on their business before writing. The email reports the result.
+2. **The mini tool** (product and engineering-led senders): a small working
+   thing scoped to their case: a calculator loaded with their numbers, a
+   checker pointed at their site, a one-page dashboard of their public data.
+   Link, no signup wall.
+3. **The first slice of the deliverable** (productized services): the opening
+   section of what a paid engagement would produce. Whole on its own,
+   obviously part of something bigger.
+4. **The borrowed lens** (the volume-friendly give): your data or client
+   experience pointed at their specific case. The lens is yours; the finding
+   must be theirs. A raw segment stat ("62% of clinics miss calls") is not a
+   give, because nothing in it belongs to the reader. Run the cheap version
+   of the check on their business and let your data explain what it means.
+
+## Matching give to tier
+
+- **Tier 1, dream accounts:** run test or mini tool, the deepest give you can
+  produce. The time is worth it for an account like this, and it should not
+  be your time: AI agents run the test, pull the data, and assemble the
+  artifact and key variables per account before the email gets written.
+- **Tier 2, solid fits:** first slice, or a run test an agent produces well.
+- **Tier 3, broad list:** the borrowed lens. Never fake personal effort at
+  volume; a real finding about their case, honestly cheap to produce, beats a
+  fake bespoke one.
+
+## Example emails
+
+All first person in the founder's voice, lowercase subjects, under 85 words.
+The finding, the gap, and the outcome always belong to the prospect; the
+sender never becomes the subject of the email.
+
+### Run test, for a service that finds gaps
+
+subject: `paylio and the ai assistants`
+
+> Maya, I ran a quick test in Claude to name the top payroll platforms worth
+> using at scale.
+>
+> It surfaced Deel, Gusto, and Rippling. Paylio was nowhere in the results.
+>
+> Good news: that's a solvable problem. It's the exact work we've done for
+> Klarvo, Wagemark, and Perch.
+>
+> Want me to take you through a complete AEO audit for Paylio? I'll pinpoint
+> where Deel and Rippling keep winning the recommendation and how to close
+> it. I'll get it over to you before our call.
+
+### Mini tool, for a dev-tool or SaaS founder
+
+subject: `built you a small thing`
+
+> Tomas, I pointed our checker at getcrateful.com and it flagged 14 pages
+> where your docs search returns nothing.
+>
+> Put the full list in a little dashboard for you, no login:
+> [link]
+>
+> We fixed the same thing for Devgrid and Portico from YC S24 this spring.
+>
+> Mind if I leave notes on which five I'd fix first?
+
+### First slice, for a productized service
+
+subject: `first page of your audit`
+
+> Sam, I ran a deliverability audit on your domain that we normally do for
+> outbound teams.
+>
+> Your tracking links point at a domain that doesn't match the one you send
+> from, so your cold email is landing in junk most of the time.
+>
+> Attached is the page. I'd love to give you a few ideas on how to fix it,
+> and happy to send the other six sections before our call. You got 10
+> minutes tomorrow at 2pm EST?
+
+### The free-build offer, at volume (a real send from the author)
+
+subject: `free custom ai agent`
+
+> Hey Rachel - been seeing your name around AI automation & GTM posts on
+> LinkedIn.
+>
+> My team wants to build you a free custom AI agent.
+>
+> Takes about a week and it's on me. Should I send more info?
+>
+> Dima Bilous | Founder, Anfloy
+>
+> P.S. Most companies start with sales agents, but we can do ops or
+> marketing too.
+
+Note what it does without any per-company research: the offer is the whole
+email, the risk sits entirely on the sender (a week of work, free), the ask
+is permission to send more, and the P.S. answers the "but what would it do"
+question before it gets asked. Signed by the founder, not the company. At
+volume, the first name is the only variable that changes.
+
+## Follow-up ladder for any give
+
+- **Touch 2:** the next finding or the next slice. New value, not a reminder.
+- **Touch 3:** the artifact itself or the tool link, complete.
+- **Touch 4:** the one allowed nudge. One line.
+- **Touch 5:** clean exit, friendly, door open.
+
+Every touch should be worth receiving on its own. If a message only works as
+a reminder of the previous one, it is the nudge, and the ladder only has room
+for one.


### PR DESCRIPTION
## What this skill does

The skill for writing a proper cold email: the CTA is a deliverable, not a request. It takes the sender's actual offer and produces casual, founder-signed emails that either give the prospect a piece of the result up front (a finding, a mini tool, a done-for-them artifact) or make the offer so complete that saying yes is the prospect's only job.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/dima-bilous/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name and LinkedIn (avatarUrl omitted per AGENTS.md; fine to pull the LinkedIn photo)
- [x] Body speaks in GTM verbs — zero vendor tool names (product names appear only inside quoted example emails)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)