### PR TITLE
add multi-account-content-fleet by vesselin-malev

### DIFF
--- a/skills/vesselin-malev/author.md
+++ b/skills/vesselin-malev/author.md
@@ -1,0 +1,9 @@
+---
+name: "Vesselin Malev"
+title: "Managing Director, The Demand Department"
+linkedinUrl: "https://www.linkedin.com/in/vesselinmalev/"
+companyDomain: demanddept.com
+email: office@demanddept.com
+---
+
+Vesselin Malev runs The Demand Department, where outbound, inbound, and conversion operate as one system rather than three teams. His earlier growth work sits behind crypto exchanges and Web3 media. He also holds operating ownership in B2B services, real estate, and consumer brands, and the firm's clients include YC-backed founders and category-leading tools.

--- a/skills/vesselin-malev/multi-account-content-fleet/SKILL.md
+++ b/skills/vesselin-malev/multi-account-content-fleet/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: multi-account-content-fleet
+title: Multi-account content fleet
+description: |
+  Use this skill when two or more accounts inside one company publish on a shared content calendar:
+  a founder plus two AEs, a leadership team, an employee advocacy roster, a set of operator voices.
+  Produces the lane map, per-account voice sheets, cadence plan, and engagement rules the fleet runs on.
+  Covers running multiple LinkedIn accounts without them sounding the same, splitting topics across
+  people, staggering posting windows, avoiding reciprocal engagement patterns, and diagnosing a
+  fleet-wide decline where every account drops at once.
+category: Influencers
+tags: [Demand Gen, Marketing]
+---
+
+# Multi-account content fleet
+
+Applies when two or more accounts in one company publish on a shared calendar. Produces the lane map, per-account voice sheets, cadence plan, and engagement rules the fleet runs on.
+
+A fleet exists to build differentiated surface area. Every decision below either protects that asset or spends it.
+
+## Assign lanes before writing anything
+
+Each account owns a topic lane and a point of view tied to that person's real role and lived work. The lane map decides who covers what, where lanes may touch, and which overlaps are scheduled on purpose, such as a launch week.
+
+The mediocre version drafts a batch of posts and distributes them round-robin with light rewording. The shared audience then sees the same idea from five faces in one week, and every account pays for it.
+
+Lane assignment happens once, up front, and gets revisited quarterly. Building the map, and the rules for when lanes may legitimately touch, is in `references/lane-map.md`.
+
+## Give every account a fingerprint
+
+One page per person: rhythm, lexicon, hard rules, and a bank of their real anecdotes.
+
+Batch production is fine. Batch sameness is what kills fleets, and it enters through shared hooks, shared structures, and shared examples, never through the calendar itself.
+
+The anecdote bank is the part that gets skipped and the part that does the most work. A person's actual stories cannot be generated, which makes them the one component of a voice that survives scale. Collect them in an interview, not from a questionnaire. The full voice sheet spec is in `references/voice-sheet.md`.
+
+## Stagger the surface
+
+Different posting windows per account. Different format mix on any given day, so the fleet never ships five text posts at 9am.
+
+Shared proof points get a different framing per account, angled through that person's lane. A customer result belongs to whoever's lane it lands in, told from that person's vantage. One calendar, N voices.
+
+Window assignment and format rotation are in `references/cadence-and-format-mix.md`.
+
+## Choreograph engagement
+
+Fleet accounts stay off each other's posts in the first hours and never form a visible closed circle of mutual likes.
+
+Each account engages outward in its own lane, where its audience actually is. Reciprocal fleet engagement reads as coordinated from a mile away, to people and to the feed. It also wastes the engagement, since it lands on an audience that already overlaps.
+
+Outward engagement in-lane is the highest-return activity a fleet account does, and it is the first thing cut when the calendar gets tight. Protect it.
+
+## Watch correlation, not averages
+
+Track a per-account impressions baseline. Independent movement is health.
+
+All accounts rising and falling together means the fleet shares a signature, some structure, template, or timing pattern that the feed has priced in. Averages hide this completely, which is why a fleet dashboard that reports fleet-wide totals will never surface the problem.
+
+When correlated decline hits, stop diagnosing individual posts and hunt the shared element: same hook shapes, same formatting, same production batch, same posting window. Break the shared element first, then re-baseline. The diagnostic procedure is in `references/correlation-diagnostics.md`.
+
+## What good looks like
+
+The best operator checks the lane map and the correlation chart before judging any single post. The mediocre version optimizes posts one at a time while the fleet-wide signature does the damage.
+
+The common mistake is efficiency worship. Every optimization that increases sameness across accounts spends the exact asset a fleet exists to build, which is differentiated surface area.
+
+The output is good when each account grows on its own curve, inbound treats each person as an individual authority, and the accounts read as colleagues who think differently rather than one template wearing several names.
+
+## Rules
+
+- MUST assign every account a distinct lane and voice sheet before production starts.
+- MUST stagger timing and vary format mix across the fleet on any given day.
+- MUST build each voice sheet on that person's real role, work, and anecdotes.
+- NEVER publish the same idea across accounts in the same window unless the overlap is a planned campaign.
+- NEVER allow a reciprocal engagement pattern between fleet accounts.
+- NEVER judge fleet health on averages. Correlation is the signal.

