### PR TITLE
add launch-window-mechanics

### DIFF
--- a/skills/danni-chen/launch-window-mechanics/SKILL.md
+++ b/skills/danni-chen/launch-window-mechanics/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: launch-window-mechanics
+title: Launch window mechanics
+description: |
+  Use this skill when a post is about to go live, or just went live, and the question is what
+  happens after publish — a creator's sponsored post, a founder announcement, a launch thread, a
+  milestone update, a customer story. "The post is scheduled, now what", "why did our sponsored post
+  die", "should we put spend behind this one", "how do we get a post moving in the first hour", "the
+  creator delivered and nothing happened", "we got impressions but no pipeline", "is this post
+  working". Produces the pre-publish setup, the minute-by-minute sequence from T−30 to T+120, the
+  paid amplification trigger and its stop conditions, the debrief, and the read on whether a post is
+  alive or already dead.
+category: Influencers
+tags: [Marketing, Demand Gen]
+---
+
+# Launch Window Mechanics
+
+Feeds do not distribute a post. They test it. A small slice of the audience sees it first, the system scores the reaction over the following half hour, and distribution either widens or stops. Almost everything written about creator marketing ends at publish. The reach was decided after that.
+
+The job in this window is narrow: produce enough real, fast, high-quality reaction inside the test to clear the threshold, then decide whether the result deserves paid spend behind it.
+
+Produces: a pre-publish setup, a timed sequence from thirty minutes before to two hours after, a go/no-go call on amplification with stop conditions, and a debrief that feeds the next cycle.
+
+## Before the post exists
+
+The window cannot be worked if the post was not built to be worked. Three things are decided at draft time, not at publish time.
+
+**The post must create an obligation to respond.** A neutral summary earns scrolling. A stated position, an open question, or a claim someone would want to correct earns replies, and replies are what the ranker weighs. This is not a call for provocation. It is the difference between "here is what we shipped" and "most teams are still doing this the slow way, here is the number that changed our mind."
+
+**Rights and attribution are contractual, not operational.** The creator agreement must grant paid usage rights on the post itself, with a stated window. Without that clause, the post you spend six hours validating cannot be amplified, and renegotiating mid-window costs both time and leverage. This is the most common preventable failure in the sequence. Attribution goes in at the same time: a distinct tracking parameter or code per creator, and where links are not permitted, a read on branded-search lift instead.
+
+**The traffic needs somewhere to land.** Reach is the entry, retention is the business. A spike arriving at a page with no next step is a spike that churns. Decide the destination before creating the demand: a signup path, a template, a resource, a community.
+
+Choosing who to run this with: [references/creator-scorecard.md](references/creator-scorecard.md).
+
+## Interaction leverage
+
+Reactions are not worth the same, and the gaps between them are much larger than most teams assume. Ordered by leverage, strongest first:
+
+| Signal | Why it scores | What it means operationally |
+|---|---|---|
+| Author replying to each commenter | Evidence of a live conversation rather than a broadcast | The highest-value action available, by a wide margin. Sit in the comments and answer individually |
+| Substantive replies from others | Costs real effort, therefore hard to fake | Build the tension or open question into the post so that replying is the natural response |
+| Reshares carrying added commentary | Redistributes into a graph the post could not otherwise reach | Line up two or three people who will add a genuine opinion, not agreement |
+| Saves and bookmarks | The silent endorsement, and a strong quality proxy | Lists, data, and frameworks earn these; opinion posts rarely do |
+| Profile clicks | The post made someone curious about the author | A byproduct of a clear point of view, not something to engineer |
+| Likes | The weakest signal on offer | Likes with no replies is a recognised low-quality pattern |
+| Hides, mutes, reports | Strongly negative, and suppressive | Exactly what purchased engagement produces |
+
+Two structural constraints apply nearly everywhere. Outbound links in the post body suppress distribution, so the link goes in the first comment. Verified accounts receive materially wider reach than unverified ones, which makes verification a cost of entry rather than an upgrade.
+
+Weightings, thresholds, and per-surface differences: [references/platform-signals.md](references/platform-signals.md).
+
+## The sequence
+
+| When | Action |
+|---|---|
+| T−30 | Publish into the hours the target audience actually reads, not the hours convenient for the team. Draft the first comment carrying the link. Write three to five seed questions that would each pull a second person into the thread. Tell the people who genuinely care that it is about to go up |
+| T+0–15 | Post the link comment immediately. The author answers every comment as it lands, individually, in substance. Target roughly ten substantive reactions inside fifteen minutes. This block clears the first threshold or it does not |
+| T+15–60 | The author keeps replying and extends threads rather than closing them with thanks. Reshares with commentary land here. Post a second question to restart the conversation once the first wave settles |
+| T+60–120 | Keep replying. Check the amplification trigger. Cross-post to a second surface for a second pulse rather than a duplicate |
+| T+6–8h | The amplification decision resolves. Trigger met and sentiment positive, deploy. Otherwise let it run |
+| T+2d | Publish the process teardown: how it was actually made, what it cost, what broke. Reliably produces a second wave, and it is planned in the original brief rather than improvised |
+| T+3–7d | Publish the method or template and the getting-started path, so viewers become participants |
+
+Never edit the original after publish. Never post and leave.
+
+## Amplification: only behind proven winners
+
+Paid spend does not rescue a weak post. It widens one that organic distribution already validated. The post itself is boosted so it stays native, rather than rebuilt as an ad, which discards the social proof that made it work in the first place.
+
+**Trigger.** Engagement reaches roughly 1.5 to 2x the account's own trailing baseline, within six to eight hours of publish, with sentiment clearly positive. The baseline is that account's own recent performance, never a cross-industry benchmark, because a strong post on a small account and a weak post on a large one produce identical absolute numbers.
+
+**Stop.** Cut on any one of these, not on all: cost per action running thirty percent over target for two consecutive days; frequency climbing while click-through declines; organic engagement on the original falling below its own baseline; a cluster of brand-safety-negative comments.
+
+A trigger stated in numbers is what separates a decision from a habit. Without one, spend goes behind whatever the team happens to like.
+
+Four-layer model, budget caps, test design, and a worked example: [references/amplification.md](references/amplification.md).
+
+## Pre-publish check
+
+- [ ] The post carries a clear interaction trigger, an open question or a stated position, not a neutral summary
+- [ ] Zero outbound links in the body; link drafted and ready for the first comment
+- [ ] No more than two hashtags
+- [ ] The publishing account is verified
+- [ ] Publish time matches when this audience actually reads
+- [ ] Three to five seed questions written; the people who care have been told it is coming
+- [ ] Paid usage rights confirmed in the creator agreement, with a stated window
+- [ ] Attribution wired: distinct parameter or code per creator, branded-search read where links are disallowed
+- [ ] The destination exists: signup path, template, or resource
+- [ ] The author has the first hour blocked out and is not in meetings
+
+## What good looks like
+
+- **Reshare speed is the call, not like count.** When reshares start outrunning likes, the post has crossed from something people consume to something people forward. That crossing is the earliest reliable read, and it appears well before the totals look impressive.
+- **Read who reacted before how many.** Twenty substantive replies from an adjacent community beat two hundred likes from anywhere, and engagement from the wrong audience scores against the post rather than for it. If nobody from the target buying group is in the first wave, more volume will not repair it.
+- **Likes with no replies is a failure state, not a modest success.** It is the exact pattern a ranker treats as low quality, and it is what purchased engagement produces.
+- **Sentiment is a gate, not a footnote.** Positive above roughly eighty percent, negative below five. Attention carrying a negative split costs more than it returns, and amplifying it buys a larger argument.
+- **Reach is the entry, retention is the business.** A spike that lands nowhere is a spike that churns.
+- **The three failures, in order of frequency:** publishing and walking away; buying engagement; and putting spend behind a post that never cleared its own organic baseline.
+- **Scoring differs by motion.** High-volume consumer runs on hit rate across many posts. A small-roster motion cannot, because the denominator is too small for the ratio to mean anything and the payoff is lagged pipeline rather than views. See [references/consumer-ai.md](references/consumer-ai.md).
+- Review cadence, metrics, and the trap list: [references/debrief.md](references/debrief.md).
+
+## Rules
+
+- MUST have the author personally answer comments through the first hour. Nothing else in this skill compensates for skipping it.
+- MUST use only real people on their own accounts, reacting because they have something to say. Coordinated pods, reciprocal-engagement groups, and purchased engagement are excluded, on quality grounds as much as ethical ones: they generate the exact low-quality pattern the ranker penalises.
+- MUST confirm paid usage rights before publish, or the validated winner cannot be amplified.
+- MUST set the amplification trigger and stop conditions in advance, in numbers.
+- MUST disclose commercial relationships according to the applicable rules. Undisclosed sponsorship is a legal exposure and an audience one.
+- NEVER put the link in the post body.
+- NEVER boost a post that has not cleared its own organic baseline.
+- NEVER edit the original after publish.
+- NEVER give a creator material that performs far beyond what an ordinary user can reproduce. The gap becomes a credibility problem that outlasts the campaign.
+
+## Example prompts
+
+```
+The post goes live in an hour. Walk me through the setup.
+```
+
+```
+Six hours in: engagement is 1.4x our average, sentiment is mixed. Boost or hold?
+```
+
+```
+Our creator post got 900 likes and 4 comments. Is it working?
+```
+
+```
+Score these three creators for a launch we need to work hard in the first hour.
+```

