### PR TITLE
add b2b-case-study-production by vesselin-malev

### DIFF
--- a/skills/vesselin-malev/author.md
+++ b/skills/vesselin-malev/author.md
@@ -1,0 +1,9 @@
+---
+name: "Vesselin Malev"
+title: "Managing Director, The Demand Department"
+linkedinUrl: "https://www.linkedin.com/in/vesselinmalev/"
+companyDomain: demanddept.com
+email: office@demanddept.com
+---
+
+Vesselin Malev runs The Demand Department, where outbound, inbound, and conversion operate as one system rather than three teams. His earlier growth work sits behind crypto exchanges and Web3 media. He also holds operating ownership in B2B services, real estate, and consumer brands, and the firm's clients include YC-backed founders and category-leading tools.

--- a/skills/vesselin-malev/b2b-case-study-production/SKILL.md
+++ b/skills/vesselin-malev/b2b-case-study-production/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: b2b-case-study-production
+title: B2B case study production
+description: |
+  Use this skill when proof assets need to be produced from real client work:
+  "write a case study", "we need case studies for the new site", "our clients
+  won't let us name them", "the sales team has nothing to send", "turn these
+  client results into stories", "anonymize this client win", "build a case study
+  section". Produces a case study series with an intake process, an anonymization
+  framework that keeps stories credible without naming anyone, and a deployment
+  map that puts each story in front of buyers in motion.
+category: Positioning
+tags: [Marketing, Sales]
+---
+
+Applies when real client results exist and proof assets do not. Produces a series of case studies a skeptical buyer believes and a sales team actually sends.
+
+## The job of a case study
+
+A case study succeeds when a specific buyer recognizes their own situation in the first hundred words and finds the causality plausible all the way down. It is written for the skeptical read: a buyer who has been burned before, scanning for the seam where marketing took over from reality. Applause is a side effect. Recognition closes deals.
+
+## Real numbers, few of them
+
+One or two verifiable anchor numbers per story. Everything else is narrative: what changed operationally, who stopped doing what, which meeting got shorter. A page carpeted in metrics reads as invented even when every figure is real, because buyers know real engagements produce two clean numbers and a lot of texture. And the rule under the rule: never fabricate, never round up, never "roughly double" a 1.7x. One invented figure, discovered, poisons every honest story in the set.
+
+## Anonymize without bleaching
+
+Clients who refuse to be named still produce usable stories, and the disguise follows a strict trade: drop the identifiers, keep the texture. Describe the client by durable attributes, a size band, a specialty or vertical, a region, a situation, specific enough that a peer thinks "that is exactly us", general enough that a determined guesser cannot confirm the identity. The full attribute table, rounding rules, and the re-identification check are in `references/anonymization-rubric.md`. The mediocre version anonymizes by deleting everything interesting, leaving "a mid-sized company improved efficiency", which protects the client by making the story worthless.
+
+## Open on the pain the reader owns
+
+The problem section is written in the buyer's own vocabulary, mined from sales calls, and aimed at the pain the reader personally absorbs, the escalations they field, the report they dread, the vendor they cannot reach. Loss framing needs care: told bluntly "you are losing money", buyers who feel fine bounce off. The version that lands describes quiet underperformance, the money that disappears a little at a time, because it matches how the reader actually experiences the problem. Steal their phrases verbatim; a buyer's own words in the opening paragraph does more work than any statistic on the page.
+
+## Intake before writing
+
+Interview the delivery team and, where possible, the client, using the full question set in `references/intake-questionnaire.md`. The single highest-value answer is the moment the engagement nearly failed, because a story with a wobble in the middle reads true and a straight line reads like an ad. Writing from memory or from a dashboard export produces the straight line every time.
+
+## Build a series, not a trophy
+
+One case study is an anecdote. Five or six, each on its own page, is evidence. Plan the set as coverage: one story per segment, per specialty, per problem shape, so every priority buyer finds a mirror. Sequence production so the strongest verifiable numbers ship first. Structure and a worked example are in `references/story-structure.md`.
+
+## Deploy where buyers are in motion
+
+Case studies are conversion assets. They belong where an evaluating buyer already is: the site's proof section, the sales follow-up, the proposal appendix, the outbound proof line. Pushed weekly at an existing audience of followers, the fifth case study lands as repetition and the format sours internally, a predictable failure that gets misread as "case studies don't work". They work on buyers in motion. Distribution to a general audience is a bonus channel, rationed and never the plan.
+
+## What good looks like
+
+The best operators collect one buyer phrase per sales call into a swipe file and open every problem section from it. The mediocre version is a wall of unverifiable metrics over a straight-line narrative with a logo the client never approved. Good output survives three tests: a skeptical stranger finds the causality plausible, the sales team sends it without being asked, and the featured client reads it and confirms every word, comfortable that nobody else can prove it is them.
+
+## Rules
+
+- MUST get explicit written approval for every name, logo, and exact figure before publication; anonymized drafts speed this instead of skipping it.
+- MUST anchor each story on at most two verified numbers, sourced from the engagement record.
+- MUST run the re-identification check on every anonymized story before it ships.
+- NEVER invent, inflate, or "estimate" a metric; a story without a clean number ships as narrative with no number.
+- NEVER imply causality the delivery team will not defend in the room.

--- a/skills/vesselin-malev/b2b-case-study-production/references/anonymization-rubric.md
+++ b/skills/vesselin-malev/b2b-case-study-production/references/anonymization-rubric.md
@@ -1,0 +1,65 @@
+# Anonymization rubric
+
+The trade is strict: drop the identifiers, keep the texture. Everything below serves that one exchange.
+
+An anonymized story that a peer reads and thinks "that is exactly us" has done its job. One that reads "a mid-sized company improved efficiency" has protected the client by making the story worthless, which is the failure this rubric exists to prevent.
+
+## The attribute table
+
+Describe the client by durable attributes. Durable means true for years, true for many companies, and not searchable back to one.
+
+| Attribute | Ship it as | Never ship |
+|---|---|---|
+| Size | A band: 50 to 200 employees, or "roughly 40 people" | Exact headcount, or a band narrow enough to name one company |
+| Revenue | An order of magnitude: mid eight figures | The actual figure, or ARR to two decimals |
+| Vertical | The specialty: specialty insurance brokerage, industrial parts distribution | A niche so narrow only three firms exist in it |
+| Region | Broad: the US Midwest, DACH, the UK | City, or a state with one obvious candidate |
+| Structure | Ownership shape: PE-backed, founder-owned, second-generation family | The sponsor's name, the fund, the family |
+| Tenure | Rounded: founded in the 1990s | The founding year |
+| Situation | The pressure: post-acquisition integration, first outbound hire, a channel that stopped working | The named acquisition, the named channel partner |
+| Team shape | Roles and counts: two AEs and a founder selling | Named people, or titles unique to that org |
+
+Combine three or four of these. Two is usually too vague to produce recognition. Six starts narrowing toward one company.
+
+## Rounding rules
+
+Rounding is a disguise technique and a fabrication risk at the same time. The line between them:
+
+- **Round the identifiers.** Headcount, revenue, founding year, contract value. Round outward to a band and say it is a band.
+- **Never round the results.** A 1.7x stays 1.7x. Rounding a result up is fabrication regardless of intent, and it is the specific failure that poisons the whole set.
+- **Direction of rounding matters.** Round result-adjacent figures against your own interest. If the pipeline grew from 11 to 29 deals, "from about 10 to under 30" is honest. "From 10 to 30" quietly inflates both ends.
+- **Timeframes round to the nearest natural unit.** "Inside a quarter" rather than "in 81 days," which is precise enough to identify an engagement.
+- **Say when a number is a band.** "Roughly" and "under" cost nothing and protect against the reader assuming false precision.
+
+## What always gets stripped
+
+- Names of people, companies, products, and tools specific to the client.
+- Logos, screenshots with visible branding, and document headers.
+- Anything from the engagement record covered by an NDA, regardless of how anonymized it looks.
+- Dates precise enough to pair with a public event: a funding round, a leadership change, an acquisition.
+- Direct quotes with an identifiable speech pattern, unless approved.
+
+## The re-identification check
+
+Run on every anonymized story before it ships. Non-negotiable, and it takes ten minutes.
+
+1. **The search test.** Take the attributes as written and search them the way a competitor would. If the client appears in the first page of results, the combination is too narrow. Broaden one attribute and repeat.
+
+2. **The insider test.** Ask someone who knows the client but did not work on the engagement to read the story cold. If they name the client, so will anyone in that industry.
+
+3. **The stack test.** Check whether the combination of attributes describes fewer than roughly twenty plausible companies. Under twenty, the story identifies a short list, and a determined guesser will work through it.
+
+4. **The pairing test.** Read the story against your other published stories, your client list, and your public case studies. Anonymity fails through cross-referencing more often than through any single detail. A story that is safe alone can be identifying next to the one published last quarter.
+
+5. **The client read.** Send the anonymized draft to the client and ask directly: are you comfortable that nobody else can prove this is you? Their answer is the only one that counts. It also frequently returns permission to include more than you asked for.
+
+Failing any test means broadening an attribute, never deleting the texture. The texture is the asset.
+
+## When the client says no to everything
+
+Some clients will not approve any version. Two options remain, in order:
+
+- **Ship the mechanism without the client.** Describe the problem shape and what was done about it as a method piece, with no engagement attached and no numbers. Weaker than a case study, more useful than nothing.
+- **Bank it.** Approvals loosen when a relationship matures or a champion changes roles. Keep the intake notes and revisit annually.
+
+Never publish against an unclear approval. An anonymized story the client did not sign off on is still a story the client can recognize.