--- a/skills/vesselin-malev/multi-account-content-fleet/references/cadence-and-format-mix.md
+++ b/skills/vesselin-malev/multi-account-content-fleet/references/cadence-and-format-mix.md
@@ -1,0 +1,48 @@
+# Cadence and format mix
+
+One calendar, N voices. The calendar coordinates topics. Everything a reader perceives, timing, format, and framing, is assigned per account.
+
+## Posting windows
+
+Assign each account a standing window and hold it. Two purposes: the account's own audience learns when to expect it, and the fleet stops arriving as a block.
+
+- Separate accounts by at least 90 minutes on any day where more than one publishes.
+- Never publish two fleet accounts inside the same 30-minute window, on any day, for any reason.
+- Windows are per-account properties, not per-post decisions. A window that moves every week is not a window.
+- Cap the fleet at two accounts publishing per day in a fleet of five or more. Everyone posting daily produces a wall, and the shared audience sees the wall rather than the posts.
+
+Launch weeks are the exception, and the overlap is scheduled in the lane map with a per-account angle assigned in advance.
+
+## Format mix
+
+The rule is that the fleet never ships five of the same format on one day.
+
+Rotate across whatever the platform offers: plain text, image, carousel or document, video, poll, longer-form article, comment-led participation on someone else's post. Assign each account a primary format it is known for and a secondary it rotates in.
+
+- Track format at the fleet level per day, not per account. Two accounts individually varied can still both post carousels on Tuesday.
+- A person's primary format should suit them. Someone who is uncomfortable on video producing weekly video is a worse asset than the same person writing well.
+- Format is a differentiator readers register before they read a word. It is the cheapest variation available and the most commonly wasted.
+
+## Shared proof points
+
+A customer result, a company milestone, a benchmark, a launch. These are the highest-risk items in a fleet, because the temptation is to give everyone the same asset.
+
+Assign a shared proof point through the lane map:
+
+1. It belongs primarily to whoever's lane it lands in. That account tells it fully.
+2. Other accounts may reference it only from their own vantage, and only if their lane gives them one. The Head of Demand talks about what the result cost to produce. The CSM talks about what the customer did in week two.
+3. No account reuses another's framing, opening, or the same number as its headline claim.
+4. Spread references across at least a week. Same-day multiplication is the single most recognizable fleet pattern.
+
+An account with no genuine angle on a proof point skips it. Skipping is free. A visibly borrowed take costs that account's standing.
+
+## Production hygiene
+
+Batch production is fine and usually necessary. The risks are structural and enter in specific places:
+
+- **Same drafter, same session.** A writer producing five accounts in one sitting will converge them, regardless of the voice sheets. Split by account across sessions, or by day.
+- **Shared hook bank.** The fastest route to a fleet signature. Hooks come from the account's own anecdote bank.
+- **Shared templates.** A house post structure applied across accounts creates the exact correlated pattern the diagnostics chapter hunts. If a template exists, it is per-account.
+- **Same approval pass.** One editor smoothing every post toward their own preference undoes the sheets. Editors check against the account's voice sheet, not against each other.
+
+Stagger the production batch from the publish date so posts are not written and shipped in the same rhythm. Batched writing plus batched shipping compounds the signature.