--- a/skills/danni-chen/launch-window-mechanics/references/amplification.md
+++ b/skills/danni-chen/launch-window-mechanics/references/amplification.md
@@ -1,0 +1,74 @@
+# Amplification model
+
+Read this when deciding whether to put paid spend behind an organic post, how much, and when to stop.
+
+The principle: paid does not resuscitate a weak post, it widens one that organic traffic already validated. Publish naturally, let early signal prove it works, then amplify only the winners. Boost the original post so it stays native rather than rebuilding it as an ad, which discards the social proof and the comment thread that made it work.
+
+## Layer 1 — Monitor
+
+Track the first six hours: impression velocity, engagement rate, save and share ratio, comment sentiment.
+
+Instruments report signal. They do not make the call. A dashboard that auto-boosts on a volume threshold will reliably spend behind posts that got attention from the wrong audience, because volume cannot distinguish between the two.
+
+## Layer 2 — Trigger
+
+Start only when all three hold:
+
+| Condition | Threshold |
+|---|---|
+| Engagement rate | ~1.5–2x the account's own trailing 30-day average |
+| Timing | Within 6–8 hours of publish |
+| Sentiment | Clearly positive; negative share below ~5% |
+
+The baseline is that account's own recent performance, never a cross-industry benchmark. A strong post on a 12,000-follower account and a weak post on a 400,000-follower account produce similar absolute numbers and opposite conclusions.
+
+## Layer 3 — Deploy
+
+Set spend caps at three levels so no single decision can consume the programme:
+
+| Cap | Purpose |
+|---|---|
+| Per post | Stops one promising post absorbing the cycle |
+| Per creator, per period | Stops a favourite creator crowding out the roster |
+| Per category, per period | Stops one content type dominating the mix |
+
+Hold fifteen to twenty percent of the budget back for a manual call on something the trigger missed. Triggers are tuned on past patterns and will not recognise a genuinely new one.
+
+Test two to four posts simultaneously rather than one, over one to three days. Short tests, quick reads. A long single test buys certainty about one asset while the window closes on the others.
+
+## Layer 4 — Stop
+
+Cut on any one of these, not on all four:
+
+| Condition | Reading |
+|---|---|
+| Cost per action >30% over target for 48h | Not going to correct on its own |
+| Frequency rising while click-through falls | Saturation; the audience has seen it |
+| Organic engagement on the original below its baseline | Paid distribution is now reaching people who do not want it |
+| Cluster of brand-safety-negative comments | Spend is buying an argument |
+
+Write the stop conditions before the first unit of spend goes out. Written afterward, they get relaxed.
+
+## Worked example
+
+A sponsored post goes live at 09:00 on an account whose trailing 30-day average engagement rate is 1.2 percent.
+
+**T+2h.** Engagement rate 1.9 percent, roughly 1.6x baseline. Under the trigger this is promising but early, and the six-hour condition has not been met. Do not spend. Keep working the comments.
+
+**T+6h.** Engagement rate 2.3 percent, now 1.9x baseline. Reshares are running ahead of the account's usual reshare-to-like ratio. Sentiment reads clearly positive with two critical comments, both substantive rather than hostile. Trigger conditions met.
+
+Check the contract before spending. Paid usage rights confirmed, thirty-day window. Deploy at the per-post cap over a 48-hour test, alongside two other posts from the same cycle.
+
+**T+30h.** Cost per action is 18 percent over target and frequency has reached 2.4 with click-through flat. Over target but not by the stop margin, and frequency is not yet coupled with declining clicks. Continue and re-read at T+48h.
+
+**T+54h.** Cost per action now 34 percent over target for the second consecutive day. Stop condition met on a single criterion. Cut, regardless of the fact that the post is still the best performer in the cycle. It is the best performer organically; paid distribution has exhausted the audience that wanted it.
+
+The judgment that matters in this example is at T+2h. Most teams spend there, because the number looks good and the excitement is highest. Spending at T+2h means spending before the signal has separated genuine spread from a burst of early enthusiasm from people who already follow the account.
+
+## What not to amplify
+
+A post below the account's own median. A post carrying divided or negative sentiment, where spend buys a larger argument. A post with likes but no replies, which the ranker has already scored as low quality and paid distribution will not repair. A post whose creator agreement lacks paid usage rights, which is not a judgment call but a legal one.
+
+## Attribution, set up before publish
+
+One distinct tracking parameter or discount code per creator, never shared across a roster, or the post-cycle analysis cannot separate them. Where the surface does not permit links, read branded-search lift over the window instead and accept the coarser signal. Request back-end screenshots from creators as a cross-check on self-reported reach; the gap between reported and actual is itself a data point on that creator.

