### PR TITLE
Depth-first contributions: kill the 600-word ceiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,15 @@ Don't transcribe a process — extract judgment. A skill that's just steps will 
 
 1. **When does this play run?** What's the trigger — a signal, a moment in the deal, a cadence?
 2. **What does it produce?** The concrete output (a list, a sequence, a brief, an updated pipeline).
-3. **Walk me through how you actually do it.** The procedure, tools aside.
-4. **What do you notice first that others miss?** The expert's tell.
-5. **What's the common mistake?** What does the mediocre version of this look like?
-6. **How do you know the output is good?** The quality bar, concretely.
-7. **Who are you?** (First submission only — name, role, LinkedIn, company, email; for `author.md`.)
+3. **Walk me through how you actually do it.** The procedure, tools aside — and keep going past the first pass. The real playbook has branches: what changes by segment, by deal size, by what the data shows.
+4. **What are the actual numbers?** Thresholds, scoring rubrics, caps, benchmarks — the values the user really uses, not "it depends". If they score things, get the whole rubric.
+5. **Give me two or three real examples.** A worked case from start to finish, an edge case, the time it went wrong.
+6. **What do you notice first that others miss?** The expert's tell.
+7. **What's the common mistake?** What does the mediocre version of this look like?
+8. **How do you know the output is good?** The quality bar, concretely.
+9. **Who are you?** (First submission only — name, role, LinkedIn, company, email; for `author.md`.)
+
+**Don't stop early.** Before drafting, ask: "What else do you check or do here that we haven't covered?" — and keep asking until the answer is genuinely nothing. The depth you extract in this interview (rubrics, numbers, worked examples) becomes `references/` pages; a thin interview produces a thin skill, and thin skills get sent back for exactly that.
 
 ### 2. Draft the files
 
@@ -68,9 +72,9 @@ contributors: []        # other creators' slugs, if any — omit if none
 
 - **Tool-agnostic, always.** GTM verbs — "check the CRM", "load the ICP", "pull recent replies" — never vendor tool names. The reader's stack is unknown.
 - Structure: when it applies (one line) → what it produces (one line) → the procedure in `##` sections → a **`## What good looks like`** section (mandatory — encode answers from interview questions 4–6) → hard rules (MUST/NEVER) last.
-- Terse and decisive. ~600 words target. No filler, no "recently", no first-person plural, no placeholder text left behind.
+- Terse and decisive in the writing — but **deep in the substance**. The parent body is the spine: sharp, no filler, no "recently", no first-person plural, no placeholder text left behind. 600–800 words is a good spine; it is a floor for seriousness, not a ceiling on depth.
+- The depth that makes a skill worth installing lives in `references/<topic>.md` pages: full scoring rubrics with real numbers, worked examples, templates, edge-case playbooks, channel variants. The body says when to read each one. **The library's flagship skills ship 2–5 reference pages** — a submission with no references usually means the interview stopped too early, and a bare checklist gets sent back.
 - Don't reference other skills by name; describe the next action in verbs.