--- a/skills/vesselin-malev/multi-account-content-fleet/references/correlation-diagnostics.md
+++ b/skills/vesselin-malev/multi-account-content-fleet/references/correlation-diagnostics.md
@@ -1,0 +1,48 @@
+# Correlation diagnostics
+
+Fleet health is a correlation question, not an average question. A dashboard reporting fleet-wide totals will never surface the failure this chapter describes.
+
+## The baseline
+
+Per account, track a rolling median of impressions per post over the trailing 10 posts. Median, not mean, because one outlier post distorts a mean for weeks and hides the trend underneath.
+
+Record alongside it: posting window, format, and topic lane. Diagnosis needs these attached, and reconstructing them after the fact is where most fleet analysis stalls.
+
+Re-baseline after any deliberate change to lanes, cadence, or production process. Comparing across a process change produces a number that means nothing.
+
+## Reading the chart
+
+Plot every account's baseline on one chart.
+
+**Independent movement is health.** Accounts rising and falling on their own schedules means each is being judged on its own merits. Expect this to look messy. Messy is the goal.
+
+**Correlated movement is the alarm.** All accounts moving together, up or down, means the fleet shares a signature that the feed has priced in. The direction matters less than the correlation. Correlated rises are equally diagnostic, and they usually precede a correlated fall, because the shared element that worked is the shared element that gets discounted.
+
+**One account diverging** is an account-level issue. Check its lane, its cadence, its recent format changes. This is the only case where post-by-post analysis is the right tool.
+
+## When correlated decline hits
+
+Stop diagnosing individual posts. Post-level analysis on a correlated decline produces plausible explanations for every post and fixes nothing, because the cause is not in any post. It is in what they share.
+
+Hunt the shared element in this order, cheapest to break first:
+
+1. **Posting window.** Did windows drift together? Did a scheduling tool normalize them?
+2. **Format.** Pull the last 20 posts fleet-wide. What percentage are one format? Above 60% is a signature.
+3. **Hook shape.** Read only the first lines, all accounts, stripped of names. If they are interchangeable, that is the answer.
+4. **Formatting.** Line break patterns, emoji use, bold conventions, list structure. These converge silently because they come from whoever is doing production.
+5. **Production batch.** Were these written in one session by one person? Check the calendar, not people's memories.
+6. **Topic.** Did the lanes collapse toward whatever is hot in the category?
+
+Break one element at a time and give it three posts per account before judging. Breaking several at once means learning nothing about which mattered, and fleets tend to repeat the same convergence.
+
+## After the break
+
+Re-baseline from scratch. The old baseline described a fleet with the shared element in it and is no longer a comparison.
+
+Expect the corrected accounts to separate before they recover. Divergence is the first sign the fix worked, and it usually shows up a cycle before the numbers do. An operator who judges the fix on impressions alone will abandon it too early.
+
+## The trap
+
+The most common failure is optimizing toward whatever the best-performing account does. It is a reasonable instinct and it produces the exact signature this chapter is about. Every account adopting the winner's hook shape converges the fleet within a month, and the winner's numbers fall with everyone else's.
+
+When one account outperforms, copy the principle, never the pattern. If it is winning because it tells specific customer stories, other accounts should tell their own specific stories from their own banks. They should not adopt its opening line, its structure, or its posting time.

