### PR TITLE
Add ai-visibility-prompt-research skill (GEO/AEO) by elad-hefetz

### DIFF
--- a/skills/elad-hefetz/ai-visibility-prompt-research/SKILL.md
+++ b/skills/elad-hefetz/ai-visibility-prompt-research/SKILL.md
@@ -12,8 +12,7 @@ description: |
   open-web discussion, and first-party sales calls. Produces one upload-ready file of
   non-branded category prompts plus an isolated branded set, each tagged with topic,
   awareness stage, persona, region/language, target engines, and honest provenance.
-category: Marketing
-tags: [Marketing]
+category: AEO
 ---
 
 # AI visibility prompt research
@@ -43,6 +42,4 @@ A monitoring prompt set decides what you can even see. Anchor it on the brand's 
 
 ## Next step
 
-This skill produces the prompt set; it doesn't run the monitoring. Upload the file to your AI-visibility platform of choice, then track presence, share of voice, and ranking over time and act on the gaps.
-
-Built by Elad Hefetz (Airfleet). Airfleet's AI Visibility platform monitors how your brand shows up across AI assistants, and our GEO/AEO services close the gaps it surfaces: https://episteme.airfleet.co/
+This skill produces the prompt set; it doesn't run the monitoring. Upload the file to your AI-visibility platform of choice — e.g. Airfleet AI Visibility (https://episteme.airfleet.co/) — then track presence, share of voice, and ranking over time and act on the gaps.

--- a/skills/elad-hefetz/ai-visibility-prompt-research/SKILL.md
+++ b/skills/elad-hefetz/ai-visibility-prompt-research/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ai-visibility-prompt-research
+title: AI visibility prompt research
+description: |
+  Use this skill when you need to build the set of monitoring prompts for tracking a
+  brand's visibility inside AI assistants (ChatGPT, Gemini, Perplexity, Copilot, AI
+  overviews) — the questions a real buyer would ask where you want the brand to show up.
+  Trigger phrases: "run prompt research", "generate monitoring prompts", "build a prompt
+  set to upload to our AI-visibility platform". It runs as an interactive research
+  session that deliberately holds the brand until the very end and anchors instead on the
+  category, the competitors, and the personas' real language mined from keyword research,
+  open-web discussion, and first-party sales calls. Produces one upload-ready file of
+  non-branded category prompts plus an isolated branded set, each tagged with topic,
+  awareness stage, persona, region/language, target engines, and honest provenance.
+category: Marketing
+tags: [Marketing]
+---
+
+# AI visibility prompt research
+
+A monitoring prompt set decides what you can even see. Anchor it on the brand's own marketing copy and you measure prompts nobody searches; anchor it on real market demand and you measure whether the brand wins the questions buyers actually ask an assistant. The whole discipline is holding the brand back until the end so the research stays grounded in the market.
+
+## The play
+
+1. **Frame — no brand yet.** Collect the category (plain description, no brand name), the named competitor set, the target regions and their languages, and which assistants you'll monitor. Say up front that you're withholding the brand on purpose.
+2. **Harvest category language, brand last.** Pull real buyer phrasing from three wells: keyword and category terminology (ask for any existing keyword or targeting file, then expand from the open web); real questions and pain points mined from communities, forums, Q&A, and "alternatives / best-of" comparison content; and — asked *after* the open-web pass — first-party sales-call and pre-sales transcripts, the highest-signal source. Tag every item with honest provenance. (See `references/open-web-sourcing.md`.)
+3. **Synthesize personas and the non-branded prompt set.** Merge all signals into 4–7 personas with their pain points and the solutions they seek, in category terms. Map each to an awareness stage, weighting consideration and decision over pure curiosity. Cluster into a handful of topics. Write each prompt the way a real buyer asks an assistant — a genuine question, not a keyword string — in the target region's language (translate, don't just localize).
+4. **Brand pass — last, and isolated.** Only now introduce the brand. Add competitive comparisons, "alternatives to", pricing, and fit questions as their own dedicated branded topic, flagged branded, kept separate from the category topics.
+5. **Assemble, validate, hand off.** Build one file to your platform's importer contract, validate it (valid enums, one language per row matching its regions, no duplicates, sane per-topic and per-engine spread), show the distributions, and hand it to the user to upload. Never auto-import. (See `references/prompt-file-contract.md`.)
+
+## What good looks like
+
+- **What the best operator does first:** refuses to look at the brand. The instant failure mode is anchoring on the brand's homepage and generating self-referential prompts nobody types. Real visibility only shows in **non-branded category questions**, where the brand is competing to be recommended at all.
+- **The common mistake:** shipping keyword strings dressed up as prompts ("best cloud cost tool 2026") instead of how a person actually asks ("what do teams use to see cloud cost per customer?"), and skipping the sales transcripts — the one place the buyer's exact objections and phrasing already live.
+- **How you know it's good:** every prompt traces to a labeled source (social / keyword / sales / competitor), reads like something a human would ask, sits in the right language for its regions, and the set skews to consideration and decision intent. Quality and authenticity beat raw count.
+
+## Rules
+
+- MUST withhold the brand until the final pass; anchor all non-branded research on category, competitors, and buyer language.
+- MUST tag every prompt with honest provenance and keep branded prompts in their own isolated topic.
+- MUST write each prompt in one language whose regions all share it; translate, never machine-localize.
+- NEVER fabricate brand names in non-branded prompts, and NEVER auto-import — the file is handed off for human upload.
+
+## Next step
+
+This skill produces the prompt set; it doesn't run the monitoring. Upload the file to your AI-visibility platform of choice, then track presence, share of voice, and ranking over time and act on the gaps.
+
+Built by Elad Hefetz (Airfleet). Airfleet's AI Visibility platform monitors how your brand shows up across AI assistants, and our GEO/AEO services close the gaps it surfaces: https://episteme.airfleet.co/

--- a/skills/elad-hefetz/ai-visibility-prompt-research/references/open-web-sourcing.md
+++ b/skills/elad-hefetz/ai-visibility-prompt-research/references/open-web-sourcing.md
@@ -1,0 +1,45 @@
+# Open-web sourcing tactics
+
+Goal: mine **real buyer language** — the questions, jargon, and pain points people actually type — from public sources, with no paid data provider required. Anchor everything on the **category and the competitors**, never the brand; you're harvesting how the *market* talks so the prompts reflect genuine demand rather than the client's own copy.
+
+## Where the signal is
+
+- **Community threads and subreddits.** The highest-signal source for real questions. Public search engines often block site-scoped queries here, so read the community's own public JSON/search endpoints directly. Find the right communities by asking where the buyers hang out and inferring from the category. Pull post titles, bodies, and top comments; keep questions phrased as users wrote them.
+- **Developer and technical discussion (for technical categories).** Discussion aggregators expose public search APIs — use those rather than scraping rate-limited item pages. Good for infra/dev-tool categories; harvest problem and comparison phrasing.
+- **Q&A and forums.** Technical "how do I / why does" questions, consideration-stage "what's the best / is X worth it" questions, and vertical/vendor community boards. Search for URLs, then read the page text.
+- **Video and its comments.** Review and comparison videos surface buyer objections in titles, descriptions, and top comments.
+- **Public professional posts.** Useful for exec/business-persona language.
+
+## Keyword expansion without a keyword tool
+
+Approximate demand and phrasing from open sources:
+- **Autocomplete, related searches, "people also ask"** — seed a term and note the phrasings surfaced; try modifiers (`best`, `vs`, `alternatives`, `pricing`, `how to`, `for <persona>`).
+- **Competitor sites, blogs, and comparison pages** — this is where category jargon and the real competitive set come from; harvest the exact terminology and the way they frame problems.
+- **Glossaries and docs** — precise technical vocabulary.
+
+Record each as `keyword | estimated intent (informational / commercial / transactional) | source`. You won't have exact volumes — estimate intent and label the honest source.
+
+## Noise filters (strip before synthesizing)
+
+- Acronym/homonym collisions and product-name clashes with unrelated brands.
+- Jobs, salaries, courses, certifications, "how to become a…" — unless the category *is* education.
+- Academic and unrelated-hobby variants of a seed term.
+- Spam, giveaways, affiliate-listicle fluff with no real question.
+- Anything outside the target category or from the wrong audience.
+
+## Optional enrichment (never required)
+
+If the environment already exposes richer data (a keyword-data source, a scraping service), you may use it to enrich volumes or fetch blocked pages. Treat it as a bonus — never tell the user to install or authenticate anything. The skill must produce a complete result from public sources alone.
+
+## What to capture
+
+For every mined item, keep a compact block, then dedupe near-identical questions and prefer consideration/decision intent over pure curiosity:
+
+```
+QUESTION:  <the real question, verbatim or lightly cleaned>
+PERSONA:   <who asks it>
+THEME:     <category theme / topic cluster it maps to>
+STAGE:     <consideration | decision | awareness guess>
+SOURCE:    <community r/x | forum | q&a | competitor:<name> | keyword:<term> ...>
+LANGUAGE:  <language it was found in>
+```