--- a/skills/vesselin-malev/b2b-case-study-production/references/intake-questionnaire.md
+++ b/skills/vesselin-malev/b2b-case-study-production/references/intake-questionnaire.md
@@ -1,0 +1,79 @@
+# Intake questionnaire
+
+Run before writing. Writing from memory or from a dashboard export produces the straight line every time, and the straight line is what reads like an ad.
+
+Two interviews per story where possible: the delivery team, then the client. Forty-five minutes each, recorded. The delivery interview usually surfaces what to ask the client, so run it first.
+
+## The delivery team interview
+
+### Before
+
+- What was the client doing about this before you arrived, and why was it not working?
+- Who inside the client organization felt the problem most? What did it cost that person personally?
+- What had they already tried and abandoned? This is the section a skeptical buyer reads hardest, because they have tried the same things.
+- What did they believe about the problem that turned out to be wrong?
+
+### The work
+
+- Walk through what actually happened, in order, including the parts that were not in the plan.
+- What did you change your approach on partway through?
+- What did the client have to stop doing?
+- What did this require from them that they did not expect? Hours, access, a hire, an uncomfortable internal conversation.
+- What would you do differently on the next one like it?
+
+### The wobble
+
+**The single highest-value question in the set: when did this nearly fail?**
+
+Follow it all the way down. What went wrong, when, who noticed, what the conversation was like, what was done about it, how long recovery took.
+
+A story with a wobble in the middle reads true. A straight line reads like an ad. Buyers who have run projects know that nothing goes cleanly, and a case study with no friction in it tells them the account is being managed rather than described.
+
+Expect resistance. Delivery teams are trained to present success. Ask it as "what was the hardest week" if the direct version stalls.
+
+### The numbers
+
+- What are the two cleanest numbers from this engagement? Cleanest means directly measured, not modeled.
+- Where does each one live in the engagement record, and who can confirm it?
+- What was the baseline, and how was it measured before you started?
+- What else moved at the same time that could account for part of the result?
+- What would you refuse to claim caused what?
+
+That last question is the causality boundary. Whatever the delivery team will not defend in the room does not go in the story.
+
+### After
+
+- What is the client doing now that they were not doing before?
+- Which meeting got shorter, which report got easier, which escalation stopped happening?
+- What did they do next as a result?
+
+## The client interview
+
+Shorter, and worth pushing for. A client's own framing of the problem is the most valuable material in the story, because it is the vocabulary other buyers use.
+
+- How would you describe the problem to a peer at another company?
+- What made you decide to do something about it when you did?
+- What were you worried about before starting?
+- What surprised you?
+- What would you tell someone considering the same thing?
+- Is there anything in here you would not want written down?
+
+Record the exact phrasing. Steal the phrases verbatim for the problem section. A buyer's own words in the opening paragraph do more work than any statistic on the page.
+
+## The approval conversation
+
+Run it during intake, not after the draft exists. Asking early costs nothing and shapes what gets written.
+
+- May we name you? May we use the logo?
+- May we cite this specific figure, exactly as measured?
+- If not named, what level of description are you comfortable with?
+- Who signs off, and what do they need to see?
+- Is there an internal communications or legal step we should start now?
+
+Bring an anonymized draft to the approval conversation where the relationship is uncertain. It speeds approval rather than skipping it, because the client is reacting to something concrete instead of imagining the worst version.
+
+## Capturing buyer language between engagements
+
+The best operators collect one buyer phrase per sales call into a swipe file. Objections, descriptions of the problem, the way they explain it to their own boss.
+
+That file is where problem sections come from. It costs a minute per call and compounds, and it is the difference between a problem section written in the buyer's vocabulary and one written in the vendor's.