--- a/skills/vesselin-malev/multi-account-content-fleet/references/lane-map.md
+++ b/skills/vesselin-malev/multi-account-content-fleet/references/lane-map.md
@@ -1,0 +1,47 @@
+# The lane map
+
+One document, built before any post is drafted, that assigns every account a topic territory and a point of view. It is the single artifact that prevents round-robin distribution.
+
+## What a lane is
+
+A lane has three parts, and all three are required:
+
+**Territory.** The subject matter this account covers. Narrow enough that a reader can state it after seeing three posts.
+
+**Point of view.** The position this person holds inside that territory. Two people can both cover pricing; one thinks usage-based billing is inevitable and the other thinks it destroys forecastability. That disagreement is the asset.
+
+**Standing.** Why this person specifically can say it. Their role, their scars, the thing they shipped. A lane without standing produces posts that anyone could have written, which is the failure the fleet exists to avoid.
+
+Territory alone is not a lane. Two accounts assigned "demand gen" and "content" will converge within a month, because the territories overlap and nothing distinguishes the takes.
+
+## Building it
+
+1. **Inventory the people.** Real role, tenure, what they actually do in a week, what they argue about internally. Internal arguments are the richest source of points of view, because they are positions the person already holds and can defend.
+
+2. **Draw territories from the work, not the market map.** Assigning lanes by keyword coverage produces accounts writing outside their competence, and readers detect it immediately. Start from what each person genuinely does, then check the coverage gaps.
+
+3. **Force the disagreements.** Where two lanes touch, name the tension explicitly. A fleet where the VP Sales and the Head of Product publicly disagree about discounting is more credible than one where every account agrees, and it gives both accounts recurring material.
+
+4. **Mark the deliberate overlaps.** Launch weeks, a shared customer story, a company milestone. These are scheduled, named, and given a per-account angle in advance. Unplanned overlap is the failure mode; planned overlap is a campaign.
+
+5. **Record the exclusions.** What each account does not post about, including topics that belong to someone else's lane. Exclusions do more work than inclusions, because the pressure in a fleet is always toward everyone covering the hot topic.
+
+## Worked example: a five-account fleet
+
+| Account | Territory | Point of view | Standing |
+|---|---|---|---|
+| Founder | Category and market direction | The category is consolidating faster than analysts think | Runs the roadmap, talks to acquirers |
+| VP Sales | Enterprise deal mechanics | Discounting is a symptom of weak qualification | Closed the last 40 enterprise deals |
+| Head of Product | Build tradeoffs and roadmap | Most feature requests are workflow problems | Owns what ships and what does not |
+| Head of Demand | Channel economics | Paid social is mispriced for B2B right now | Owns the budget and the CAC number |
+| Senior CSM | Post-sale reality | Churn is decided in week two, not month eleven | Sits with customers daily |
+
+Where they touch, on purpose: the VP Sales and Head of Demand disagree publicly about lead quality. The Founder and Head of Product both cover roadmap during launch weeks, from strategy and from tradeoffs.
+
+Where they must not touch: only the Senior CSM posts customer stories in the CSM's own accounts. Only the Head of Demand posts channel numbers.
+
+## Review cadence
+
+Revisit quarterly, and immediately when someone changes role. A lane tied to a job the person no longer does produces posts with no standing behind them, and standing is the part readers actually respond to.
+
+When two accounts start drifting into the same territory, the fix is a lane adjustment, not a content note. Content notes decay within two cycles.

