### PR TITLE
add human-mannerisms by gali-firon

### DIFF
--- a/skills/gali-firon/author.md
+++ b/skills/gali-firon/author.md
@@ -1,0 +1,9 @@
+---
+name: Gali Firon
+title: Sales & Marketing Coordinator, Kidoz Inc.
+linkedinUrl: https://www.linkedin.com/in/gali-firon-a43664201/
+companyDomain: kidoz.net
+email: gali@kidoz.net
+---
+
+Gali Firon is a Sales & Marketing Coordinator at Kidoz Inc., working across content, executive thought leadership, and earned media for the company's ad-tech brands. Her skills encode the editing and outreach standards she uses in production: how to make AI-drafted GTM copy read like a specific human, how to run founder LinkedIn content that does not repeat itself, and how to pitch journalists so they actually reply.

--- a/skills/gali-firon/human-mannerisms/SKILL.md
+++ b/skills/gali-firon/human-mannerisms/SKILL.md
@@ -9,7 +9,9 @@ tags: [Marketing]
 
 Applies when a piece of copy has had its AI tells removed but still has no voice. Produces a version with one or two earned human moves added, so a real person is visibly in the room.
 
-Stripping AI tells gets copy "to zero": nothing screams machine. It does not get you above zero. Clean copy with no texture still reads as AI, because "flawless and flat" is itself the tell. This skill is the positive pass: a small library of moves that put a specific person back into the writing. It runs *after* the tell-stripping pass, never instead of it.
+Stripping AI tells gets copy "to zero": nothing screams machine. It does not get you above zero. Clean copy with no texture still reads as AI, because "flawless and flat" is itself the tell. This skill is the positive, additive pass: a small library of moves that put a specific person back into the writing. It runs *after* the subtractive pass, never instead of it.
+
+This is deliberately a separate skill from the anti-ai-slop-writing pass, not one combined step, because the two jobs do not always both apply. Every piece that ships should have its AI tells removed; not every piece should be made to sound casual. A formal announcement, a compliance note, or a technical one-pager needs to be clean, not chatty - it gets the tell-stripping pass and stops there. A LinkedIn post, a founder's thought leadership, or a personal email needs voice on top - it gets both, in order. Bundling the two would force human texture onto writing that should stay plain. Keeping them apart lets you run the floor everywhere and reach for these moves only where the register calls for it.
 
 ## The play
 
@@ -17,7 +19,7 @@ Stripping AI tells gets copy "to zero": nothing screams machine. It does not get
 
 2. **Read the piece once and locate the flatness.** Find the stretch where the writing is smooth, correct, and voiceless - usually the middle, where the argument goes on autopilot. That is where a move earns its place. Do not spray moves across every line.
 
-3. **Add one or two moves, no more.** Pick from the move library below. One or two earned moments per piece. A piece stuffed with quirks reads as try-hard, which is its own kind of slop. Match the move to the writer's real register - a dry operator gets a deadpan undercut, not a whimsical aside.
+3. **Add one or two moves, no more.** This counts distinct move-types from the library below - pick one or two, not all eight. A single move may recur its own handful of times within the piece (the conjunction-opener below, for instance, can appear two or three times); that still counts as one move. What reads as try-hard is stacking many different quirks, so hold the line at one or two move-types per piece. Match the move to the writer's real register - a dry operator gets a deadpan undercut, not a whimsical aside.
 
 4. **Pull the real detail, never invent it.** The specificity move (below) uses only true detail the writer actually has. Specificity you own reads as lived; specificity you invent reads as fraud, and invented numbers or moments are a hard failure.
 
@@ -31,7 +33,7 @@ Each is expanded with multiple specimens in `references/move-library.md`.
 - **Undercut your own big statement.** A confident claim, then a small deflation. "It's the best tool we've built. Low bar, given the last one."
 - **Oddly specific real detail.** The weirdly exact true detail instead of the smooth generic one. "Fill rate dropped the Tuesday after the holiday, 11%, and nobody noticed until Thursday."
 - **Short. Then shorter.** Vary sentence length hard; follow a long winding sentence with a two-word one.
