### PR TITLE
add leaked-demand-recovery

### DIFF
--- a/skills/eliezer-cohen/author.md
+++ b/skills/eliezer-cohen/author.md
@@ -1,0 +1,12 @@
+---
+name: Eliezer Cohen
+title: Head of Global Sales & Partnerships, GoPerfect
+linkedinUrl: https://www.linkedin.com/in/eliezercohen/
+companyDomain: goperfect.com
+email: eliezer@goperfect.com
+---
+
+Head of Global Sales & Partnerships at GoPerfect, an AI-first HR tech company. Previously spent
+seven years at HiBob, progressing from BDR to Sales Manager and leading one of its UK and Ireland
+sales teams. Turns frontline B2B SaaS experience into practical, repeatable GTM playbooks for
+selling and scaling with AI.

--- a/skills/eliezer-cohen/leaked-demand-recovery/SKILL.md
+++ b/skills/eliezer-cohen/leaked-demand-recovery/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: leaked-demand-recovery
+title: Leaked demand recovery
+description: |
+  Use this skill when demand may have leaked between systems: a chat or form lead who never
+  completed a booking, a demo request with no meeting, a call held with no follow-up sent, an
+  inbound reply never answered, a trial that ended quietly, a deal closed lost on a blocker that
+  has since changed. Produces a list of confirmed drops with the evidence attached and one drafted
+  recovery message each, queued for a human to send. Fires on "did they ever book", "who fell
+  through the cracks", "what did we drop", "who never got a follow-up", "unworked inbound", "leads
+  that went nowhere", "recover lost inbound", and before any re-engagement send.
+category: RevOps
+tags: [Sales, RevOps]
+---
+
+The cheapest pipeline in any organisation is demand already paid for and then lost in the gap
+between two systems. This finds it, proves the drop is real before anyone touches it, and drafts
+the recovery.
+
+## The play
+
+1. **Scope the sweep.** Choose the seams to work and the window: about a month for active leaks,
+   six to twelve months for closed-lost revival. Confirm the window if one was specified.
+
+2. **Build the candidate list from the capture systems, not the CRM.** The CRM holds what someone
+   remembered to log. The mailbox, the calendar, the call recorder and the lead-capture channel
+   hold what actually happened. Take the union, deduplicate by person and by company, and include
+   people with no CRM record at all: they are the largest silent category and the entire reason to
+   build the list this way. `references/leak-map.md` lists the seams worth working and what each is
+   verified against.
+
+3. **Verify every candidate against two independent systems. This is a hard gate.** The record
+   saying someone was dropped is frequently wrong, and the cost is asymmetric: a missed recovery
+   forfeits one opportunity, while messaging someone who already booked or already replied costs the
+   relationship. Read `references/verification-gate.md` before running this step. Candidates that
+   fail the gate leave the list with a one-line note. Never soften a failed gate into a light touch
+   anyway.
+
+4. **Establish history before choosing a voice.** A recovered hand-raiser is usually not new. No
+   history: fresh first touch. Prior conversation: re-engagement voice that references the context
+   honestly. Existing or churned customer: route to the account owner and stop drafting. Open deal
+   owned by a colleague: flag the owner and stop, because a parallel message collides with a live
+   motion. Closed lost: carry the stated reason into the framing, and proceed only if the blocker
+   has genuinely changed.
+
+5. **Apply hard disqualifiers before scoring fit.** Geography, regulatory coverage, segment.
+   Serviceability is binary and cheap; fit scoring is expensive and pointless on an account that
+   cannot be served. Verify thin enrichment rather than trusting it, since poor records under-report
+   company size. Keep the disqualifier list in one place, or a stale gate rejects markets since
+   opened and admits ones since dropped.
+
+6. **Draft one message per confirmed drop**, personalised on what they asked about or the exact point
+   the last conversation reached. The recovery framing does the work; generic re-engagement copy
+   wastes the advantage of knowing precisely where they fell. Where the drop was an internal failure,
+   acknowledge it in a clause and move on. One unambiguous next step.
+
+7. **Present for approval.** Per confirmed drop: person and company, leak type, evidence checked,
+   history, suggested action. Then the drafts. Keep failed-gate candidates visible at one line each
+   so the verification work is auditable and a bad call can be spotted. On a scheduled sweep that
+   finds nothing, end silently.
+
+## What good looks like
+
+- The tell: the best operator distrusts the field claiming nothing happened more than the one
+  claiming something did. Absence of evidence is nearly always a query problem, not a cold prospect.
+  An empty result is a hypothesis about the search, not a finding about the person.
+- The mediocre version filters the CRM for "no activity in 30 days" and mails the list. It produces
+  volume, a few confused replies from people already mid-conversation, and a reputation cost nobody
+  measures because no system reports it.
+- The output is good when it leads with what was confirmed dropped rather than how many records were
+  scanned, and every claim carries its evidence. "Not booked" is not a finding. "No forward-dated
+  event under their name or domain, no meeting on the contact record, still in initial status" is.
+
+## Rules
+
+- **MUST** confirm every drop against two independent systems before it advances.
+- **MUST** resolve the contact record and search by address and domain before concluding no activity.
+- **MUST** let the system closest to the event win when systems disagree: the calendar beats the CRM
+  on bookings, the mailbox beats the CRM on last contact, the recorder beats the calendar on
+  attendance.
+- **NEVER** treat one system's field as proof of contact or of non-contact.
+- **NEVER** treat a chat transcript, a bot's promise, or an auto-applied status as evidence that a
+  booking exists or a call was held.
+- **NEVER** send or post anything automatically. This verifies and drafts; a human decides.
+- **NEVER** message into an account a colleague is working without flagging it first.
+- **NEVER** re-engage a prior contact in fresh-inbound voice. It reads as institutional amnesia and
+  is worse than sending nothing.
+- **NEVER** recover a lead outside serviceable coverage. Flag it and stop.