--- a/skills/vesselin-malev/multi-account-content-fleet/references/voice-sheet.md
+++ b/skills/vesselin-malev/multi-account-content-fleet/references/voice-sheet.md
@@ -1,0 +1,62 @@
+# The voice sheet
+
+One page per account. Built from an interview, not a questionnaire. Loaded before any draft is written for that person.
+
+Keep it to a single page. A voice sheet long enough to require reading rather than skimming stops getting used, and an unused voice sheet is how a fleet converges.
+
+## The four sections
+
+### Rhythm
+
+How this person's sentences actually move.
+
+- Typical, shortest, and longest sentence length, counted from real samples.
+- Whether they fragment, and how often.
+- Paragraph length. One-liners or blocks.
+- How they open: question, claim, number, scene, or anecdote. Record the distribution across their last ten pieces, not the one you like best.
+- How they close: next action, callback, blunt stop, or question.
+
+### Lexicon
+
+- Words they use that others in the fleet do not.
+- Words they never use. This list prevents drift more reliably than the first one.
+- Jargon tolerance. Do they say ARR or revenue, ICP or the people we sell to.
+- Formality and profanity level.
+- Their standard analogies and the examples they return to.
+
+### Hard rules
+
+Per-person constraints that override any house style:
+
+- Formatting they refuse. No emoji, no bold, no bullet lists.
+- Topics they will not touch, including anything under legal or HR sensitivity.
+- Claims they cannot make given their role. A CSM cannot announce roadmap.
+- Disclosure requirements. When affiliation gets stated and how directly.
+
+### The anecdote bank
+
+The section that gets skipped, and the one that does the most work.
+
+Twenty to forty real stories from this person's actual work, each recorded in three or four lines: what happened, who was involved, the specific number or detail, and what it taught them.
+
+A person's actual stories cannot be generated. That makes the bank the one component of voice that survives batch production intact. A fleet running on generated examples converges no matter how carefully the rhythm and lexicon are documented, because the examples are where sameness enters first.
+
+Refill the bank quarterly in a 30-minute conversation. Banks run dry faster than anyone plans for, and a dry bank is the moment an account starts sounding like the others.
+
+## Sourcing
+
+Collect 5 to 10 genuine samples per person, written before any assisted drafting. Mixing assisted and unassisted samples corrupts the sheet, because habits picked up from a model get recorded as the person's voice and then defended on every future draft.
+
+If someone has never written publicly, run the interview and transcribe. Speech patterns transfer to the page better than an invented style does.
+
+## Using it
+
+Load the sheet before drafting, not after. A draft written without it and then corrected against it keeps the structure it was born with, and structure is what readers register.
+
+When the sheet and a fleet-wide style guide disagree, the sheet wins. That is its entire purpose.
+
+## Drift check
+
+Once a quarter, pull three recent posts per account, strip the names, and ask someone who knows the team to attribute them. Attribution at better than chance across the fleet means the sheets are holding. At chance, the fleet has converged and the sheets need rebuilding from fresh samples.
+
+Run the same check whenever a new drafter joins the production process. Convergence usually enters with a new writer working from the calendar instead of the sheets.


### PR DESCRIPTION
## What this skill does

Covers what happens after a company has two or more accounts publishing on one calendar: the lane map that assigns each account a topic territory, point of view, and standing; per-account voice sheets built on that person's real work and anecdotes; a cadence plan that staggers windows and format mix; and engagement rules that keep fleet accounts out of reciprocal patterns.

The load-bearing idea is that fleet health is a correlation question, not an average one. When every account rises and falls together, the fleet shares a signature — a hook shape, a template, a production batch, a posting window — and post-by-post analysis will never find it. `references/correlation-diagnostics.md` carries the hunt procedure and the re-baselining rule.

## Relationship to existing skills

Adjacent to `founder-employees-or-creators`, which decides *who* should carry distribution. This one starts after that decision, when N accounts already exist and the problem is keeping them differentiated. No overlap in procedure or output.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

**Note on `author.md`:** identical to the copy in #75. Whichever merges first makes it a no-op for the other.

**Note on the avatar:** `avatarUrl` is omitted so maintainers can pull the LinkedIn profile photo per AGENTS.md.