-- **Start on And / But / So.** A conjunction opener for a beat before the turn. Two or three per piece, max.
+- **Start on And / But / So.** A conjunction opener for a beat before the turn. If you pick this move, two or three uses is its ceiling.
 - **Talk to one person.** Write to a single reader, not an audience. Contractions, "you", direct address.
 - **Self-interruption mid-thought.** Start to say one thing, stop, say the truer thing. The visible seam is the humanness.
 - **Deadpan the absurd.** State the ridiculous thing in a flat tone. Let the gap between calm delivery and wild content do the work.

--- a/skills/gali-firon/human-mannerisms/SKILL.md
+++ b/skills/gali-firon/human-mannerisms/SKILL.md
@@ -19,7 +19,7 @@ This is deliberately a separate skill from the anti-ai-slop-writing pass, not on
 
 2. **Read the piece once and locate the flatness.** Find the stretch where the writing is smooth, correct, and voiceless - usually the middle, where the argument goes on autopilot. That is where a move earns its place. Do not spray moves across every line.
 
-3. **Add one or two moves, no more.** This counts distinct move-types from the library below - pick one or two, not all eight. A single move may recur its own handful of times within the piece (the conjunction-opener below, for instance, can appear two or three times); that still counts as one move. What reads as try-hard is stacking many different quirks, so hold the line at one or two move-types per piece. Match the move to the writer's real register - a dry operator gets a deadpan undercut, not a whimsical aside.
+3. **Add one or two moves, no more.** This counts distinct move-types from the library below - pick one or two, not all eight. A single move-type may recur two or three times within the piece and still count as one move (the conjunction opener, for instance). The one exception is the mid-sentence aside: use it at most once per piece. What reads as try-hard is stacking many different quirks, so hold the line at one or two move-types per piece. Match the move to the writer's real register - a dry operator gets a deadpan undercut, not a whimsical aside.
 
 4. **Pull the real detail, never invent it.** The specificity move (below) uses only true detail the writer actually has. Specificity you own reads as lived; specificity you invent reads as fraud, and invented numbers or moments are a hard failure.
 

