### PR TITLE
add email-deliverability

### DIFF
--- a/skills/joshua-waldman/author.md
+++ b/skills/joshua-waldman/author.md
@@ -1,0 +1,9 @@
+---
+name: Joshua Waldman
+title: Founder, SendX
+linkedinUrl: https://www.linkedin.com/in/joshuawaldman/
+companyDomain: sendx.io
+email: joshua@sendx.io
+---
+
+Joshua runs SendX, an email marketing platform, and SendPost, an email API for high-volume senders. His skills encode the deliverability methodology built from managing shared IP pools that process 10-18 million messages a day and consulting for ESPs handling billions of emails.

--- a/skills/joshua-waldman/email-deliverability/SKILL.md
+++ b/skills/joshua-waldman/email-deliverability/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: email-deliverability
+title: Email deliverability audit and rescue
+description: |
+  Use this skill when emails hit spam, open rates drop, a domain or IP gets
+  blocklisted, or a sender wants a deliverability audit before scaling volume.
+  Triggers: "why are we going to spam", "audit my email setup", "open rates
+  dropped", "we got blocklisted", "warm up this domain", "check my
+  deliverability". Produces a severity-ranked audit or a root-cause diagnosis
+  with a recovery plan and the thresholds to monitor.
+category: Newsletters
+tags: [Marketing, RevOps]
+---
+
+Run this when email performance breaks, or before it gets the chance to. It produces either a severity-ranked audit of the sending setup or a root-cause diagnosis with a dated recovery plan.
+
+## The play
+
+1. Pick the mode. Proactive review → audit the setup top to bottom. Active fire ("we're in spam") → diagnose.
+2. Scope first. Pull send volume, open rates by mailbox provider, shared vs dedicated IPs, and what changed right before the drop. An open rate below 10% at any provider confirms a deliverability problem, whatever anyone thinks of open tracking accuracy.
+3. Walk the four pillars, in order:
+   - Infrastructure. SPF, DKIM, DMARC present and verified recently — whole zone files disappear during migrations. The server's HELO announcement must match the IP's reverse DNS; a mismatch is an automatic blocklisting.
+   - Data. Hard bounces above 0.5% or soft bounces above 2% mean stop and clean. After an ESP migration, check whether old bounces were accidentally re-imported.
+   - Content. Ask: how is this email distinguishable from a scam? Missing branding, HTML-only sends, bloated code, and mismatched sender identity all read as scam patterns to filters.
+   - Traffic shape. The big one — solving it at the pipe solves most of the problem. Throttle per provider, never raise volume more than 50% week over week, and spread large sends across 3-4 days.
+4. Classify and prescribe. Blocklisted → delist, but fix the root cause first or the listing comes back. Content filtered → pause that provider for 24-48 hours, fix, retest on an engaged segment. Broken authentication → fix DNS, wait for propagation before resuming. New or damaged sender → run the ramp in references/warmup-playbook.md.
+5. Define monitoring. Set thresholds that trigger a pause, not a postmortem: bounce spikes, complaint rate above 0.3%, one provider dropping while the others hold.
+
+When the work goes deep, read references/warmup-playbook.md (week-by-week recovery ramp with per-provider volumes), references/shared-pool-management.md (pool contamination, compliance rails, high-risk verticals), and references/provider-specific-tactics.md (Gmail, Microsoft, Yahoo, iCloud, ProofPoint).
+
+## What good looks like
+
+- The best operators diagnose by provider, not in aggregate. A Gmail-only drop and an everywhere drop are different diseases with different cures.
+- The mediocre version blames "spam trigger words" and rewrites subject lines. Content is the least common root cause; infrastructure, data quality, and traffic shape break far more often.
+- A real diagnosis names the broken pillar and the change that broke it, with a date. "Improve engagement" is not a diagnosis.
+- Honesty beats comfort. A sender at 2-4% opens needs to hear that recovery takes weeks and may cost 10-20% of the list. Fully inboxing typically returns 10x the engagement, so frame the pause as an investment.
+- The output is good when the plan has dates, per-provider daily ceilings, and explicit stop conditions.
+
+## Rules
+
+- MUST report audit findings by severity: critical (causing spam placement or blocks right now), warning (fix this week), improvement (fix when able).
+- MUST check open rates by mailbox provider before proposing any fix.
+- MUST fix the root cause before resuming volume on any IP, new or old — a fresh IP with the same practices just burns the fresh IP.
+- NEVER exceed 4x the previous day's opens per provider during warmup or recovery.
+- NEVER recommend purchased lists or mailing contacts who never opted in.
+- NEVER let a damaged sender blast a full list in one day — spread it or stop it.