--- a/skills/vesselin-malev/b2b-case-study-production/references/story-structure.md
+++ b/skills/vesselin-malev/b2b-case-study-production/references/story-structure.md
@@ -1,0 +1,57 @@
+# Story structure and series planning
+
+## The structure
+
+Six sections, in this order. Roughly 700 to 1,100 words for a page a sales team will actually send.
+
+**1. The recognition line.** One or two sentences placing the client by durable attributes and naming the problem in the buyer's vocabulary. This is the first hundred words the whole story depends on. A buyer who does not recognize themselves here never reaches the numbers.
+
+**2. Before.** What they were doing, what it cost, what they had already tried and abandoned. The abandoned attempts are the most-read part of the story for a skeptical buyer, because they have tried the same things and want to know why this was different.
+
+**3. What was done.** Chronological, specific, with the decisions visible. Not a feature list. A buyer is assessing whether the causality holds, and causality lives in the sequence.
+
+**4. The wobble.** Where it nearly failed and what was done about it. One paragraph. This is the section that separates a case study from an advertisement, and the one most often cut by someone trying to make the story cleaner.
+
+**5. After.** One or two anchor numbers, then the operational texture: what stopped happening, which meeting got shorter, what the team does now instead. The texture is longer than the numbers.
+
+**6. What it required.** What the client had to give: hours, access, a hire, an uncomfortable internal conversation. Advice with no cost reads as a pitch. Stating the cost is what makes the rest credible.
+
+Close on the client's own words where an approved quote exists. No summary paragraph, no call to action inside the story. The page it lives on handles that.
+
+## What not to include
+
+- A metrics grid. Two anchor numbers in prose beat eight in a table.
+- Stock photography of people in meetings.
+- The vendor's origin story or methodology branding.
+- Superlatives about the result. The number carries it or it does not.
+- Causality the delivery team will not defend in the room.
+
+## Worked example: the recognition line
+
+**Weak, no recognition:**
+
+> A leading company in the financial services space was struggling with inefficient lead generation processes and sought a scalable solution.
+
+Nothing here is false and nothing is usable. No reader sees themselves, and the phrasing signals that the specifics were removed because they were never collected.
+
+**Strong, anonymized:**
+
+> A specialty insurance brokerage in the US Midwest, about 60 people, two producers doing all the new business. They had bought lists twice and hired an SDR who left in five months. The owner was still personally sourcing the pipeline that paid for everyone else.
+
+Same level of anonymity. The attributes are durable and the combination describes a wide field. But a broker in that situation reads the third sentence and recognizes their own Tuesday.
+
+The difference is not the amount of information. It is that the second version keeps the texture the anonymization rubric says to keep, and the first bleached it out.
+
+## Planning the series
+
+One case study is an anecdote. Five or six is evidence.
+
+**Plan for coverage, not for the best stories.** Map the priority segments, specialties, and problem shapes, then assign one story to each cell. A set of five stories about the same segment proves depth in one place and leaves every other buyer without a mirror.
+
+**Sequence by verifiability.** Ship the stories with the cleanest approved numbers first. They set the credibility level the rest of the set inherits, and they are the ones the sales team reaches for while the set is still small.
+
+**Keep one page per story.** A combined "success stories" page reads as a brochure. Separate pages get sent individually, which is the actual use case.
+
+**Track which stories the sales team sends.** The ones nobody sends are telling you something about the segment, the problem shape, or the credibility of the numbers. That signal is worth more than a traffic metric.
+
+**Refresh annually.** Numbers go stale, clients change, approvals lapse. Re-confirm the figures and the permissions once a year, and retire stories whose champion has left the client organization.


### PR DESCRIPTION
## What this skill does

Produces a case study series from real client work: an intake process built around the moment the engagement nearly failed, an anonymization framework that keeps stories credible when the client won't be named, and a deployment map that puts each story in front of buyers already in motion.

Two ideas carry it. **One or two verifiable anchor numbers per story, and the rest narrative** — a page carpeted in metrics reads as invented even when every figure is real. And **anonymize by dropping identifiers, never by deleting texture** — "a mid-sized company improved efficiency" protects the client by making the story worthless.

`references/anonymization-rubric.md` carries the attribute table, the rounding rules that separate disguise from fabrication (round the identifiers, never the results), and a five-step re-identification check including the pairing test, since anonymity fails through cross-referencing published stories more often than through any single detail.

## Relationship to existing skills

Adjacent to `roi-proof-generator`, which builds a value receipt for an existing customer ahead of a renewal or QBR. This one produces external proof assets for buyers who aren't customers yet. No overlap in procedure or output.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

**Note on `author.md`:** identical to the copy in #75, #76, and #77. Whichever merges first makes it a no-op for the others.

**Note on the avatar:** `avatarUrl` is omitted so maintainers can pull the LinkedIn profile photo per AGENTS.md.