--- a/skills/gali-firon/human-mannerisms/SKILL.md
+++ b/skills/gali-firon/human-mannerisms/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: human-mannerisms
+title: Human writing mannerisms
+description: |
+  Use this skill when GTM copy is clean but reads flat, generic, or "technically fine but nobody's home" - a LinkedIn post, a cold email, a newsletter, an exec's thought-leadership draft, a landing page. Produces the same copy with one or two deliberate human moves added, so it reads as one specific person instead of a competent machine. Reach for it when someone says "this sounds like AI", "it's fine but boring", "make it sound like me", "add some personality", or right after a de-AI editing pass leaves the writing smooth and voiceless.
+category: Positioning
+tags: [Marketing]
+---
+
+Applies when a piece of copy has had its AI tells removed but still has no voice. Produces a version with one or two earned human moves added, so a real person is visibly in the room.
+
+Stripping AI tells gets copy "to zero": nothing screams machine. It does not get you above zero. Clean copy with no texture still reads as AI, because "flawless and flat" is itself the tell. This skill is the positive pass: a small library of moves that put a specific person back into the writing. It runs *after* the tell-stripping pass, never instead of it.
+
+## The play
+
+1. **Strip first, then add.** Run the de-AI pass before this one. Order matters: adding texture to copy that still has rhetorical AI tells just makes the tells louder. If the tells are gone, continue.
+
+2. **Read the piece once and locate the flatness.** Find the stretch where the writing is smooth, correct, and voiceless - usually the middle, where the argument goes on autopilot. That is where a move earns its place. Do not spray moves across every line.
+
+3. **Add one or two moves, no more.** Pick from the move library below. One or two earned moments per piece. A piece stuffed with quirks reads as try-hard, which is its own kind of slop. Match the move to the writer's real register - a dry operator gets a deadpan undercut, not a whimsical aside.
+
+4. **Pull the real detail, never invent it.** The specificity move (below) uses only true detail the writer actually has. Specificity you own reads as lived; specificity you invent reads as fraud, and invented numbers or moments are a hard failure.
+
+The move library, with why each one works and how to place it, lives in `references/move-library.md`. The rules for pairing this pass with tell-stripping - the order, the "to zero / above zero" model, and what not to do - are in `references/pairing-and-order.md`.
+
+## The moves (summary)
+
+Each is expanded with multiple specimens in `references/move-library.md`.
+
+- **Mid-sentence aside.** A short comment dropped into the middle of a line that steps outside the point to be dry or say the quiet part. "We ran it for six weeks (which, in ad-tech time, is roughly a geological era) and the numbers held."
+- **Undercut your own big statement.** A confident claim, then a small deflation. "It's the best tool we've built. Low bar, given the last one."
+- **Oddly specific real detail.** The weirdly exact true detail instead of the smooth generic one. "Fill rate dropped the Tuesday after the holiday, 11%, and nobody noticed until Thursday."
+- **Short. Then shorter.** Vary sentence length hard; follow a long winding sentence with a two-word one.
+- **Start on And / But / So.** A conjunction opener for a beat before the turn. Two or three per piece, max.
+- **Talk to one person.** Write to a single reader, not an audience. Contractions, "you", direct address.
+- **Self-interruption mid-thought.** Start to say one thing, stop, say the truer thing. The visible seam is the humanness.
+- **Deadpan the absurd.** State the ridiculous thing in a flat tone. Let the gap between calm delivery and wild content do the work.
+
+## What good looks like
+
+- **What the best editor notices first:** the flatness is not a grammar problem or a word-choice problem - it is the absence of a point of view. The tell is that every clause is load-bearing and on-task. A human cannot resist the unnecessary side comment; the unnecessary bit is the human bit. The fix is to add one, not to rewrite the sentence.
+- **The common mistake:** treating this as a checklist and applying every move at once. Copy with an aside *and* an undercut *and* a fragment *and* a conjunction opener in four consecutive lines reads as an AI performing "casual", which is worse than flat. The mediocre version also reaches for a generic quirk ("Let's be real,") instead of a move that fits the specific writer.
+- **How you know it worked:** read it aloud. If one moment makes you hear a specific person - their dryness, their impatience, their eye for the weird true detail - it worked. If it is smooth all the way through with nothing that could only have come from this writer, it is still at zero. If it now reads as someone trying hard to sound casual, you added too much; cut back to one move.
+
+## Rules
+
+- MUST run the tell-stripping pass before this one. This is the second pass, never the only pass.
+- MUST use only real, true detail for the specificity move. Invented numbers, dates, or moments are a hard failure.
+- MUST keep it to one or two moves per piece.
+- MUST match the move to the writer's real register, not a generic "fun" voice.
+- NEVER stack multiple moves in consecutive lines.
+- NEVER use a move to prop up a claim that is not actually true or not actually the writer's.

--- a/skills/gali-firon/human-mannerisms/references/move-library.md
+++ b/skills/gali-firon/human-mannerisms/references/move-library.md
@@ -1,6 +1,6 @@
 # Move library — the human moves, with specimens
 
-The eight moves that put a specific person back into flat copy. Each entry: what it is, why it reads as human, how to place it, and multiple specimens. Pull one or two per piece. Never all of them.
+The eight moves that put a specific person back into flat copy. Each entry: what it is, why it reads as human, how to place it, and multiple specimens. Pull one or two distinct moves per piece, never all of them. A single move may recur a couple of times within the piece; that still counts as one move.
 
 ---
 
@@ -46,7 +46,7 @@ Vary sentence length hard. Follow a long, winding sentence with a two-word one. 
 
 Open a sentence with a conjunction when you want a beat before the turn. The period-then-"But" lands harder than a comma.
 