--- a/skills/danni-chen/launch-window-mechanics/references/consumer-ai.md
+++ b/skills/danni-chen/launch-window-mechanics/references/consumer-ai.md
@@ -1,0 +1,27 @@
+# The high-volume consumer variant
+
+Read this when the product sells to consumers or prosumers rather than to a buying committee, and the motion runs across dozens or hundreds of creators rather than a handful.
+
+## The hit-rate argument, and where it stops working
+
+With a large denominator, hit rate becomes the thing to optimise: the share of posts clearing roughly 3x the account's own average. Broad untargeted spending sits in the low single digits, commonly around three percent. Selecting creators on demonstrated hit rate, engineering the content, and working the launch window lifts it several times over.
+
+The compounding is the whole argument. Moving from three percent to ten percent, at identical budget and identical post count, produces roughly three times the output over a year. Nothing else in creator marketing returns that much for the same spend, which is why the discipline is worth its overhead.
+
+It stops working when the denominator is small. Eleven posts against a niche audience cannot express a rate; three winners out of eleven is three winners, and next cycle it might be one. A small-roster motion has to score on composition of engagement and lagged pipeline instead, which is slower, coarser, and unavoidable.
+
+## What else changes
+
+**Creator selection weighting.** Score on the creator's own recent hit rate rather than audience size. Size sets initial distribution; content decides whether anything spreads beyond it.
+
+**Tiering.** Consumer motions support three tiers: one or two at the top for narrative reach, ten to thirty in the middle carrying the quality signal, and a long tail of fifty to two hundred carrying density and template spread. Small-roster motions collapse to head and mid.
+
+**Templates and remix.** Publishing the method, the prompt, or the workflow turns viewers into participants, and every imitator becomes a new distribution node. This mechanic drives most large consumer spread and is the highest-leverage single decision in a consumer launch. It largely does not occur in B2B, where buyers read but do not remix.
+
+**Emotional register.** Consumer spread concentrates in awe, humour, and controversy. Negative and moral-emotional content carries a measurable click-through advantage, roughly thirty percent, and a proportionate risk: controversy only converts when it is consistent with the product's actual value, otherwise it collects anger and nothing else. In B2B it backfires outright, because a buyer who must defend the purchase internally will not forward something that makes them look reckless. Contrarian travels in B2B; outrage does not.
+
+**Sequencing.** Consumer motions extend across four waves rather than one: the initial break, the publicly released template, the tutorial, then the conversion path. Peak attention landing nowhere produces downloads that churn, and the gap between a record launch and a collapsed retention curve is routinely a single quarter.
+
+## What stays identical
+
+The window itself. The leverage ordering of reactions, links out of the post body, the author answering comments, real people only, amplify winners rather than rescue losers, trigger and stop conditions written in numbers before publish. Feeds test small and score fast regardless of who the buyer is.