--- a/skills/joshua-waldman/email-deliverability/SKILL.md
+++ b/skills/joshua-waldman/email-deliverability/SKILL.md
@@ -20,7 +20,7 @@ Run this when email performance breaks, or before it gets the chance to. It prod
 2. Scope first. Pull send volume, open rates by mailbox provider, shared vs dedicated IPs, and what changed right before the drop. An open rate below 10% at any provider confirms a deliverability problem, whatever anyone thinks of open tracking accuracy.
 3. Walk the four pillars, in order:
    - Infrastructure. SPF, DKIM, DMARC present and verified recently — whole zone files disappear during migrations. The server's HELO announcement must match the IP's reverse DNS; a mismatch is an automatic blocklisting.
-   - Data. Hard bounces above 0.5% or soft bounces above 2% mean stop and clean. After an ESP migration, check whether old bounces were accidentally re-imported.
+   - Data. Hard bounces above 0.5% mean stop and clean. Soft bounces above 2% mean investigate before removing anything: Microsoft graylists legitimate senders heavily and ProofPoint soft-bounces on send rate, so both inflate the number with no list-quality problem behind it. Retry soft bounces three times across 72 hours, then treat what still fails as hard. After an ESP migration, check whether old bounces were accidentally re-imported.
    - Content. Ask: how is this email distinguishable from a scam? Missing branding, HTML-only sends, bloated code, and mismatched sender identity all read as scam patterns to filters.
    - Traffic shape. The big one — solving it at the pipe solves most of the problem. Throttle per provider, never raise volume more than 50% week over week, and spread large sends across 3-4 days.
 4. Classify and prescribe. Blocklisted → delist, but fix the root cause first or the listing comes back. Content filtered → pause that provider for 24-48 hours, fix, retest on an engaged segment. Broken authentication → fix DNS, wait for propagation before resuming. New or damaged sender → run the ramp in references/warmup-playbook.md.