-- Deep material (worked examples, frameworks, channel variants) goes in `references/<topic>.md`, and the body says when to read each one.
 
 **`skills/<author>/author.md`** (first submission): frontmatter `name`, `avatarUrl`, `title`, `linkedinUrl`, `companyDomain`, `email`; the bio is the body text. The directory name is the slug — there is no slug field.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ No git? Open a ["Submit a skill" issue](https://github.com/swan-gtm/gtm-skills/i
 - **Judgment, not steps.** A skill captures what the best operator notices first, the trap the average one falls into, and what good output looks like. Every skill has a `## What good looks like` section. A bare checklist gets sent back.
 - **Tool-agnostic.** GTM verbs ("check the CRM", "load the ICP") — never vendor tool names. Readers run HubSpot, Salesforce, Attio, spreadsheets, or nothing.
 - **Dense description.** Leads with "Use this skill when…" — it's what an agent reads to decide when to fire your skill.
-- **Compact.** ~600 words of instructions; past ~800, move depth into `references/`.
+- **Deep, not padded.** Extensive skills are the bar, not the exception — full rubrics with real numbers, worked examples, edge cases. Keep the parent body a sharp ~600–800-word spine and put the depth in `references/` pages (flagship skills ship 2–5 of them; see [account-tier-scoring](https://www.gtmskills.com/skill/account-tier-scoring) and [outreach-execution](https://www.gtmskills.com/skill/outreach-execution) for the bar). Padding gets trimmed; depth gets featured.
 - **No rot.** No dates, no "recently", no UI-specific references.
 
 ## Review — the five gates

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add `-a claude-code`, `-a cursor`, `-a codex`, etc. to target a specific agent; 
 
 You don't need to know git. Paste this to Claude, Cursor, or any capable agent:
 
-> Fetch https://raw.githubusercontent.com/swan-gtm/gtm-skills/main/AGENTS.md and follow its submission flow. Interview me about my GTM skill, draft it in their format, and submit it.
+> Fetch https://raw.githubusercontent.com/swan-gtm/gtm-skills/main/AGENTS.md and follow its submission flow. Interview me thoroughly about my GTM skill — the full playbook, including my rubrics, numbers, and real examples — draft it in their format with reference pages for the depth, and submit it.
 
 Your agent will interview you, package your playbook in our format, validate it, and open the PR (or a submission issue if it can't use git). Details in [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/templates/skill/SKILL.md
+++ b/templates/skill/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 1. [First step — a GTM verb: "check the CRM", "load the ICP", "pull recent replies". Never a vendor tool name.]
 2. [Next step.]
-3. [If a step has depth worth its own page, move it to references/<topic>.md and say here when to read it.]
+3. [If a step has depth worth its own page — a scoring rubric, worked examples, a
+   channel variant — move it to references/<topic>.md and say here when to read it.
+   Most skills worth installing ship 1–4 reference pages; see
+   templates/skill/references/example-reference.md for the shape.]
 
 ## What good looks like
 

--- a/templates/skill/references/example-reference.md
+++ b/templates/skill/references/example-reference.md
@@ -1,0 +1,24 @@
+# [Topic — e.g. "Scoring rubric", "Worked example: mid-market SaaS", "Objection library"]
+
+[This is a reference page — the depth behind one step of the parent skill. The
+parent body says WHEN to read this page; this page carries the full material.
+Delete every bracketed hint. Good reference pages are the difference between a
+checklist and a skill someone installs: real numbers, real examples, the tables
+you actually use.]
+
+## [The material itself]
+
+[Examples of what belongs here:
+
+- A full scoring rubric — every factor, its weight, the thresholds, and what each
+  band means for the next action. Real values, not "adjust to taste".
+- A worked example from start to finish — the input you started with, each
+  decision as it happened, the output, and what made it good or bad.
+- A template with every field explained — not just the skeleton, but why each
+  part is there and the mistake each part prevents.
+- An edge-case playbook — the situations the main procedure doesn't cover and
+  exactly what changes in each one.]
+
+| [Factor] | [Weight] | [Threshold] | [What it means] |
+|---|---|---|---|
+| | | | |


### PR DESCRIPTION
The Contribute flow (README paste-prompt -> AGENTS.md -> agent) was biasing submissions short. Two lines told agents '~600 words target' / 'Compact', and agents obey: every repo-first contributor to date averages 2,500-3,800 chars of instructions with ZERO reference pages, while the skills the library leads with (account-tier-scoring, outreach-execution, Ariel's and Rutger's sets) run 12,000-26,000 chars with 2-5 reference pages.

Changes:

- **AGENTS.md interview**: adds 'what are the actual numbers' and 'give me 2-3 real examples' questions, plus a don't-stop-early rule: keep asking 'what else do you check that we haven't covered?' until the answer is nothing.
- **AGENTS.md body rules**: 600-800 words is now framed as the spine, a floor for seriousness rather than a ceiling on depth; flagship skills ship 2-5 reference pages; a submission with no references usually means the interview stopped too early.
- **CONTRIBUTING.md**: 'Compact' bullet replaced with 'Deep, not padded', linking the two exemplar skills as the visible bar.
- **templates/skill**: adds references/example-reference.md so the template itself scaffolds depth (rubric table skeleton, worked-example guidance).
- **README paste-prompt**: now asks the agent for the full playbook - rubrics, numbers, real examples - with reference pages for the depth.

Note for reviewers: PR is from Ariel, so per require_last_push_approval it needs Ido or Niv to approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)