### PR TITLE
add founder-persona-ops by vesselin-malev

### DIFF
--- a/skills/vesselin-malev/author.md
+++ b/skills/vesselin-malev/author.md
@@ -1,0 +1,9 @@
+---
+name: "Vesselin Malev"
+title: "Managing Director, The Demand Department"
+linkedinUrl: "https://www.linkedin.com/in/vesselinmalev/"
+companyDomain: demanddept.com
+email: office@demanddept.com
+---
+
+Vesselin Malev runs The Demand Department, where outbound, inbound, and conversion operate as one system rather than three teams. His earlier growth work sits behind crypto exchanges and Web3 media. He also holds operating ownership in B2B services, real estate, and consumer brands, and the firm's clients include YC-backed founders and category-leading tools.

--- a/skills/vesselin-malev/founder-persona-ops/SKILL.md
+++ b/skills/vesselin-malev/founder-persona-ops/SKILL.md
@@ -53,7 +53,7 @@ The story bank is what makes volume possible without fiction. It is the differen
 
 Batch drafts. One approval touchpoint a week. Target under 30 minutes of founder time, because approval friction is the number one killer of consistency.
 
-Track edit rate, the share of drafts approved untouched. Falling means calibration is working. Rising means voice drift, so go back to the corpus and re-extract rather than absorbing the edits one at a time.
+Track edit rate, the share of drafts the founder changes before approving. Falling means calibration is working. Rising means voice drift, so go back to the corpus and re-extract rather than absorbing the edits one at a time.
 
 Under 10 percent after the first month is the working target. An engagement that needs an hour of founder time a week will quietly stop getting it, and the posts stop with it.
 

--- a/skills/vesselin-malev/founder-persona-ops/SKILL.md
+++ b/skills/vesselin-malev/founder-persona-ops/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: founder-persona-ops
+title: Founder persona ops
+description: |
+  Use this skill when someone else's name goes on the content and their reputation rides on it:
+  ghostwriting a founder's LinkedIn, running an executive's personal brand, operating a CEO's
+  thought leadership program. Produces the written operating agreement and running cadence the
+  engagement runs on. Covers approval boundaries and escalation, voice intake, mining real stories
+  instead of inventing them, keeping founder time under 30 minutes a week, tracking edit rate,
+  and working the comments and DMs where the pipeline actually forms.
+category: Influencers
+tags: [Marketing, Leadership]
+---
+
+# Founder persona ops
+
+Applies when someone else's name goes on the content and their reputation rides on it. Produces the written operating agreement and running cadence for the engagement.
+
+The content is the founder's substance. The operation is what makes that true at volume.
+
+## Set boundaries before content
+
+Agree in writing what publishes autonomously and what always needs sign-off:
+
+- Numbers and client names.
+- Opinions about named people.
+- Anything touching the client's regulated ground: medical, financial, legal claims.
+- Any reply to a journalist or an angry customer.
+
+Define escalation triggers and who gets pinged. The mediocre version starts writing posts on day one and discovers the boundaries through an incident.
+
+The agreement is a document, not an understanding. The sign-off matrix, escalation ladder, and the clauses that matter when something goes wrong are in `references/operating-agreement.md`.
+
+## Run intake once, properly
+
+Two assets come out of intake.
+
+First, the voice corpus, the genuine samples a fingerprint gets built from and every draft gets checked against.
+
+Second, a world bible: offers, clients that may be named, numbers that may be cited, collaborators, competitor policy, and the list of people and topics never to touch.
+
+The never-list saves the engagement more often than the rest combined. Both assets are specified in `references/intake-and-world-bible.md`.
+
+## Mine stories, never invent them
+
+Ghosts fabricate exactly nothing about lived experience. No invented anecdotes. No family moments. No opinions the founder has not voiced.
+
+Instead, run a short monthly story-mining call or collect voice memos, and bank real anecdotes with dates and sensory detail.
+
+The story bank is what makes volume possible without fiction. It is the difference between an account that compounds trust and one that eventually gets caught. When the bank runs dry, the correct response is to book another mining call, not to fill the gap. Running the call and structuring the bank is in `references/story-mining.md`.
+
+## Build a rhythm the founder can survive
+
+Batch drafts. One approval touchpoint a week. Target under 30 minutes of founder time, because approval friction is the number one killer of consistency.
+
+Track edit rate, the share of drafts approved untouched. Falling means calibration is working. Rising means voice drift, so go back to the corpus and re-extract rather than absorbing the edits one at a time.
+
+Under 10 percent after the first month is the working target. An engagement that needs an hour of founder time a week will quietly stop getting it, and the posts stop with it.
+
+## Operate the engagement layer
+
+Publishing is half the job.
+
+Comments get answered in-voice inside the first hour. DMs get triaged on a written split: the ghost handles logistics and thank-yous, the founder handles relationships, and qualified sales conversations route through the agreed handoff.
+
+The pipeline forms in comments and DMs. An engagement that ships posts while ignoring them is decorating a feed. The triage split and handoff rules are in `references/engagement-and-handoff.md`.
+
+## Two or more personas, one company
+
+Distinct lanes per persona. The same take never appears twice, even reworded. No reciprocal engagement pattern between them.
+
+Two leaders echoing each other reads as staged and burns both accounts.
+
+## What good looks like
+
+The best operator designs the approval loop and risk boundaries before drafting a single post. The mediocre version is a content vendor: posts delivered, engagement ignored, anecdotes invented when the calendar runs dry.
+
+The output is good when the founder spends under 30 minutes a week, edit rate sits under 10 percent after the first month, nothing has been walked back, and the audience treats the account as genuinely the founder.
+
+## Rules
+
+- MUST agree the sign-off boundaries and escalation triggers in writing before the first draft.
+- MUST build the voice corpus and world bible before production starts.
+- MUST source every anecdote from the founder's own account of it, with a date.
+- MUST keep approval batched to one weekly touchpoint under 30 minutes.
+- MUST track edit rate and re-extract from the corpus when it rises.
+- NEVER invent lived experience, or publish an opinion the founder has not voiced.
+- NEVER ship posts while leaving comments and DMs unworked.
+- NEVER allow a reciprocal engagement pattern between personas at the same company.