@@ -41,6 +41,6 @@ When the work goes deep, read references/warmup-playbook.md (week-by-week recove
 - MUST report audit findings by severity: critical (causing spam placement or blocks right now), warning (fix this week), improvement (fix when able).
 - MUST check open rates by mailbox provider before proposing any fix.
 - MUST fix the root cause before resuming volume on any IP, new or old — a fresh IP with the same practices just burns the fresh IP.
-- NEVER exceed 4x the previous day's opens per provider during warmup or recovery.
+- NEVER exceed 4x the previous day's opens at a provider whose opens you can trust — Gmail, Microsoft, Yahoo. Apple Mail Privacy Protection pre-fetches images and inflates iCloud opens, so ramp Apple on a fixed schedule and read delivery and bounce signals there instead.
 - NEVER recommend purchased lists or mailing contacts who never opted in.
 - NEVER let a damaged sender blast a full list in one day — spread it or stop it.

--- a/skills/joshua-waldman/email-deliverability/references/provider-specific-tactics.md
+++ b/skills/joshua-waldman/email-deliverability/references/provider-specific-tactics.md
@@ -46,7 +46,7 @@ Microsoft tends to be more aggressive with blocking than Gmail. Where Gmail migh
 
 ### Microsoft-Specific Issues
 - **Outages affect senders:** Microsoft's own outages can cause mass bounces. The ESP should detect this and pause sending: "If everybody starts getting blocked at Microsoft because it went down again, we should pause sending and not just bounce a gazillion emails off of Microsoft's infrastructure."
-- **Aggressive gray-listing:** Microsoft uses gray-listing (code 400 soft bounces) extensively. Legitimate senders retry and get through; spammers don't. Understanding this behavior is critical — it inflates apparent soft bounce rates for legitimate senders.
+- **Aggressive gray-listing:** Microsoft uses gray-listing (code 400 soft bounces) extensively. Legitimate senders retry and get through; spammers don't. Understanding this behavior is critical — it inflates apparent soft bounce rates for legitimate senders. Never treat graylisted soft bounces as a dirty list: retry them, and only treat what still fails after three attempts across 72 hours as a hard bounce. Suppressing on the first soft bounce at Microsoft deletes valid, reachable addresses.
 
 ### Microsoft-Specific Fixes
 - When Microsoft blocks: 48-hour pause from that IP, then restart at minimal volume
@@ -81,6 +81,7 @@ iCloud/Apple Mail open rates below 10% indicate severe inbox placement problems.
 - Apple MPP (Mail Privacy Protection) pre-fetches images, which inflates open rate numbers
 - If you're seeing sub-10% opens at iCloud despite MPP inflation, the actual engagement is dramatically worse
 - iCloud placement is heavily reputation-dependent
+- Do not use the 4x-opens ramp here — MPP inflation makes it unsafe. Use a fixed daily schedule and watch bounces and delivery instead
 - Recovery approach follows the standard warmup playbook but with extra attention to engagement quality
 
 ---
@@ -147,6 +148,8 @@ Real-world example of segment management during warmup:
 - **Gradual decline:** Engagement erosion — probably sending to too many inactive contacts
 
 ### The 4x Rule
-Across all providers: "Never send more than 4x previous day's opens."
+Where opens are trustworthy: "Never send more than 4x previous day's opens."
 
-This is a universal safety guardrail. If you sent 100 emails yesterday and got 25 opens, today's maximum is 100 emails (4x25). This prevents over-sending to unengaged audiences and naturally scales volume as engagement improves.
+If you sent 100 emails yesterday and got 25 opens, today's maximum is 100 emails (4x25). This prevents over-sending to unengaged audiences and naturally scales volume as engagement improves.
+
+**The Apple exception.** Do not ramp on this rule at iCloud or Apple Mail. Mail Privacy Protection pre-fetches images, so a large share of those opens are machines, not people. Multiplying an inflated number authorizes volume no human asked for. Ramp Apple on a fixed schedule instead, and judge it on delivery and bounce behavior. The same caution applies anywhere else opens are proxied or prefetched.

--- a/skills/joshua-waldman/email-deliverability/references/provider-specific-tactics.md
+++ b/skills/joshua-waldman/email-deliverability/references/provider-specific-tactics.md
@@ -1,0 +1,152 @@
+# Provider-Specific Tactics
+
+How to diagnose and fix deliverability issues at each major mailbox provider and spam filter, based on experience managing large-scale sending operations.
+
+---
+
+## Gmail
+
+### How Gmail Thinks
+Gmail uses correlation-based filtering — it connects multiple data points to identify coordinated operations. It's not just looking at one signal; it's looking for patterns.
+
+**Gmail's strategy:** "Make it unprofitable, not impossible." They don't block everything outright — they make spamming so costly in terms of blocked mail and wasted resources that legitimate senders optimize while bad actors give up.
+
+### Correlation Points Gmail Watches
+- Physical business addresses shared across domains
+- Web hosting IPs shared across "different" brands
+- Similar domain naming patterns
+- Sender identity mismatches (display name vs. email address)
+- Similar or identical content sent from different domains
+- Lack of consistent branding across sends
+
+### Gmail-Specific Warmup
+- Start at ~200 emails/day for campaigns
+- Never exceed 4x previous day's opens
+- Domain reputation in Google Postmaster Tools is your primary signal
+- Reputation levels: High → Medium → Low → Bad
+- Moving from Low to High takes weeks of consistent positive signals
+
+### Gmail-Specific Fixes
+- **Content filtering:** Address all correlation points. If multiple domains share infrastructure markers, Gmail treats them as one sender.
+- **Domain reputation "Bad":** Full warmup restart needed. Consider whether the domain is recoverable or if starting fresh is more practical.
+- **Low engagement:** Gmail heavily weights engagement. Sending to inactive subscribers actively damages your reputation there.
+
+---
+
+## Microsoft (Outlook / Hotmail)
+
+### How Microsoft Differs
+Microsoft tends to be more aggressive with blocking than Gmail. Where Gmail might spam-folder your emails, Microsoft might outright reject them.
+
+### Microsoft-Specific Warmup
+- Start very low: 25 emails/day when recovering from damaged reputation
+- Never exceed 4x previous day's opens
+- Microsoft separates Outlook.com and Hotmail — track both independently
+- Recovery is often slower at Microsoft than Gmail
+
+### Microsoft-Specific Issues
+- **Outages affect senders:** Microsoft's own outages can cause mass bounces. The ESP should detect this and pause sending: "If everybody starts getting blocked at Microsoft because it went down again, we should pause sending and not just bounce a gazillion emails off of Microsoft's infrastructure."
+- **Aggressive gray-listing:** Microsoft uses gray-listing (code 400 soft bounces) extensively. Legitimate senders retry and get through; spammers don't. Understanding this behavior is critical — it inflates apparent soft bounce rates for legitimate senders.
+
+### Microsoft-Specific Fixes
+- When Microsoft blocks: 48-hour pause from that IP, then restart at minimal volume
+- New IP may be preferable to rehabilitating a blocked one
+- Track Hotmail and Outlook.com as separate segments during warmup
+
+---
+
+## Yahoo
+
+### How Yahoo Differs
+Yahoo is generally more forgiving than Gmail or Microsoft. Good news: easier to recover. Bad news: people sometimes use Yahoo success as false confidence about overall deliverability.
+
+### Yahoo-Specific Warmup
+- Start at ~50 emails/day when recovering
+- Never exceed 4x previous day's opens
+- Yahoo performance recovering doesn't mean Gmail performance is fine
+
+### Yahoo-Specific Tactics
+- Yahoo's engagement weighting is lighter than Gmail's
+- Still important to segment by engagement, but Yahoo gives more room for recovery
+- Watch for Yahoo-specific spam folder placement vs. blocks — they behave differently
+
+---
+
+## iCloud / Apple Mail
+
+### The iCloud Signal
+iCloud/Apple Mail open rates below 10% indicate severe inbox placement problems. Because Apple Mail Privacy Protection inflates open rates, genuinely low iCloud opens mean almost nothing is being delivered to inbox.
+
+### iCloud-Specific Considerations
+- Apple MPP (Mail Privacy Protection) pre-fetches images, which inflates open rate numbers
+- If you're seeing sub-10% opens at iCloud despite MPP inflation, the actual engagement is dramatically worse
+- iCloud placement is heavily reputation-dependent
+- Recovery approach follows the standard warmup playbook but with extra attention to engagement quality
+
+---
+
+## ProofPoint
+
+### How ProofPoint Works
+ProofPoint is a corporate spam filter (not a mailbox provider). It protects enterprise email systems — so when you're sending to business addresses at companies using ProofPoint, different rules apply.
+
+### ProofPoint-Specific Issues
+- **Sending rate sensitivity:** "The rate at which they were sending for one customer into the ProofPoint spam filter was not working. It was generating huge numbers of soft bounces."
+- **IP-level blocking:** ProofPoint blocks at the IP level. Getting delisted requires contacting ProofPoint directly.
+- **Throttling requirement:** The ESP's MTA must throttle sending rate to ProofPoint-filtered domains. Sending too fast = automatic soft bounces.
+
+### ProofPoint-Specific Fixes
+- Get the IP delisted from ProofPoint's blocklist directly
+- Implement MTA-level throttling for ProofPoint-filtered domains
+- Reduce sending volume to ProofPoint destinations during recovery
+- ProofPoint soft bounces are often rate-related, not reputation-related — distinguish between the two
+
+---
+
+## SpamHaus
+
+### What SpamHaus Does
+SpamHaus maintains blocklists that many mailbox providers and spam filters reference. A SpamHaus listing can cascade across multiple providers simultaneously.
+
+### Automatic SpamHaus Listing Triggers
+- **HELO/rDNS mismatch:** "If the HELO, the server announcement that comes through the SMTP connection, doesn't match the IP's reverse DNS — that is an automatic SpamHaus listing. If you hit enough networks with it."
+- **Spam trap hits:** Sending to SpamHaus-maintained spam traps
+- **High complaint rates:** Excessive spam reports from multiple sources
+
+### SpamHaus Diagnosis
+Use the free SpamHaus domain reputation checker to check:
+- Negative reputation scores
+- Infrastructure quality assessment
+- Domain creation dates (new domains are higher risk)
+- Whether multiple domains share the same IP address
+
+### SpamHaus Delisting
+- Fix the root cause first — delisting without fixing the cause results in re-listing
+- Submit delisting request through SpamHaus portal
+- Provide evidence of remediation steps taken
+- Monitor closely after delisting — re-listing happens fast if the problem recurs
+
+---
+
+## Cross-Provider Strategy
+
+### The Segment-by-Provider Approach
+During any warmup or recovery, segment sending by mailbox provider. Each provider has different:
+- Rate tolerances
+- Engagement weighting
+- Block vs. spam-folder behavior
+- Recovery timelines
+
+Real-world example of segment management during warmup:
+"I literally one time had to create eight separate segments for the different mailbox providers and spam filters and then literally update those every day and say okay, well today I sent to the last one to three days of engaged people at ProofPoint, Microsoft, Gmail, Hotmail, whatever."
+
+### Reading Provider Signals Together
+- **All providers declining:** Likely a content or data quality issue
+- **One provider declining, others stable:** Provider-specific throttling or reputation issue
+- **Sudden drops everywhere:** Authentication failure, DNS change, or SpamHaus listing
+- **Gradual decline:** Engagement erosion — probably sending to too many inactive contacts
+
+### The 4x Rule
+Across all providers: "Never send more than 4x previous day's opens."
+
+This is a universal safety guardrail. If you sent 100 emails yesterday and got 25 opens, today's maximum is 100 emails (4x25). This prevents over-sending to unengaged audiences and naturally scales volume as engagement improves.

--- a/skills/joshua-waldman/email-deliverability/references/shared-pool-management.md
+++ b/skills/joshua-waldman/email-deliverability/references/shared-pool-management.md
@@ -1,0 +1,118 @@
+# Shared Pool Management & Compliance
+
+How to manage shared IP pools, detect contaminating senders, and handle high-risk verticals — ESP-level deliverability management, learned at the scale of millions of messages a day.
+
+---
+
+## The Core Problem
+
+"Everything you have is connected in some kind of way and a problem in any one area can bleed over onto the whole if you don't address it, because mailbox providers and spam filters will just keep increasing their scrutiny and the amount of your mail that they filter. Until they ultimately decide — well, I'm spamming most of this and you keep sending, so I'm just gonna block it."
+
+---
+
+## Diagnosing Shared Pool Issues
+
+### Step 1: Scale Assessment
+Ask: "What percentage of the ESP's infrastructure is getting hit and having problems, by weight?"
+- If a minority percentage of IPs are affected → probably isolated bad sender(s)
+- If double digits → "there's a pretty serious problem, likely it's all gonna come down to the customers that you're sending on your network"
+
+### Step 2: Shared vs. Dedicated Analysis
+"Is it mostly your shared IPs that are getting blocked or is it mostly your dedicated IPs that are getting blocked?"
+- **Shared IPs blocked** → Pool contamination. One or more senders are dragging down the pool.
+- **Dedicated IPs blocked** → Look for commonalities: "Are they in the same industry vertical? Maybe there's just a lot of risk around that industry vertical and you need to vet customers in that industry a bit more stringently."
+
+### Step 3: Find the Contaminator
+Build visibility into which clients generate the highest block rates:
+- "You would want a really robust system that would allow us to see which clients are getting the highest block rates. Where are those clients blocked?"
+- Cross-reference block patterns with customer sending behavior
+- Check if any customer connected servers outside the approved warmup protocol
+- Look for HELO/rDNS mismatches on recently added IPs
+
+### Step 4: Assess Cascade Risk
+One misconfigured customer can melt down the entire infrastructure:
+- Example: Client connected to new server outside of warmup protocol. The SMTP HELO announcement didn't match the IP's reverse DNS → automatic SpamHaus listing → "started causing everything we were doing to melt down"
+- Cascade principle: Filters increase scrutiny incrementally → filtering more mail → eventually blocking entirely
+
+---
+
+## Building Compliance Rails
+
+The operating rule: "Having as many compliance checks as possible built into your system as well as the ability to view ongoing compliance checks for your team and take action in the system when there looks to be a sustained issue."
+
+### On Intake (New Customer Onboarding)
+1. **Validate data on import** — Run list hygiene automatically. "When you move onto a new ESP, I want to validate your data just because mistakes happen."
+2. **Sample and risk-evaluate** — "Maybe even sampling some portion of that and throwing it at a tool that can evaluate the risk of that data."
+3. **Check domain age** — Domains under 90 days old need special warmup handling.
+4. **Verify authentication setup** — SPF, DKIM, DMARC records must be in place before first send.
+5. **Industry vertical assessment** — Flag high-risk verticals for additional review.
+
+### Ongoing Monitoring
+1. **Bounce rate monitoring** — "Why would your ESP let you bounce five thousand or fifty thousand messages when they could look at a sample of like a hundred or five hundred and go, you know what, I'm pulling the plug?"
+2. **Open rate tracking** — Below 10% = intervene. "I've seen ESPs let customers persist with two to four percent open rates, bad domain reputation... they don't want to risk the contract."
+3. **Complaint rate alerts** — Automated intervention at threshold.
+4. **Block detection** — Real-time visibility into which IPs are blocked where.
+5. **Provider outage detection** — "If everybody starts getting blocked at Microsoft because it went down again, we should pause sending and not just bounce a gazillion emails off of Microsoft's infrastructure."
+
+### Automated Intervention
+All of this should be automated, not manual:
+- "Frankly, all this can be automated. Don't need a person to reach out to the customer. You can shoot them an email."
+- Trigger automated alerts at first sign of problems
+- Suspend sending automatically when bounce patterns indicate issues
+- Resume requires human review of root cause
+
+---
+
+## High-Risk Vertical Management
+
+### Verticals That Get Blanket-Banned at Many ESPs
+- Crypto/cryptocurrency
+- Casino/iGaming
+- Adult content
+- Political content
+
+### The Better Approach: Enhanced Vetting, Not Blanket Bans
+"There are also plenty of legitimate senders in many of those industries."
+
+Instead of rejecting outright: "We're not gonna say no, but you definitely have to go for some kind of additional questioning."
+
+### Enhanced Vetting Process
+1. Additional questionnaire about sending practices
+2. Review of content samples
+3. List source verification
+4. Volume and frequency expectations
+5. Explicit agreement to aggressive sunsetting policies
+
+### Casino/iGaming Specific Requirements
+- Aggressive sunsetting: suppress after 3-5 unopened emails (not standard 90-180 day window)
+- Spread monthly newsletters across the month (no single-day spikes)
+- May need dedicated IP allocation to isolate from shared pool
+- "With the right sending strategy, you can be successful"
+
+---
+
+## ESP Accountability
+
+A frustration with the industry:
+
+"What I've seen in the industry ecosystem is ESPs avoiding responsibility like it's the plague. Even when the customer is like, yo, I know this is my fault, but can you help me?"
+
+The healthy approach:
+- **Don't hide problems** — "It's unconscionable to me. I've seen ESPs let customers send millions of emails into the spam folder when they absolutely had the intelligence to tell their customer, this is not working."
+- **Alert early** — "They're just delaying the pain. It's gonna blow up later when someone realizes they paid you thousands or tens of thousands, even hundreds of thousands of dollars to get literally no traction."
+- **Own the infrastructure** — The ESP controls the MTA. Use that control to protect all senders on the platform.
+- **Make it a win-win-win** — "The customer is happy. Your infrastructure is not gonna get as damaged. The customer is gonna get a timely alert about a potential cybersecurity issue."
+
+---
+
+## When to Fire a Customer
+
+There's a line between helping a struggling sender and letting a bad actor damage your infrastructure:
+
+- Persistent violation of sending policies after warnings
+- Refusal to implement list hygiene or engagement segmentation
+- Sending to purchased lists repeatedly
+- Content that consistently fails compliance checks
+- Business model that inherently requires spammy practices
+
+The "ice skating uphill" test: If their business model requires practices that will always trigger spam filters, they probably won't succeed on your platform regardless of how much you help them. Better to part ways than let them contaminate shared infrastructure.

--- a/skills/joshua-waldman/email-deliverability/references/warmup-playbook.md
+++ b/skills/joshua-waldman/email-deliverability/references/warmup-playbook.md
@@ -1,0 +1,169 @@
+# Warmup & Reputation Recovery Playbook
+
+The step-by-step process for warming up new senders or recovering damaged sender reputation, built from managing IP pools that process 10-18 million messages a day. Follow it exactly — the order matters.
+
+---
+
+## When to Use This Playbook
+
+- New domain or IP needs warming before production sending
+- Sender has been blocklisted and needs reputation recovery
+- Open rates have cratered (below 10%) and domain reputation is damaged
+- Migrating from another ESP and need to establish reputation on new infrastructure
+
+---
+
+## Phase 1: The Pause (Week 1)
+
+**Do NOT send bulk email. Do NOT do nothing.**
+
+This week is for data analysis and preparation. The rule is emphatic: "Don't do nothing during that week. During that week, it's generally spent on data analysis."
+
+### Step 1: Assess Current State
+- Pull current open rates by mailbox provider (Gmail, Microsoft, Yahoo, iCloud, ProofPoint)
+- Check domain reputation in Google Postmaster Tools
+- Run SpamHaus check on all sending domains and IPs
+- Check all authentication records (SPF, DKIM, DMARC) are present and valid
+- Verify HELO/reverse DNS match on every IP
+
+### Step 2: Analyze Historical Performance
+- **For promotional senders:** Identify the best-performing offers. "What are the best offers that you've sent?"
+- **For newsletter senders:** Identify the most engaging topics. "What are the most salient topics that your audience likes?"
+- Goal: Have a strong piece of content ready to launch when sending resumes.
+
+### Step 3: Segment the Audience
+Build these segments from most to least engaged:
+
+1. **Recently signed up** — Opted in within the last 30 days. Highest natural engagement.
+2. **Super fans** — Your most email-engaged subscribers. "Every brand has their super fans. They love the interaction. They love it when you send them email."
+3. **Regular engaged** — Opened or clicked within the last 90 days.
+4. **Lightly engaged** — Opened within the last 180 days.
+5. **Inactive** — No engagement in 180+ days. These come last, if at all.
+
+### Step 4: Segment by Mailbox Provider
+Within each engagement tier, create sub-segments by mailbox provider:
+- Gmail
+- Microsoft (Outlook/Hotmail)
+- Yahoo
+- iCloud/Apple
+- ProofPoint-filtered domains
+- Other
+
+**Start your warmup with Gmail contacts who have engaged with an email in the last 90 days.** Gmail is the largest provider and provides the clearest reputation signals via Google Postmaster Tools. Starting with recently engaged Gmail contacts gives you the highest chance of strong initial engagement, which builds positive domain reputation that carries over when you expand to other providers.
+
+Real-world example: "I did a warmup on Klaviyo a while back. I ended up having to manage eight segments because they had a substantial consumer and B2B audience... seven material buckets of mailbox provider and spam filter plus the other category."
+
+### Step 5: Validate the Data
+- Run list hygiene on the entire list
+- Remove hard bounces, soft bounces from previous ESP
+- Sample and evaluate data risk with validation tools
+- Check for spam trap indicators (custom-hosted domains on their own nameservers with 5-letter names)
+
+"When you move onto a new ESP, I want to validate your data just because mistakes happen. Data sets — bounces sometimes will remain in the list."
+
+---
+
+## Phase 2: The Ramp (Weeks 2-6+)
+
+### Starting Volumes by Provider (Reputation Recovery)
+When restarting from severely damaged reputation:
+
+| Provider | Day 1 Volume | Ramp Rule |
+|----------|-------------|-----------|
+| Microsoft | 25 emails | Never send more than 4x previous day's opens |
+| Yahoo | 50 emails | Never send more than 4x previous day's opens |
+| Gmail | 200 emails | Never send more than 4x previous day's opens |
+| iCloud | 50 emails | Monitor carefully — under 10% open rate at iCloud = severe issue |
+
+### Starting Volumes (New Domain/IP Warmup)
+When warming from scratch (not damaged, just new):
+
+- **Days 1-7:** Send only automated/transactional volume (a few hundred per day)
+- **Week 2:** Begin blending in engaged audience segments
+- **Week 3+:** Gradually introduce less engaged segments
+- **Target timeline:** 1-2 months to reach 100K/day (depends on audience engagement quality)
+
+### New Domain Requirements
+- New domains need a **90-day aging period** before heavy sending use
+- Consider aftermarket domains that already have age — they cost $1-200 depending on keywords
+- Look for domains with keywords relevant to the brand (e.g., "blitz" and "games" for a gaming company)
+- Even aged domains need sending warmup — domain age helps but isn't sufficient alone
+
+### Daily Management During Ramp
+
+Each day during the warmup:
+
+1. Check yesterday's metrics by provider segment
+2. Identify who opened/clicked (these people are "done" for this campaign cycle)
+3. Update segments: remove already-mailed contacts, add next batch
+4. Send to the next day's segment — only people who haven't received this campaign yet
+5. Monitor bounce rates, complaint rates, and inbox placement
+6. If any provider shows warning signs, reduce volume or pause for that provider
+
+The manual process: "Literally update those every day and say okay, well today I sent to the last one to three days of engaged people at ProofPoint, Microsoft, Gmail, Hotmail, whatever."
+
+### Automated Warmup (When Available)
+With proper tooling, you can load the full weekly segment and let the system manage distribution: "Load up a whole 10,000 segment and just let our warmup schedule run it all out of that one campaign without you having to really do a lot about it. Other than watch it and check the metrics."
+
+---
+
+## Phase 3: Steady State
+
+### When to Declare Victory
+- Open rates consistently above 20% across providers
+- Domain reputation "High" in Google Postmaster Tools
+- No active blocklist entries
+- Soft bounce rate under 0.5%
+- Complaint rate under 0.1%
+
+### Ongoing Monitoring
+- Check domain/IP reputation weekly
+- Monitor open rate trends (direction matters more than absolute number)
+- Watch for provider-specific drops (one provider declining while others hold = provider-specific issue)
+- Validate new list imports before sending
+- Maintain engagement-based suppression (sunset inactive contacts)
+
+### For Casino/iGaming Clients
+More aggressive sunsetting required:
+- Suppress users after 3-5 unopened emails (not the standard 90-180 day window)
+- Monthly newsletter sends should be spread across the month, not spiked on one day
+- Large campaigns can be spread across 3-4 days rather than a single send
+
+---
+
+## Content Strategy During Warmup
+
+### Best Practice: Identical Content Approach
+Send the same newsletter content to both engaged AND disengaged audiences:
+- Engaged audience sends first → builds positive content reputation
+- Same content then reaches disengaged users → benefits from the positive reputation already established
+- This is more effective than sending different content to different segments
+
+### Launch Content
+- Use your strongest-performing content type for the first send
+- Ensure perfect branding, clean HTML, proper images
+- Include plain text version
+- Keep links minimal
+- Avoid trigger words (URGENT, ACTION REQUIRED, etc.)
+
+### Transactional Email First
+If warming a completely new domain:
+- Start with automated/transactional emails (OTP codes, order confirmations)
+- These have fewer links and higher natural engagement
+- Build initial reputation before adding marketing volume
+
+---
+
+## Setting Client Expectations
+
+How to set expectations honestly:
+
+**On the pause:** "Not going to be a lot of volume going out. It's really going to be curated sends to small segments."
+
+**On timeline:** Reputation recovery takes weeks to months, not days. "You just got to let that kind of rest for a little bit."
+
+**On the upside:** "If you're fully inboxing, you're going to be getting 10X that kind of engagement." Frame the pause as an investment, not a loss.
+
+**On list cuts:** "It's truly not the size. It's how it performs and how much money it makes you." Be prepared to cut 10-20% of a list for quality.
+
+**On the long game:** "For me, email is about the long game, not the short game. Yes, there are short-term things you need to do in the interim to keep everything afloat, but really keeping your email reputation high is part of building a sustainable business."

--- a/skills/joshua-waldman/email-deliverability/references/warmup-playbook.md
+++ b/skills/joshua-waldman/email-deliverability/references/warmup-playbook.md
@@ -73,7 +73,7 @@ When restarting from severely damaged reputation:
 | Microsoft | 25 emails | Never send more than 4x previous day's opens |
 | Yahoo | 50 emails | Never send more than 4x previous day's opens |
 | Gmail | 200 emails | Never send more than 4x previous day's opens |
-| iCloud | 50 emails | Monitor carefully — under 10% open rate at iCloud = severe issue |
+| iCloud | 50 emails | Fixed schedule, not the 4x rule — MPP inflates opens here. Under 10% open rate at iCloud = severe issue |
 
 ### Starting Volumes (New Domain/IP Warmup)
 When warming from scratch (not damaged, just new):


### PR DESCRIPTION
## What this skill does

Diagnoses why email lands in spam and produces the fix. Two paths: a severity-ranked audit before someone scales volume, or a root-cause diagnosis with a recovery ramp when performance has already broken.

This is the bulk-sender and ESP side of deliverability, so it complements the cold-email warmup skills already in the library rather than overlapping them. It's built from managing shared IP pools that process 10-18 million messages a day, so the judgment leans toward traffic shape and pool contamination, the things that break at volume.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

Two notes on the checklist above:

`author.md` has no `avatarUrl`, so it'll fall back to my LinkedIn photo per the template. Happy to add one if you'd rather have it explicit.

On vendor names: the body names mailbox providers and spam filters (Gmail, Microsoft, Yahoo, iCloud, ProofPoint) because diagnosing by provider is the whole method, and an aggregate view hides which one is actually broken. No sending platforms, ESPs, or tooling vendors are named anywhere, including my own.
