### PR TITLE
add company-domain-resolver by boaz-descalo

### DIFF
--- a/skills/boaz-descalo/author.md
+++ b/skills/boaz-descalo/author.md
@@ -1,0 +1,9 @@
+---
+name: Boaz Descalo
+title: Founder & CEO, Node8
+linkedinUrl: https://www.linkedin.com/in/descalo/
+companyDomain: node8.ai
+email: boaz@node8.ai
+---
+
+I build and scale AI systems for B2B companies. Today I run Node8, where we partner with teams from early-stage startups to public companies to move from AI strategy to production implementation and measurable adoption. My skills encode the data-plumbing side of GTM — the unglamorous resolution, dedupe, and hygiene steps that decide whether enrichment and outreach downstream actually work.

--- a/skills/boaz-descalo/company-domain-resolver/SKILL.md
+++ b/skills/boaz-descalo/company-domain-resolver/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: company-domain-resolver
+title: Company domain resolver
+description: |
+  Use this skill when you have a list of company names — a CSV, CRM export,
+  event attendee list, or pasted prospecting list — and need website domains
+  before enrichment, dedupe, or CRM import. Produces the original list with a
+  resolved domain and a per-row match-confidence label, using the free, keyless
+  Clearbit autocomplete endpoint. Trigger on "find the domains for these
+  companies", "what's the website for X", "clean up this company list",
+  "resolve these company names", "add domains to this CSV", "company name to
+  domain", or Clearbit autocomplete/suggest. Also applies proactively when a
+  company list is missing domains and the next step needs them.
+category: Prospecting
+tags: [Sales, RevOps]
+contributors: []
+---
+
+Applies whenever a company list has names but no domains and the next step —
+enrichment, dedupe, CRM import — needs them. Produces the same list back with
+`resolved_domain`, `matched_name`, a confidence label per row, and the rows
+that need human review called out, never a bare domain list.
+
+## The play
+
+1. **Get the input and confirm the column.** Accept a CSV/TSV, plain-text
+   list, or names pasted in chat. For a CSV, name the company column
+   explicitly. Over ~40 names, tell the user each name is one HTTP call and
+   confirm before starting.
+2. **Resolve via the free Clearbit autocomplete endpoint** —
+   `https://autocomplete.clearbit.com/v1/companies/suggest?query=<name>`. No
+   key, no auth, up to 5 matches best-guess first, `[]` on no match. It is an
+   undocumented typeahead, not a contracted API: keep volume modest, pace
+   requests, and read `references/endpoint-behavior.md` before your first
+   batch — it covers the two failure modes that silently corrupt lists.
+3. **For one or two names**, query directly with your agent's web-fetch tool
+   and report matches inline, flagging when several results share a name.
+4. **For a batch**, use the resolver script in
+   `references/resolver-script.md`. It runs plan → fetch → merge: dedupes on a
+   normalized key, strips legal suffixes before querying, then scores every
+   row. If the environment blocks direct HTTP, the script's plan output lists
+   the URLs so you can fetch them with your agent's web-fetch tool (5–8 in
+   parallel per batch) and feed the responses back to the merge step.
+5. **Score every row.** Confidence labels and what they mean:
+
+   | confidence | meaning | review |
+   |---|---|---|
+   | `exact` | name and domain both match, ranked first | no |
+   | `strong` | exactly one result's domain matches the name | no |
+   | `plausible` | same slug on several TLDs; picked the gTLD | spot-check |
+   | `ambiguous` | several same-named companies, different domains | yes |
+   | `weak` | nothing lined up; top result is a guess | yes |
+   | `none` | empty response — not in the index | yes |
+
+6. **Report, don't just deliver a file.** Give counts per confidence level and
+   list the specific rows needing review with their alternatives. If `weak`
+   plus `none` exceed a third of the list, say so plainly — the input is
+   likely full of internal shorthand, DBA names, or companies the index
+   doesn't cover. For those rows, offer (don't auto-run) a web search on
+   `"<company name>" official site` as a second pass.
+7. **Hand off.** Domains are the join key for enrichment and CRM dedupe. For
+   people-level data (titles, emails, profiles), pass the resolved domains to
+   a real enrichment step — this endpoint returns name and domain only.
+
+## What good looks like
+
+- The best operator distrusts the top result by default. This endpoint always
+  returns *something* for common words — "Clay" returns five
+  Clayton-somethings and no Clay — so a bare domain list with no confidence
+  column is malpractice, not a deliverable.
+- The common mistake is querying names as-is. Legal suffixes wreck results:
+  "Stripe Inc." returns `stripe-inc.jp` (wrong company), "Bright Data Ltd"
+  returns nothing, while "Stripe" and "Bright Data" both resolve cleanly.
+  Strip trailing Inc/Ltd/LLC/GmbH/Corp/Holdings/Group before every query.
+- Good output is auditable: every original column preserved, every row
+  labeled, alternatives shown for ambiguous rows, and the review burden
+  quantified up front ("41 exact/strong, 6 need review, here they are") —
+  never a 30% weak-match rate buried in a file.
+
+## Rules
+
+- MUST attach a confidence label to every resolved row — never hand back a
+  bare name→domain list.
+- MUST record empty responses as explicit no-matches, distinct from rows that
+  were never fetched — those are different problems with different fixes.
+- NEVER write `weak`, `ambiguous`, or `none` rows into a CRM unattended;
+  resolve them with the user first.
+- NEVER present this endpoint's output as authoritative company data or
+  promise logos from it — it is a best-effort typeahead index.