-**Why it's human:** it mimics how a thought arrives, as a continuation of the last one. Two or three per piece, max; constant use is sloppy, not casual.
+**Why it's human:** it mimics how a thought arrives, as a continuation of the last one. If you pick this move, two or three uses is its ceiling; constant use is sloppy, not casual.
 
 - "We had the data the whole time. But nobody had put it on one slide."
 - "So we stopped guessing and asked the client what they actually measured."

--- a/skills/gali-firon/human-mannerisms/references/move-library.md
+++ b/skills/gali-firon/human-mannerisms/references/move-library.md
@@ -1,0 +1,85 @@
+# Move library — the human moves, with specimens
+
+The eight moves that put a specific person back into flat copy. Each entry: what it is, why it reads as human, how to place it, and multiple specimens. Pull one or two per piece. Never all of them.
+
+---
+
+## 1. The mid-sentence aside
+
+Drop a short comment into the middle of a line, in parentheses or between commas, that steps outside the main point to be dry, to exaggerate, or to say the quiet part.
+
+**Why it's human:** it reveals a point of view that isn't strictly necessary to the argument. A machine optimises the sentence so every clause is load-bearing; a person can't resist the side comment. The unnecessary bit is the human bit.
+
+**How to place it:** once per piece, let a real reaction interrupt the sentence. Keep it short. It should feel tossed off, not staged.
+
+- "We ran it for six weeks (which, in ad-tech time, is roughly a geological era) and the numbers held."
+- "The client wanted 'something viral', of course they did, so we started with what actually moves the metric."
+- "It works. Not in a demo-day way, in a boring-Tuesday-it-just-runs way."
+
+## 2. Undercut your own big statement
+
+Make a confident claim, then immediately deflate it with something small, dry, or self-aware.
+
+**Why it's human:** AI inflates stakes and leaves them inflated. A person builds a claim and then punctures it. The puncture is the credibility.
+
+- "This changed how we think about reach. Also it took four people and a spreadsheet nobody wants to maintain."
+- "It's the best tool we've built. Low bar, given the last one."
+
+## 3. Oddly specific real detail
+
+Reach for the weirdly exact, true detail instead of the smooth generic one. Not "we saw strong engagement" but the precise concrete thing no one would bother to invent.
+
+**Why it's human:** AI generates plausible averages. Real specifics you actually have read as lived. This is the inverse of fabricated specificity: use only what is true.
+
+- "Fill rate dropped the Tuesday after the holiday, 11%, and nobody noticed until Thursday."
+- "The winning ad had a llama in it. I don't know why. It just did."
+
+## 4. Short. Then shorter.
+
+Vary sentence length hard. Follow a long, winding sentence with a two-word one. Let a fragment stand alone for rhythm.
+
+**Why it's human:** rhythm is how a voice sounds out loud. The variation is the pulse. AI defaults to sentences of similar length - the monotone hum that reads as machine-set even when every sentence is fine.
+
+- "We tested six headlines, moved budget three times, argued about the CTA for a full afternoon, and shipped on a Friday against everyone's better judgment. It worked. Go figure."
+
+## 5. Start on And / But / So
+
+Open a sentence with a conjunction when you want a beat before the turn. The period-then-"But" lands harder than a comma.
+
+**Why it's human:** it mimics how a thought arrives, as a continuation of the last one. Two or three per piece, max; constant use is sloppy, not casual.
+
+- "We had the data the whole time. But nobody had put it on one slide."
+- "So we stopped guessing and asked the client what they actually measured."
+
+## 6. Talk to one person
+
+Write to a single reader - a specific colleague, a friend - not to "an audience". Contractions, "you", the occasional direct address.
+
+**Why it's human:** voice is a two-person thing. The moment you picture one reader, the register drops into something real.
+
+- "You know the deck I mean. The one with forty slides and no argument."
+
+## 7. Self-interruption mid-thought
+
+Change direction inside the sentence. Start to say one thing, stop, say the truer thing.
+
+**Why it's human:** AI delivers finished thoughts. People revise in real time, on the page. The visible seam is the humanness.
+
+- "The problem is the copy - okay, two problems, the copy and the fact that no one approved it."
+- "I wanted to call it a strategy. It was three good instincts in a trench coat."
+
+## 8. Deadpan the absurd
+
+State something ridiculous or frustrating in a completely flat, casual tone. No exclamation, no signposting the joke.
+
+**Why it's human:** AI signposts humour ("funnily enough...") or over-sincerely avoids it. Dry delivery trusts the reader to catch it - a trust machine copy rarely extends.
+
+- "The brief was two words and a deadline. We made it work, as one does."
+
+---
+
+## Placement notes
+
+- Match the move to the writer's real register. A dry, numbers-first operator gets the undercut and the deadpan; a warmer voice gets the aside and the direct address. Forcing a whimsical aside onto a blunt writer reads as a costume.
+- The middle of a piece is where copy goes flat and where a move earns its place. Openers and closers usually carry more attention already.
+- If you can only find a spot for a move by inventing a detail, stop. No move is worth a fabricated specific.