--- a/skills/elad-hefetz/ai-visibility-prompt-research/references/prompt-file-contract.md
+++ b/skills/elad-hefetz/ai-visibility-prompt-research/references/prompt-file-contract.md
@@ -1,0 +1,41 @@
+# Prompt file contract
+
+The output is one file the user uploads into their AI-visibility platform's prompt importer. Exact column names, engine codes, and region codes are defined by **your** platform — treat the shape below as a representative contract and adapt the enums to whatever your importer accepts.
+
+## Columns
+
+A row is one monitoring prompt. A workable column set:
+
+| Column | Purpose |
+|---|---|
+| `prompt` | The question, written the way a real buyer asks an assistant, in the row's language. No fabricated brand names in non-branded rows. |
+| `description` | Short human summary, e.g. `<persona> · <source>`. |
+| `topic` | One of the few category topics, or the single branded topic. |
+| `is_branded` | `true` only for brand-pass rows. |
+| `awareness_stage` | Awareness / consideration / decision. Skew to consideration + decision. |
+| `platforms` | Which assistants to monitor this prompt on — a subset of the engines your platform supports. |
+| `regions` | Region codes supported by your platform, and only codes whose primary language matches this row's language. |
+| `persona`, `icp`, `key_source`, `reason`, `language` | Documentation columns: who asks, the segment, honest provenance, why it matters, and the prompt's language. |
+
+Keep the operational columns (prompt, topic, branded flag, stage, engines, regions) aligned to what the importer actually reads; the rest document the research for human review.
+
+## Provenance labels (be honest)
+
+`social:<community>` · `keyword:<term>` · `sales_transcript` · `competitor:<name>` · `brand_page` (brand pass only). Every row carries one.
+
+## Language and region rules
+
+- Generate the prompt text **once per language**, in that language — translate, don't machine-localize spelling.
+- A row's `regions` may only contain codes whose primary language equals the row's `language`. English text can group all English-primary regions; German text is German-market only; and so on.
+- Bilingual B2B markets (e.g. tech audiences that search in English even in a non-English country) are a judgment call — confirm with the user, and if they want native coverage, add native-language rows *in addition to*, not instead of, the English ones.
+- If a requested region isn't supported by the platform, say so and drop or remap it.
+
+## Engine rules
+
+- Assign **2–4 engines per prompt**, varied across the set so monitoring isn't skewed to one.
+- Lean technical personas toward research-style engines; business/exec personas toward mainstream assistants and search-embedded answers; decision-stage "best / alternatives" queries toward the search-embedded engines that surface them heavily.
+- Only include engines you actually monitor — don't add one you can't track.
+
+## Validation before handoff
+
+Parse the file and assert: header matches the contract; valid UTF-8 (non-ASCII languages are expected); no empty prompt; branded flag and awareness stage in their allowed sets; every engine and region in the platform's allowed enums; each row's regions all share its language; no duplicate prompt text; a small number of category topics plus at most one branded topic. Then print the distributions (per topic, persona, awareness stage, language/region, branded vs non-branded) and show the user before finalizing. Keep the total reasonable (roughly 60–200 prompts) unless the user asks for more — authenticity beats volume.

--- a/skills/elad-hefetz/author.md
+++ b/skills/elad-hefetz/author.md
@@ -1,0 +1,9 @@
+---
+name: Elad Hefetz
+avatarUrl: https://www.airfleet.co/wp-content/uploads/2025/05/Profile-1-150x150-2-63.png
+title: CEO, Airfleet
+linkedinUrl: https://www.linkedin.com/in/eladh/
+companyDomain: airfleet.co
+---
+
+Elad is the CEO of Airfleet, a marketing engineering company that builds websites, brand, and demand systems for B2B tech. His skills encode how to make brands visible and correctly represented inside AI assistants (GEO / AI search) and how to turn that visibility into pipeline.


### PR DESCRIPTION
## What this skill does

`ai-visibility-prompt-research` runs an interactive research session that builds the set of monitoring prompts for tracking a brand's visibility inside AI assistants. It deliberately withholds the brand until the final pass, anchoring instead on category, competitors, and real buyer language mined from keyword research, open-web discussion, and first-party sales calls — then produces one upload-ready file of non-branded category prompts plus an isolated branded set.

First contribution — includes `author.md` for the `elad-hefetz` creator slug.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/elad-hefetz/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