--- a/skills/vesselin-malev/founder-persona-ops/references/engagement-and-handoff.md
+++ b/skills/vesselin-malev/founder-persona-ops/references/engagement-and-handoff.md
@@ -1,0 +1,47 @@
+# Engagement and handoff
+
+Publishing is half the job. The pipeline forms in comments and DMs, and an engagement that ships posts while ignoring them is decorating a feed.
+
+Budget engagement time explicitly in the scope. It is the first thing cut when a week gets tight, and cutting it removes the part that produces revenue.
+
+## Comments
+
+Answered in-voice inside the first hour, on the founder's own posts.
+
+The first hour matters for two reasons. It is when the post is still being distributed, and it is when the people most likely to become conversations are reading. A reply the next day is a courtesy. A reply in the first hour is a conversation.
+
+- Replies follow the same fingerprint as the posts. A perfectly voiced post under a generic "Great point, thanks for sharing!" undoes itself.
+- Substantive disagreement gets a substantive answer, not a deflection. This is where credibility is actually built, and where most engagements go quiet.
+- Anything on the review tier in the operating agreement stays unanswered until cleared, including in replies. The boundaries do not weaken below the post.
+- A journalist or an angry customer in the comments triggers escalation. Nothing is answered.
+
+Outward commenting on other people's posts, inside the founder's lane, is the highest-return activity available and the one most often skipped. Agree a weekly volume and hold it.
+
+## DM triage
+
+A written split, agreed in the operating agreement, so nothing waits on a judgment call.
+
+**Ghost handles:** logistics, scheduling, thank-yous, routine questions answered by public information, requests for a link or a resource, podcast and speaking inquiries up to the point of a commitment.
+
+**Founder handles:** anything relational. Old colleagues, investors, peers, anyone the founder knows personally, anyone offering something that needs a real judgment. A ghost answering a personal message from someone the founder knows is the fastest way to break the account's credibility, and it is unrecoverable with that person.
+
+**Routes to sales:** qualified buying conversations, through the agreed handoff below.
+
+**Escalates:** journalists, legal matters, complaints, anything touching the never-list, anything the ghost is unsure about. Unsure escalates by default.
+
+## The sales handoff
+
+Agree these four things before the first qualified DM arrives, because improvising the handoff in the moment is how a warm conversation goes cold.
+
+1. **The qualification bar.** What makes a DM a sales conversation rather than a networking one. Keep it low. Most inbound is unqualified and the cost of routing one extra is trivial next to missing a real one.
+2. **The transition line.** How the conversation moves from the founder's inbox to a rep, in the founder's voice, without the person feeling handed off. Usually an introduction rather than a redirect.
+3. **Where it goes.** The named person who picks it up, and the response window. A handoff to a shared inbox is a handoff to nobody.
+4. **What the founder stays in.** Some conversations should not leave the founder, and the bar for that is a judgment they set once, not per message.
+
+Log routed conversations somewhere both sides can see. Attribution for this channel is otherwise invisible, and invisible channels lose their budget.
+
+## Two or more personas
+
+Where a company runs several ghosted accounts, the engagement layer is where coordination becomes visible fastest.
+
+Fleet accounts stay off each other's posts in the first hours, and never form a visible pattern of mutual replies. Each account engages outward in its own lane, where its audience actually is. Two leaders echoing each other in each other's comments reads as staged and burns both accounts.

--- a/skills/vesselin-malev/founder-persona-ops/references/intake-and-world-bible.md
+++ b/skills/vesselin-malev/founder-persona-ops/references/intake-and-world-bible.md
@@ -10,7 +10,7 @@ Genuine samples the fingerprint gets built from and every draft gets checked aga
 
 **What to collect:**
 
-- 10 to 20 pieces the founder wrote themselves, unassisted. Posts, internal memos, long Slack messages, investor updates, conference talk transcripts.
+- 10 to 20 pieces the founder wrote themselves, unassisted. Posts, internal memos, long messages in the team chat, investor updates, conference talk transcripts.
 - Recordings of them talking about their work, unscripted. Podcast appearances are ideal. Speech patterns transfer to the page better than an invented style does.
 - Anything they have written that they dislike, with the reason. Negative examples calibrate faster than positive ones.
 

--- a/skills/vesselin-malev/founder-persona-ops/references/intake-and-world-bible.md
+++ b/skills/vesselin-malev/founder-persona-ops/references/intake-and-world-bible.md
@@ -1,0 +1,49 @@
+# Intake and the world bible
+
+Intake runs once, properly, before production. Two assets come out of it. Re-running intake later because it was rushed costs more than doing it slowly the first time, since every draft produced in between has to be re-checked.
+
+Budget two to three hours of founder time, once. This is the only large block the engagement should ever ask for.
+
+## Asset one: the voice corpus
+
+Genuine samples the fingerprint gets built from and every draft gets checked against.
+
+**What to collect:**
+
+- 10 to 20 pieces the founder wrote themselves, unassisted. Posts, internal memos, long Slack messages, investor updates, conference talk transcripts.
+- Recordings of them talking about their work, unscripted. Podcast appearances are ideal. Speech patterns transfer to the page better than an invented style does.
+- Anything they have written that they dislike, with the reason. Negative examples calibrate faster than positive ones.
+
+**What to extract:**
+
+- Rhythm: typical, shortest, and longest sentence length. Whether they fragment. Paragraph shape.
+- Openers and closers, as a distribution across the samples rather than a single preferred form.
+- Lexicon: words they use, words they never use, jargon tolerance, formality, profanity.
+- Formatting habits and refusals. Emoji, bold, lists, line breaks.
+- Their standard analogies and the examples they return to.
+
+Never mix assisted drafts into the corpus. Habits picked up from a model get recorded as the founder's voice and then defended on every future draft.
+
+Re-extract from the corpus when edit rate rises. Absorbing edits one at a time produces a voice that drifts toward the ghost's preferences without anyone deciding to.
+
+## Asset two: the world bible
+
+The facts the drafts are allowed to stand on.
+
+**Offers.** What the company sells, at what price points, to whom, in the founder's own framing. Include what they do not sell, which is the more common source of an inaccurate post.
+
+**Nameable clients.** An explicit list of clients that may be named, and under what conditions. Default is that nobody is nameable until they are on the list. Note any that may be described but not named.
+
+**Citable numbers.** Every metric the founder is willing to state publicly, with the date it was true and the source. A number without a date becomes a liability the moment someone asks. Refresh the list quarterly.
+
+**Collaborators.** Partners, investors, advisors, portfolio companies. Who may be tagged, who may be mentioned, who prefers neither.
+
+**Competitor policy.** Whether competitors are named at all, named only neutrally, or engaged directly. Most engagements should pick one and hold it, because inconsistency here reads as opportunism.
+
+**The never-list.** People and topics that never appear under any circumstances. Former co-founders, live litigation, a family member's business, an industry fight the founder has decided to stay out of, politics, anything under NDA.
+
+The never-list saves the engagement more often than the rest of the bible combined. It is also the section founders fill in fastest, because they already know what it contains. Ask directly: who should never see their name here, and what topic would make you regret a post.
+
+## Maintenance
+
+The bible is a living document with one owner on each side. Update it when a client relationship changes, a number goes stale, or something joins the never-list. Anything added to the never-list applies retroactively to the drafts already in the queue, so check the queue at the same time.