--- a/skills/danni-chen/launch-window-mechanics/references/creator-scorecard.md
+++ b/skills/danni-chen/launch-window-mechanics/references/creator-scorecard.md
@@ -1,0 +1,43 @@
+# Creator scorecard
+
+Read this when choosing who to run a launch window with. This is not general creator sourcing. It is the narrower question of who can carry a post that will be worked hard in its first hour, which weights differently: a creator who will not answer their own comments cannot be worked, whatever their reach.
+
+## Scoring rubric
+
+| Dimension | Weight | Pass line and how to check |
+|---|---|---|
+| Hit rate | 30% | Share of their last 90 days of posts exceeding 3x their own average, above 10%. Compare each post to their own baseline, never to a category benchmark |
+| Audience match | 25% | Follower composition overlaps the target buying group. Check the audience's disposition toward the category as well as its demographics; an audience that is hostile to the category will punish the post regardless of fit on paper |
+| Hands-on ability | 20% | Can they actually use the product, build the demo, show the work? Creators who read from supplied copy are downgraded across the board. They cannot answer comments credibly, which removes the highest-leverage action in the window |
+| Engagement authenticity | 15% | Engagement rate above 1.5%, with comment text that reads like people rather than bots |
+| Brand safety | 10% | No history of crossing disclosure or conduct lines; visible habit of disclosing sponsorship |
+
+Hit rate carries the most weight because audience size only determines initial distribution. Content determines whether anything travels beyond it. A 60,000-follower account in the right niche with a 15 percent hit rate will outperform a 2,000,000-follower general account working from a script, and it costs an order of magnitude less.
+
+## Verification: three checks that catch most problems
+
+**Engagement rate against follower count.** Well below one percent on a large account usually means purchased followers or a long-dead audience. Well above ten percent on a large account usually means purchased engagement.
+
+**Follower growth curve.** Organic growth is uneven but continuous. Vertical steps mean bought followers. A single step of tens of thousands inside a day is not a viral post, it is a purchase.
+
+**Engagement time distribution.** Real engagement spreads across the hours the audience is awake. Engagement clustered into narrow, repeating windows means an engagement service. This check catches what the first two miss.
+
+A fourth, specific to this skill: **look at whether they reply to their own comment threads.** Open three of their recent posts. If the creator is absent from their own comments, the single highest-leverage action in the launch window is unavailable no matter what you pay them, and their posts will underperform their follower count.
+
+## Tiering a cycle
+
+| Tier | Count | Role |
+|---|---|---|
+| Head | 1–2 | Narrative reach and the trend-setting effect that gives the mid tier something to react to |
+| Mid | 10–30 | The quality signal and the bulk of the hit rate. Where most of the return sits |
+| Long tail | 50–200 | Density and template spread. Only meaningful in high-volume consumer motions |
+
+In small-roster motions the long tail does not exist, because the population of credible voices in a niche category is measured in dozens. That collapses the structure to head and mid, and it changes the economics: with no long tail to generate density, each mid-tier post has to carry more, which raises the value of working the window properly on every one of them.
+
+Budget follows the same logic. Concentration beats spread: one head-tier placement or thirty mid-tier placements, not both diluted. The mid tier is usually where the same spend buys several times the effective reach, because head-tier pricing has been bid up by buyers who are still selecting on follower count.
+
+## Brief discipline
+
+Give direction and constraints. Do not supply a script. Creators understand their own audience better than the brand does, and a scripted post is detectable, underperforms, and cannot be defended in the comments by the person whose name is on it.
+
+Give the creator real product access early enough to form an actual opinion. A creator who has used the thing can answer questions in the window. A creator who has not will go quiet in the comments at exactly the moment the post needs them.