--- a/skills/boaz-descalo/company-domain-resolver/references/endpoint-behavior.md
+++ b/skills/boaz-descalo/company-domain-resolver/references/endpoint-behavior.md
@@ -1,0 +1,57 @@
+# Clearbit autocomplete endpoint behavior
+
+```
+GET https://autocomplete.clearbit.com/v1/companies/suggest?query=<url-encoded name>
+```
+
+- **No API key, no auth header, no account.** Just a GET.
+- Returns a JSON array of **up to 5** matches, best-guess first:
+  `[{"name": "Ramp", "domain": "ramp.com", "logo": null}, ...]`
+- No match returns `[]` with HTTP 200, not a 404.
+- `logo` is **null in practice** — do not promise logos off this endpoint.
+  If a logo is needed, fall back to
+  `https://www.google.com/s2/favicons?domain=<domain>&sz=128` and tell the
+  user it's a favicon, not a brand asset.
+- Undocumented and unsupported. It is a typeahead for a signup form, not a
+  contracted data API. Assume no SLA, keep volume modest, pace requests, and
+  never present its output as authoritative without the confidence column.
+- Quoting a multi-word query (`?query="bright data"`) makes no difference;
+  don't bother.
+
+## Two things that will burn you
+
+1. **Legal suffixes wreck results.** `Stripe Inc.` returns `stripe-inc.jp`
+   (wrong company). `Bright Data Ltd` returns `[]`. `Stripe` and
+   `Bright Data` both resolve correctly. Always strip trailing
+   `Inc / Ltd / LLC / GmbH / AG / Corp / Holdings / Group` before querying.
+   The resolver script does this automatically.
+2. **Common names silently return the wrong company.** `Clay` returns five
+   Clayton-somethings, no Clay. The top result is always *something*, never
+   an error. This is why every row gets a confidence label — never hand back
+   a bare domain list.
+
+## Worked single-lookup example
+
+For one or two names, skip the script: fetch the endpoint directly with your
+agent's web-fetch tool and report matches inline. `Harvest` returns two
+results literally named "Harvest" — `getharvest.com` (the time-tracking
+tool) and `harvest.org` (a church ministry) — alongside `harvesthosts.com`,
+`harvestright.com`, and `harvesttotable.com`. The index cannot tell
+same-named companies apart, and note the `get` prefix on the real one: say
+which is which and let the user confirm. (The batch script strips common
+domain prefixes like `get`/`try`/`join` when matching, so `getharvest.com`
+still scores as a name match for "Harvest".)
+
+## Blocked-network environments
+
+Some sandboxed agent environments block direct HTTP to this host (a proxy
+403 on CONNECT). Plan for it:
+
+- Use your agent's web-fetch tool to hit the endpoint — that path usually
+  works when raw sockets don't.
+- Use the shell only for local file work (planning, scoring, CSV writing).
+- The resolver script's `fetch` subcommand tries direct HTTP first and exits
+  with a clear message if blocked, so it still works in environments that do
+  have network (e.g. a laptop CLI agent).
+- When falling back to web-fetch, batch **5–8 requests in parallel**, then
+  move to the next batch. Don't fire 50 at once.