--- a/skills/vesselin-malev/founder-persona-ops/references/operating-agreement.md
+++ b/skills/vesselin-malev/founder-persona-ops/references/operating-agreement.md
@@ -1,0 +1,52 @@
+# The operating agreement
+
+A written document, signed before the first draft. It exists so that the first difficult moment is a procedure rather than an argument.
+
+Engagements that skip it do not avoid the boundaries. They discover them through an incident, at the founder's expense.
+
+## The sign-off matrix
+
+Every category of content sits in one of three tiers. Assign all three before production starts.
+
+**Autonomous.** Publishes without review. Typically observational posts, industry commentary inside the agreed lane, and reshares with a take that follows the fingerprint. This tier is what makes the cadence survivable, so it should be the largest one by volume.
+
+**Review before publish.** Anything in these categories, without exception:
+
+- Numbers of any kind: revenue, headcount, growth rates, client results.
+- Named clients, partners, or investors.
+- Opinions about named people, including competitors and former employees.
+- Anything touching the founder's regulated ground: medical, financial, or legal claims.
+- Hiring, fundraising, or anything a reader could price as material news.
+- Posts that reference internal decisions not yet announced.
+
+**Founder writes or explicitly dictates.** Condolences, apologies, anything about a death or illness, public disagreements with a named person, and responses to a crisis. A ghost drafting these is a category error even when the voice is perfect.
+
+## Escalation triggers
+
+Name the trigger, the person pinged, and the response window. Vague escalation clauses fail precisely when they are needed.
+
+Standard triggers worth writing in:
+
+- A journalist comments or DMs. Nothing is answered. Ping the founder and whoever handles press, within the hour.
+- An angry customer posts publicly. Draft nothing. Route to whoever owns that relationship.
+- A post gets unusual negative velocity. Agree in advance what "unusual" means for this account, and who decides between leaving it, editing, and deleting.
+- A legal or regulatory word appears in a draft or a reply thread.
+- Anyone asks whether the founder writes the posts themselves. Agree the answer in advance, in writing, and let the founder set it.
+
+## The clauses that matter later
+
+**Deletion authority.** Who can delete a live post, and how fast. Usually both parties, no permission needed, questions afterward.
+
+**Account access.** Which credentials the ghost holds, under what arrangement, and the offboarding step that revokes them. Access lives in the client's own password management, never in a shared document or a message thread.
+
+**Attribution policy.** Whether the engagement is disclosed, to whom, and how the founder answers if asked directly. This is the founder's call and it belongs in writing, so nobody improvises it under pressure.
+
+**Approval defaults.** What happens when the founder does not respond by the deadline. Silence is not approval on anything in the review tier. Autonomous-tier content ships on schedule regardless.
+
+**Off-limits standing list.** Carried from the world bible. People and topics that never appear, whatever the news cycle does.
+
+**Termination and archive.** What happens to the story bank, the corpus, and the drafts when the engagement ends. The founder's own stories are the founder's.
+
+## Review
+
+Revisit the matrix quarterly and after any incident. Most engagements find that the autonomous tier can safely grow over time as calibration improves, and that one or two categories need to move the other way. Both moves are signs the agreement is working.