--- a/skills/danni-chen/launch-window-mechanics/references/debrief.md
+++ b/skills/danni-chen/launch-window-mechanics/references/debrief.md
@@ -1,0 +1,46 @@
+# Debrief
+
+Read this after the window closes, and again at the end of the cycle.
+
+## Second and third waves
+
+The launch window opens distribution. Two follow-ups extend it, and both belong in the original brief rather than being improvised once the first post does well.
+
+**Around T+2, the process teardown.** First-person, how it was actually made, what it cost, what went wrong. This feeds three audiences simultaneously: people who want to learn the method, people who want to argue with it, people who want to buy the thing. It frequently travels as far as the original and costs almost nothing to produce, because the material is a byproduct of having done the work.
+
+**Around T+3 to T+7, the method and the on-ramp.** Publish the template, the workflow, or the prompt so others can reproduce the result, alongside a short getting-started path and a destination for the traffic. Showing an impressive output without the method earns applause and stops there. Publishing the method converts viewers into participants, and each participant becomes a new distribution point.
+
+## Review cadence
+
+Hourly during the window. Weekly across the cycle. Monthly across the roster. Three different questions, and collapsing them into one monthly review loses the only one that could have changed an outcome.
+
+## Metrics worth keeping
+
+| Metric | What it tells you | Reasonable target |
+|---|---|---|
+| Engagement rate | Whether the post earned its distribution | Above 1.5% |
+| Sentiment split | Whether the attention is the kind you want | Positive above 80%, negative below 5% |
+| Reshare-to-like ratio | Passive consumption versus active spread | Rising is the signal; the absolute value matters less |
+| Save rate | Durable value rather than momentary reaction | Surface-dependent; on short video, above 4% strong, above 8% exceptional |
+| Composition of early engagers | Whether the right people showed up | Titles you would put on a target list |
+| Reply-to-like ratio | Whether the post created obligation or just approval | Compare against the account's own history |
+| Attributed conversion | Whether any of it reached the business | Traceable end to end via per-creator parameter or code |
+
+Hit rate belongs on this list only when the post count is large enough for a ratio to mean something. On a small roster it is noise wearing the costume of a metric: three posts out of eleven is not ten percent of anything, it is three posts.
+
+## Trap list
+
+| Stage | Failure | Instead |
+|---|---|---|
+| Expectation | Betting on one post; treating reach as the finish line | Raise the rate across many; decide the destination before creating demand |
+| Selection | Choosing on follower count; buying reach from bought audiences; using creators who read scripts | Choose on hit rate, audience fit, and whether they answer their own comments |
+| Accounting | No attribution; judging by likes; forgetting paid usage rights | One parameter per creator; request back-end screenshots; put the rights clause in the contract |
+| Content | Feature-list reviews; showing the result without the method; link in body plus hashtag stacking | Build the post to demand a response; publish the method; link in the first comment |
+| Window | Posting and leaving; buying engagement; boosting a post that never cleared baseline | Author answers every comment for an hour; real people only; amplify winners with a numeric trigger |
+| Conduct | Undisclosed sponsorship; letting the creator absorb the criticism; late payment; demos beyond what users can reproduce | Disclose by default; the brand answers for the brand; pay on time; ship the honest version |
+
+## What to carry into the next cycle
+
+Per-creator performance measured against their own baseline, not against each other. Which hooks produced replies rather than likes. Which publish hours actually worked for this audience, which is usually not what the scheduling tool suggests. Which posts cleared the amplification trigger and what the spend returned against organic.
+
+Tiering for the next round comes out of this record. It does not come out of follower counts, and it does not come out of which creator was easiest to work with.