--- a/skills/eliezer-cohen/leaked-demand-recovery/references/leak-map.md
+++ b/skills/eliezer-cohen/leaked-demand-recovery/references/leak-map.md
@@ -1,0 +1,32 @@
+# Where demand leaks
+
+Read this at step 2, when building the candidate list. Each row is a seam where two systems hand off
+and neither owns the failure, which is why the loss is silent.
+
+| Leak | Signal | Verify against |
+|---|---|---|
+| Booking never completed | Lead shared contact details through chat or a form, no meeting exists | Calendar AND CRM meetings |
+| Meeting booked, never held | Event on the calendar, no recording or notes | Call recorder AND calendar |
+| Call held, follow-up never sent | Recording exists, a commitment was logged, no outbound message | Complete sent history AND targeted per-domain search |
+| Inbound reply never answered | The last message in the thread is theirs | The full thread, not search snippets |
+| Live conversation with no record | A real thread in the mailbox, nothing in the CRM | The mailbox as source of truth |
+| Closed lost on a blocker that changed | Loss reason was timing, coverage, a missing capability, or a departed champion | Loss reason AND current product and coverage state |
+| Trial or pilot that ended quietly | Usage stopped, no close-out conversation | Product usage AND the mailbox |
+
+## Which seams pay
+
+The last two rows are the highest-yield and the most neglected, because neither generates an inbound
+signal to remind anyone it exists. Everything above them is triggered by something arriving; a
+closed-lost record whose blocker quietly expired, and a pilot that faded rather than ended, produce
+no event at all. Nobody is reminded, so nobody looks.
+
+Work them on a slower cycle than the active leaks, six to twelve months back, and re-check the loss
+reason against what has actually shipped or opened since. A revival message that claims something
+changed when nothing did is worse than silence, because it burns the one reason they would have
+taken the call.
+
+## Prioritising within a sweep
+
+Rank confirmed drops by the strength of the original intent, not by how recent they are. Someone who
+completed a form and sat through a call outranks someone who abandoned a chat widget, even if the
+chat lead is fresher. Intent that survived several steps is the scarcer signal.

--- a/skills/eliezer-cohen/leaked-demand-recovery/references/verification-gate.md
+++ b/skills/eliezer-cohen/leaked-demand-recovery/references/verification-gate.md
@@ -1,0 +1,53 @@
+# The verification gate
+
+Read this before running step 3. Every re-engagement workflow assumes the CRM is right. It usually
+is not, and the failure is asymmetric: a missed recovery forfeits one opportunity, while messaging
+someone who already booked, already replied, or is already being worked costs the relationship.
+
+## Failures this gate exists to prevent
+
+Each of these has produced a false drop in a live pipeline.
+
+- A CRM last-contacted field reported a prospect silent for three weeks. The mailbox showed an email
+  sent five days earlier. The field lags, misses sends from other addresses, and misses non-email
+  channels entirely.
+- A follow-up was flagged as never sent because the search used the company name as a keyword. It had
+  been sent as a reply inside an older scheduling thread whose subject never contained that name.
+- A mailbox search returned only its first page. Later pages were silently absent, and valid sends
+  were flagged as missing.
+- A thread search returned only the first few messages per thread. The most recent message, a
+  submitted proposal, sat further down and was invisible to every search made against it.
+- A CRM auto-flipped past meetings to a completed status regardless of whether anyone attended,
+  making that status worthless as evidence a call happened.
+
+The rule that follows: **a single system is never sufficient evidence, in either direction.** Not
+evidence that someone was dropped, and not evidence that they were not.
+
+## Verification rules
+
+- **Only a forward-dated event counts as a live booking.** A past-dated meeting is not a booking to
+  protect, and an auto-applied completed status is not proof anyone attended.
+- **When systems disagree, the system closest to the event wins.** The calendar beats the CRM on
+  bookings. The mailbox beats the CRM on last contact. The recorder beats the calendar on attendance.
+- **An empty result means the query was wrong, not that the person is cold.** Resolve the actual
+  contact record and email domain first, then search by address and by domain. Never conclude "no
+  activity" from a keyword search that returned nothing.
+- **Paginate to exhaustion.** If a response carries a continuation token, follow it until there is
+  none. A partial pull manufactures false drops.
+- **Never conclude a thread's last message from search snippets.** Search commonly truncates threads
+  to their first few messages. If any other system suggests activity more recent than the last
+  visible message, fetch the full thread before deciding anything.
+- **Search by recipient address, not by keyword.** A follow-up sent as a reply inside an older thread
+  will not match a company-name search.
+- **Two checks are required before flagging an owed follow-up as unsent:** the complete sent history,
+  and a targeted search restricted to that recipient's domain after the event date. Either alone has
+  produced false positives.
+- **Note channel blind spots rather than assuming silence.** Messages sent over social, SMS, or from
+  a personal address will not appear. Absence of evidence in the mailbox is not evidence of absence,
+  and the gap belongs in the output as a stated limitation.
+
+## Recording the verdict
+
+State the evidence checked for every candidate, whether it passed or failed, so the call is auditable
+by someone who was not there. A verdict without its evidence is an assertion, and assertions are what
+this gate exists to replace.


### PR DESCRIPTION
## What this skill does

Finds demand that already raised its hand and then fell through a gap between systems, verifies each apparent drop against two independent systems before anyone acts on it, and drafts a recovery message only for those that survive. Encodes the rule that no single CRM field counts as evidence of contact or non-contact, in either direction.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile