### PR TITLE
rutger-katz: add companyDomain (neontriforce.com)

### DIFF
--- a/skills/rutger-katz/author.md
+++ b/skills/rutger-katz/author.md
@@ -3,6 +3,7 @@ name: Rutger Katz
 avatarUrl: "https://www.gtmskills.com/authors/rutger-katz.jpg"
 title: "Founder @ Neon Triforce — AI-Ready Revenue Systems"
 linkedinUrl: "https://www.linkedin.com/in/rutgerkatz"
+companyDomain: neontriforce.com
 ---
 
 Helps B2B scale-ups (€15–150M) build AI-ready revenue systems — diagnostics first, then the operating system: forecasting, pipeline architecture, handoffs, and the tooling to run it.


### PR DESCRIPTION
One line: Rutger's author.md was missing companyDomain, which kept Neon Triforce off the /companies page and risks a future author sync nulling the domain we just set in the DB. His title already says Founder @ Neon Triforce and his site is neontriforce.com.

Note for reviewers: PR from Ariel, needs Ido or Niv per require_last_push_approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)