--- a/skills/boaz-descalo/company-domain-resolver/references/resolver-script.md
+++ b/skills/boaz-descalo/company-domain-resolver/references/resolver-script.md
@@ -1,0 +1,225 @@
+# Batch resolver script
+
+Write the script at the bottom of this page verbatim to `clearbit_resolve.py`
+in the working directory, then run the three subcommands in order.
+
+## 1. Plan
+
+```bash
+python3 clearbit_resolve.py plan input.csv --column "Company Name" --out plan.json
+```
+
+Dedupes on a normalized key, strips legal suffixes, and emits `plan.json`
+with a `urls` map of `query -> URL`. Plain-text input (one name per line)
+works too — omit `--column`.
+
+## 2. Fetch
+
+Try direct first — it costs one call and works outside sandboxes:
+
+```bash
+python3 clearbit_resolve.py fetch plan.json --out raw.json
+```
+
+If it exits with the network-blocked message, fall back to your agent's
+web-fetch tool:
+
+- Read `plan.json` → `urls`.
+- Fetch each URL, 5–8 in parallel per batch.
+- Assemble `raw.json` yourself, keyed by the **query string** (the key in
+  `urls`, not the URL, and not the original CSV value):
+
+```json
+{
+  "Ramp": [{"name": "Ramp", "domain": "ramp.com", "logo": null}],
+  "Bright Data": []
+}
+```
+
+- Empty arrays must be recorded as `[]`, not omitted — omitted queries land
+  in the output as `not_fetched`, which is a different problem than
+  "no match".
+
+## 3. Merge and score
+
+```bash
+python3 clearbit_resolve.py merge plan.json raw.json --out resolved.csv
+```
+
+Output keeps every original column and appends `resolved_domain`,
+`matched_name`, `confidence`, `needs_review`, `alternatives`, and prints
+counts per confidence level.
+
+## The script
+
+```python
+#!/usr/bin/env python3
+"""Company name -> domain resolution via the Clearbit autocomplete endpoint."""
+import argparse, csv, json, re, sys, urllib.parse, urllib.request
+
+ENDPOINT = "https://autocomplete.clearbit.com/v1/companies/suggest?query="
+
+SUFFIXES = {
+    "inc", "inc.", "llc", "l.l.c", "ltd", "ltd.", "limited", "corp", "corp.",
+    "corporation", "co", "co.", "company", "gmbh", "plc", "sa", "s.a", "ag",
+    "bv", "b.v", "nv", "ab", "oy", "as", "pty", "pte", "srl", "spa", "kk",
+    "holdings", "holding", "group", "the",
+}
+PREFIXES = ("www.", "get", "join", "try", "use", "hey", "the", "my", "go")
+
+
+def norm(s: str) -> str:
+    s = (s or "").lower()
+    s = re.sub(r"[‘’“”\"']", "", s)
+    s = re.sub(r"[^a-z0-9]+", " ", s).strip()
+    toks = [t for t in s.split() if t not in SUFFIXES]
+    return " ".join(toks) if toks else s
+
+
+def clean_query(s: str) -> str:
+    """Strip trailing legal suffixes, keep casing. The endpoint degrades badly
+    on 'Acme Inc.' / 'Acme Ltd' -- literal junk match or an empty array."""
+    s = re.sub(r"\s+", " ", (s or "").strip().strip(","))
+    toks = s.split()
+    while toks and re.sub(r"[^a-z0-9.]", "", toks[-1].lower()) in SUFFIXES:
+        toks.pop()
+    out = " ".join(toks).strip(" ,.;-")
+    return out or s
+
+
+def compact(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def domain_slug(domain: str) -> str:
+    d = (domain or "").lower()
+    if d.startswith("www."):
+        d = d[4:]
+    core = d.split(".")[0]
+    for p in PREFIXES:
+        if p != "www." and core.startswith(p) and len(core) > len(p) + 2:
+            core = core[len(p):]
+            break
+    return re.sub(r"[^a-z0-9]", "", core)
+
+
+GTLD = (".com", ".io", ".ai", ".co", ".net", ".org")
+
+
+def score(query: str, results: list) -> dict:
+    q_n, q_c = norm(query), compact(norm(query))
+    if not results:
+        return {"domain": "", "matched_name": "", "confidence": "none",
+                "needs_review": "yes", "alternatives": ""}
+
+    name_hits = [r for r in results if norm(r.get("name")) == q_n]
+    slug_hits = [r for r in results if domain_slug(r.get("domain")) == q_c]
+
+    def rank(r):
+        d = (r.get("domain") or "").lower()
+        return (0 if domain_slug(d) == q_c else 1,
+                0 if d.endswith(GTLD) else 1,
+                d.count("."), len(d))
+
+    pool = sorted(slug_hits or name_hits or results, key=rank)
+    best = pool[0]
+
+    if len(slug_hits) == 1:
+        conf = "exact" if name_hits and results[0] is slug_hits[0] else "strong"
+    elif len(slug_hits) > 1:
+        conf = "plausible"
+    elif len(name_hits) > 1:
+        conf = "ambiguous"
+    elif len(name_hits) == 1:
+        conf = "strong"
+    else:
+        conf = "weak"
+
+    review = {"exact": "no", "strong": "no", "plausible": "spot-check"}.get(conf, "yes")
+    alts = [r.get("domain", "") for r in pool[1:4] if r.get("domain")]
+    return {"domain": best.get("domain", ""), "matched_name": best.get("name", ""),
+            "confidence": conf, "needs_review": review, "alternatives": "; ".join(alts)}
+
+
+def read_names(path, column):
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        if path.lower().endswith((".csv", ".tsv")):
+            delim = "\t" if path.lower().endswith(".tsv") else ","
+            rows = list(csv.DictReader(f, delimiter=delim))
+            if column not in (rows[0].keys() if rows else []):
+                sys.exit(f"Column '{column}' not found. Available: "
+                         f"{list(rows[0].keys()) if rows else []}")
+            return rows, [r[column] for r in rows]
+        names = [ln.strip() for ln in f if ln.strip()]
+        return [{"Company": n} for n in names], names
+
+
+def cmd_plan(a):
+    rows, names = read_names(a.input, a.column)
+    seen, queries = set(), []
+    for n in names:
+        k = norm(n)
+        if k and k not in seen:
+            seen.add(k)
+            queries.append(clean_query(n))
+    plan = {"column": a.column, "rows": rows, "queries": queries,
+            "urls": {q: ENDPOINT + urllib.parse.quote(q) for q in queries}}
+    json.dump(plan, open(a.out, "w", encoding="utf-8"), indent=2)
+    print(f"{len(rows)} rows -> {len(queries)} unique queries. Plan: {a.out}")
+
+
+def cmd_fetch(a):
+    plan = json.load(open(a.plan, encoding="utf-8"))
+    raw = {}
+    for i, (q, url) in enumerate(plan["urls"].items(), 1):
+        try:
+            with urllib.request.urlopen(url, timeout=15) as r:
+                raw[q] = json.load(r)
+        except Exception as e:
+            sys.exit(f"Direct fetch failed on '{q}' ({e}).\n"
+                     f"Network is likely blocked here -- use a web-fetch tool "
+                     f"on plan['urls'], hand-build raw.json, then run `merge`.")
+        if i % 25 == 0:
+            print(f"  ...{i}/{len(plan['urls'])}", file=sys.stderr)
+    json.dump(raw, open(a.out, "w", encoding="utf-8"), indent=2)
+    print(f"Fetched {len(raw)} queries -> {a.out}")
+
+
+def cmd_merge(a):
+    plan = json.load(open(a.plan, encoding="utf-8"))
+    raw = json.load(open(a.raw, encoding="utf-8"))
+    by_norm = {norm(q): score(q, res) for q, res in raw.items()}
+    col = plan["column"]
+    out_fields = list(plan["rows"][0].keys()) + [
+        "resolved_domain", "matched_name", "confidence", "needs_review", "alternatives"]
+    counts = {}
+    with open(a.out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=out_fields)
+        w.writeheader()
+        for row in plan["rows"]:
+            s = by_norm.get(norm(row.get(col, "")), {
+                "domain": "", "matched_name": "", "confidence": "not_fetched",
+                "needs_review": "yes", "alternatives": ""})
+            counts[s["confidence"]] = counts.get(s["confidence"], 0) + 1
+            w.writerow({**row, "resolved_domain": s["domain"],
+                        "matched_name": s["matched_name"],
+                        "confidence": s["confidence"],
+                        "needs_review": s["needs_review"],
+                        "alternatives": s["alternatives"]})
+    print(f"Wrote {a.out}")
+    for k in ("exact", "strong", "plausible", "ambiguous", "weak", "none", "not_fetched"):
+        if counts.get(k):
+            print(f"  {k:11} {counts[k]}")
+
+
+p = argparse.ArgumentParser()
+sub = p.add_subparsers(dest="cmd", required=True)
+sp = sub.add_parser("plan"); sp.add_argument("input")
+sp.add_argument("--column", default="Company"); sp.add_argument("--out", default="plan.json")
+sp.set_defaults(fn=cmd_plan)
+sf = sub.add_parser("fetch"); sf.add_argument("plan")
+sf.add_argument("--out", default="raw.json"); sf.set_defaults(fn=cmd_fetch)
+sm = sub.add_parser("merge"); sm.add_argument("plan"); sm.add_argument("raw")
+sm.add_argument("--out", default="resolved.csv"); sm.set_defaults(fn=cmd_merge)
+a = p.parse_args(); a.fn(a)
+```


### PR DESCRIPTION
## What this skill does

Resolves a list of company names (CSV, CRM export, event attendee list) to canonical website domains in bulk via the free, keyless Clearbit autocomplete endpoint, with legal-suffix stripping, dedupe, and per-row match-confidence scoring so wrong matches get flagged for review instead of silently shipped into enrichment or a CRM.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/boaz-descalo/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name and LinkedIn (avatar omitted per the template note — please pull from my LinkedIn profile photo)
- [x] Body speaks in GTM verbs — zero vendor tool names. One honest disclosure: the skill names the Clearbit autocomplete endpoint, because that specific free public endpoint *is* the skill's data source (its quirks are the encoded judgment), not a tool-of-choice standing in for a category.
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions — the only outbound calls are GETs of company names to the public suggest endpoint, and the skill tells the agent to confirm with the user before large batches
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)