--- a/skills/gali-firon/human-mannerisms/references/move-library.md
+++ b/skills/gali-firon/human-mannerisms/references/move-library.md
@@ -1,6 +1,6 @@
 # Move library — the human moves, with specimens
 
-The eight moves that put a specific person back into flat copy. Each entry: what it is, why it reads as human, how to place it, and multiple specimens. Pull one or two distinct moves per piece, never all of them. A single move may recur a couple of times within the piece; that still counts as one move.
+The eight moves that put a specific person back into flat copy. Each entry: what it is, why it reads as human, how to place it, and multiple specimens. Pull one or two distinct moves per piece, never all of them. A single move-type may recur two or three times within the piece and still count as one move. The one exception is the mid-sentence aside (move 1): use it at most once per piece.
 
 ---
 
@@ -10,7 +10,7 @@ Drop a short comment into the middle of a line, in parentheses or between commas
 
 **Why it's human:** it reveals a point of view that isn't strictly necessary to the argument. A machine optimises the sentence so every clause is load-bearing; a person can't resist the side comment. The unnecessary bit is the human bit.
 
-**How to place it:** once per piece, let a real reaction interrupt the sentence. Keep it short. It should feel tossed off, not staged.
+**How to place it:** at most once per piece (this is the one move that does not recur), let a real reaction interrupt the sentence. Keep it short. It should feel tossed off, not staged.
 
 - "We ran it for six weeks (which, in ad-tech time, is roughly a geological era) and the numbers held."
 - "The client wanted 'something viral', of course they did, so we started with what actually moves the metric."

--- a/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
+++ b/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
@@ -1,6 +1,6 @@
 # Pairing and order — how this pass fits with tell-stripping
 
-This skill is one half of a two-pass editing standard. The other half strips AI tells (the "anti-slop" pass). They are not interchangeable, and the order is not optional.
+This skill is one half of a two-pass editing standard. The other half strips AI tells (the anti-ai-slop-writing pass). They are not interchangeable, and the order is not optional.
 
 ## The two-zero model
 