--- a/skills/vesselin-malev/founder-persona-ops/references/story-mining.md
+++ b/skills/vesselin-malev/founder-persona-ops/references/story-mining.md
@@ -1,0 +1,54 @@
+# Story mining
+
+The story bank is what makes volume possible without fiction. Every anecdote that publishes comes out of it, and everything in it came from the founder's own account of something that happened.
+
+## The rule
+
+Ghosts fabricate exactly nothing about lived experience. No invented anecdotes. No composite customers presented as one. No family moments. No opinions the founder has not voiced. No numbers that did not come from the world bible.
+
+This is not a stylistic preference. An account that publishes invented experience is one screenshot away from a correction the founder has to make personally, and the audience that punishes it is the same audience the engagement exists to build.
+
+When the bank runs dry, book another mining call. Do not fill the gap. A week of observational posts inside the lane costs nothing. A fabricated anecdote costs the engagement.
+
+## The monthly call
+
+Thirty minutes, recorded, once a month. Protect it in the calendar the way the weekly approval touchpoint is protected, because it is the input that makes the approval touchpoint fast.
+
+Questions that produce usable material:
+
+- What went wrong this month, and what did you do about it?
+- What did a customer say that surprised you, and roughly when?
+- What did you change your mind about?
+- What decision are you still unsure about?
+- Who did you disagree with internally, and what was the argument?
+- What did you say in a meeting that you would say publicly?
+- What are you tired of hearing in this market?
+
+Follow every answer with the specifics: when, who else was in the room, what number was on the screen, what it felt like. The details are what make the story unusable by anyone else, which is exactly why they are worth collecting.
+
+## Voice memos between calls
+
+Give the founder one channel for unstructured capture, and keep it frictionless. Most will not use it consistently, which is fine. The monthly call is the reliable input; memos are the bonus.
+
+Prompt them when something visible happens: a launch, a churned account, a conference, a hard conversation. A single prompt within a day of the event returns more than a general standing request.
+
+## Banking a story
+
+Each entry, three or four lines:
+
+- **What happened**, in the founder's own words where possible.
+- **When**, with an actual date. Undated stories drift into "recently" and then into inaccuracy.
+- **Who was involved**, and whether they are nameable per the world bible.
+- **The specific detail**: the number, the exact phrase someone used, the thing on the screen.
+- **What it taught them**, which is the part that becomes the post's point.
+- **Clearance**: publishable as-is, publishable with the client anonymized, or hold.
+
+Tag each entry to a theme so the calendar can pull against a topic without the drafter re-reading the whole bank.
+
+## Health of the bank
+
+Twenty to forty live entries is a working bank for a weekly cadence. Below ten, the calendar starts pulling toward generic posts and the temptation to invent arrives.
+
+Track how many published posts in the last month traced to a banked story. When that share falls, the account is drifting toward commentary that anyone could have written, which is the slow version of the same failure.
+
+Retire entries after use. A story republished in a new wrapper is recognizable to anyone who has followed the account for a year, and those are the readers who matter most.


### PR DESCRIPTION
## What this skill does

The operating model for an engagement where someone else's name goes on the content: the written sign-off matrix and escalation ladder agreed before the first draft, a one-time intake producing a voice corpus and a world bible, a monthly story-mining call that keeps the anecdote bank full, an approval rhythm held under 30 minutes of founder time a week, and the comment and DM triage where the pipeline actually forms.

The hard line runs through the middle of it: ghosts fabricate exactly nothing about lived experience. When the story bank runs dry the answer is another mining call, never a filled gap. `references/story-mining.md` carries the call structure, the banking format, and the bank-health signals that predict the drift toward invention.

## Relationship to existing skills

Adjacent to `founder-post-triggers-24`, which gives a founder writing their own posts things to write about. This one is the operating agreement and cadence for an engagement where someone else drafts. No overlap in procedure or output.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

**Note on `author.md`:** identical to the copy in #75 and #76. Whichever merges first makes it a no-op for the others.

**Note on the avatar:** `avatarUrl` is omitted so maintainers can pull the LinkedIn profile photo per AGENTS.md.