--- a/skills/danni-chen/launch-window-mechanics/references/platform-signals.md
+++ b/skills/danni-chen/launch-window-mechanics/references/platform-signals.md
@@ -1,0 +1,59 @@
+# Ranking signals and weightings
+
+Read this when choosing where a post goes, how hard to work the window there, and which numbers to watch.
+
+Treat every figure below as an order of magnitude, not a constant. Platforms retune continuously and none of them publish their weights; these come from operator testing and platform disclosure. The relative ordering is far more stable than any individual multiplier, and the ordering is what the decisions rest on. Re-verify before committing budget to a specific number.
+
+## Conversation-led text feeds
+
+Short-form text and threads. Ranked primarily on interaction velocity in the first thirty to sixty minutes.
+
+Relative weighting, with a like as the unit:
+
+| Signal | Approximate weight | Operational consequence |
+|---|---|---|
+| Author replying to a comment on their own post | ~150x | Overwhelmingly the highest-leverage action. The author sits in the comments for the first hour and answers each one individually |
+| Reshare with added commentary | ~20x | Worth more than a plain reshare. Ask people for an opinion, not a repost |
+| Reply from another account | ~13.5–27x | Engineer the post so replying is necessary. Questions and stated positions outperform summaries |
+| Save or bookmark | ~10–12x | The silent signal. Lists, data, and frameworks collect these |
+| Profile click | ~12x | Follows from a distinct point of view rather than a distinct format |
+| Like | 1x | The floor. A post with likes and no replies reads as low quality |
+| Hide, mute, report | Strongly negative | Suppresses distribution outright. This is the yield on bought engagement |
+
+Two documented penalties: an outbound link in the post body suppresses reach by roughly thirty to fifty percent, and stacking three or more hashtags costs around forty percent. Both are avoidable at zero cost. Verified accounts see distribution several times wider than unverified ones on the same content.
+
+Best suited to opinion hooks, threads, live demos, and founder accounts. This surface has the tightest window of any, which makes the T+0 to T+15 block decisive rather than merely helpful.
+
+## Short-form video
+
+Ranked first on completion rate, then on saves and shares. The first forty-eight hours determine the outcome, a longer window than text but a harder one to influence after the fact.
+
+Save rate is the underrated accelerator: above roughly four percent is strong, above eight percent is exceptional. Completion is the gate before any of that matters, which puts the weight on the first two seconds rather than on the payoff.
+
+Suits native meme formats, template challenges, and before-and-after demonstrations.
+
+## Saves-and-search feeds
+
+Image-plus-text surfaces where the save-to-like ratio and comment interaction drive ranking, and search long-tail keeps delivering traffic for months afterward.
+
+The only family where a post compounds after the launch window closes. That changes what is worth optimising: keyword coverage in the caption matters more than first-hour velocity, and a post that underperforms in week one can still be the best performer in month three. Do not judge these on window metrics.
+
+Suits tutorials, checklists, and honest first-person notes.
+
+## Long-form video
+
+Ranked on watch time, retention curve shape, click-through rate, and search. Suits full workflow walkthroughs, deep reviews, and tutorials.
+
+Typically the strongest converting surface and the slowest to move. The launch window matters least here; title and thumbnail matter most, and a video can find its audience weeks after publication. Amplification decisions should use a longer read than six to eight hours.
+
+## Professional networks
+
+Ranked on early first-degree engagement, comment depth, and dwell time. Outbound links in the body are demoted here as elsewhere.
+
+Comment depth is doing more work than comment volume: a handful of long exchanges outperforms many short ones, which makes the author's replies the primary lever again. This is also the surface where the audience is legible enough to judge a post by who replied rather than how many did, which is the whole basis of the composition read in the parent skill.
+
+Suits build-in-public milestones, customer cases, and founder narrative.
+
+## Cross-surface rules that hold everywhere
+
+Link out of the body, into the first comment. Keep hashtags to two or fewer. Get the publishing account verified. Never edit the original after publish, which resets or penalises distribution on several surfaces. And never buy engagement: the specific pattern it produces, high likes with no replies and no saves, is the pattern every ranker on this list treats as evidence of low quality.


### PR DESCRIPTION
## What this skill does

Covers the part of creator marketing that every existing skill stops before: what happens after a post publishes. The spine holds the pre-publish setup, the T-30 to T+120 sequence, the paid amplification trigger with its stop conditions, and the read on whether a post is alive or already dead.

Five reference pages carry the depth: relative interaction weightings per surface, a weighted creator scorecard with pass lines and three authenticity checks, the four-layer amplification model with a worked example, debrief metrics and a trap table, and the high-volume consumer variant that explains why hit-rate scoring does not transfer to a small B2B roster.

Note on the security gate: the early-engagement section is explicitly scoped to real people on their own accounts. Engagement pods, reciprocal-engagement groups, and purchased engagement are excluded as a MUST NOT, on quality grounds as much as ethical ones, since bought engagement produces the likes-without-replies pattern that rankers penalise.

## Checklist (mirrors the review gates - check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [ ] First contribution: `author.md` is included with a real name, avatar, and LinkedIn — n/a, not a first contribution; author.md already merged
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