--- a/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
+++ b/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
@@ -1,0 +1,39 @@
+# Pairing and order — how this pass fits with tell-stripping
+
+This skill is one half of a two-pass editing standard. The other half strips AI tells (the "anti-slop" pass). They are not interchangeable, and the order is not optional.
+
+## The two-zero model
+
+- **Tell-stripping gets copy to zero.** After it, nothing in the piece screams machine: no negative parallelism ("it's not X, it's Y"), no false-suspense transitions ("here's the thing"), no grandiose stakes, no formulaic openers, no em-dash addiction. The copy is clean.
+- **This pass gets copy above zero.** Clean is not the same as human. "Flawless and flat" is itself a recognisable AI signature - copy that is technically perfect and has no point of view. This pass adds one or two deliberate human moves so a specific person is visibly present.
+
+Both matter. Clean copy with no texture still reads as AI. Textured copy that still has rhetorical tells reads as an AI trying to sound casual, which is worse.
+
+## Why the order is fixed
+
+Run tell-stripping first, this pass second.
+
+If you add human moves to copy that still carries AI tells, the moves make the tells louder, not quieter - a mid-sentence aside sitting next to a "here's what nobody tells you" transition just draws attention to the transition. Strip the machine patterns to a clean baseline, then add texture to that baseline.
+
+## The failure modes this pairing prevents
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Reads as AI, smooth and lifeless | Only tell-stripping ran; no texture added | Run this pass; add one or two moves |
+| Reads as AI "doing casual", overwrought | This pass ran without stripping, or too many moves | Strip first; cut back to one or two moves |
+| Reads as a costume, not the writer | Moves don't match the writer's register | Match dry moves to dry writers, warm to warm |
+| Reads as fabricated | Specificity move used invented detail | Use only true detail, or drop the move |
+
+## What this pass is NOT
+
+- **Not a checklist to apply all at once.** One or two moves per piece. A wall of quirks is try-hard slop.
+- **Not a licence to invent.** The specificity move uses only real, true detail; fabricated specifics are still a hard failure.
+- **Not a replacement for tell-stripping.** Strip the tells first, then add the texture. A piece that skips the first pass is not ready for this one.
+
+## Quick sequence
+
+1. Draft.
+2. Strip AI tells to a clean baseline.
+3. Read once, find the flat stretch.
+4. Add one or two moves from the move library, matched to the writer.
+5. Read aloud. One moment should sound like a specific person. If not, adjust. If it now sounds try-hard, cut back.

--- a/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
+++ b/skills/gali-firon/human-mannerisms/references/pairing-and-order.md
@@ -24,6 +24,8 @@ If you add human moves to copy that still carries AI tells, the moves make the t
 | Reads as a costume, not the writer | Moves don't match the writer's register | Match dry moves to dry writers, warm to warm |
 | Reads as fabricated | Specificity move used invented detail | Use only true detail, or drop the move |
 
+One row above needs a carve-out: "smooth and lifeless" is only a problem for voice-forward copy. Formal, compliance, or technical copy is *supposed* to read clean and plain - it correctly stops after the tell-stripping pass, and this pass should not run on it. Do not add casual texture to writing meant to stay plain; smooth-and-neutral is the target there, not a failure.
+
 ## What this pass is NOT
 
 - **Not a checklist to apply all at once.** One or two moves per piece. A wall of quirks is try-hard slop.


### PR DESCRIPTION
## Skill: human-mannerisms

First submission from a new creator (`skills/gali-firon/`), so this PR includes `author.md`.

**What it does:** the positive half of a two-pass copy-editing standard. Where a de-AI pass strips machine tells to get copy "to zero", this pass adds one or two deliberate human moves to get it "above zero", so GTM copy reads as one specific person rather than a competent machine. Production-tested on LinkedIn posts, cold emails, newsletters, and exec thought leadership.

**Files:**
- `author.md` (first submission)
- `human-mannerisms/SKILL.md` — ~840-word spine, `## What good looks like` included
- `references/move-library.md` — the eight moves with multiple specimens, why each reads as human, and placement notes
- `references/pairing-and-order.md` — how this pass pairs with tell-stripping, the two-zero model, failure-mode table

### Review-gate checklist
- **Convention:** `node tools/validate.mjs` passes. `name` == folder name, kebab-case, unique. No lifecycle/operational fields.
- **Security:** no endpoints, secrets, third-party URLs, prompt-injection, or destructive/bulk actions. This is a pure prose-editing judgment skill with no side effects.
- **Judgment, not steps:** the skill is built around what a good editor notices first (flatness = absence of POV), the common mistake (applying every move at once), and a concrete "how you know it worked" (read aloud).
- **Tool-agnostic:** no vendor tool names; no dates or "recently"; no first-person plural.
- **Author identity:** real person, own LinkedIn profile, public work email. `avatarUrl` omitted — OK to re-host my LinkedIn photo per the author.md rules.

**Note on category:** used `Positioning` as the closest existing category for a voice/copy-craft skill; happy to move it if you'd prefer a different home. Three related skills (a de-AI tell-stripping pass, an exec LinkedIn engine, and a journalist-outreach play) are ready to follow in separate PRs.