### PR TITLE
add abm-signal-watchlist by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/abm-signal-watchlist/SKILL.md
+++ b/skills/ryan-iyengar/abm-signal-watchlist/SKILL.md
@@ -2,7 +2,7 @@
 name: abm-signal-watchlist
 title: Build an ABM signal watchlist
 description: |
-  Use this skill when a team has target companies and wants to engage only when meaningful account changes occur. Produces a resolved account watchlist, signal definitions, stakeholder coverage plan, ranked action queue, and learning loop.
+  Use this skill for ongoing monitoring across a fixed target-account list; use trigger-based-outbound when evaluating one already-detected event. Produces a resolved account watchlist, signal definitions, stakeholder coverage plan, ranked action queue, and learning loop.
 category: ABM
 tags: [Sales, Marketing, Demand Gen]
 ---

--- a/skills/ryan-iyengar/abm-signal-watchlist/SKILL.md
+++ b/skills/ryan-iyengar/abm-signal-watchlist/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: abm-signal-watchlist
+title: Build an ABM signal watchlist
+description: |
+  Use this skill when a team has target companies and wants to engage only when meaningful account changes occur. Produces a resolved account watchlist, signal definitions, stakeholder coverage plan, ranked action queue, and learning loop.
+category: ABM
+tags: [Sales, Marketing, Demand Gen]
+---
+
+Use this when account selection is known but timing is not. Produce a stable company watchlist and an action queue tied to verified changes and appropriate stakeholders.
+
+## Resolve the account list
+
+Start from companies, not purchased people. For every target, retain the submitted name and resolve a canonical domain, operating entity, parent relationship, segment, owner, and ICP evidence. Search existing and archived CRM records before proposing creation.
+
+Route ambiguous domains, subsidiaries, and namesakes for review. Do not watch an unresolved company name: signal matching will blend unrelated entities and contaminate both action and learning.
+
+Classify each account as watch, research, or exclude. “Watch” requires stable identity and fit. “Research” means fit or identity is incomplete. “Exclude” records a durable reason.
+
+## Define meaningful changes
+
+Create a signal specification before collecting events. For each signal family, document the observable event, primary evidence, freshness window, expected business implication, false-positive patterns, and likely buying roles.
+
+Favor changes that alter capacity, priority, risk, leadership, or operating complexity. Generic news volume and social engagement are not inherently buying signals. Read [references/watchlist-rubric.md](references/watchlist-rubric.md) to rank account fit, event strength, and stakeholder access separately.
+
+## Build stakeholder coverage
+
+For each watched account, identify the minimum role coverage needed to act on likely signal families. Verify current employment and account relationship. Preserve known relationships, previous replies, opportunity context, and customer status.
+
+Missing contact coverage is a research task, not permission to create speculative people. Resolve every proposed contact against existing identities and attach it to a canonical account. Name one accountable owner for the account.
+
+## Operate the queue
+
+On each cadence:
+
+1. Collect fresh events and preserve exact evidence and occurrence dates.
+2. Resolve each event to one watched account.
+3. Suppress duplicate events and changes already acted upon.
+4. Re-evaluate fit, active opportunities, recent touches, and exclusions.
+5. Rank the account-event-contact combination, not the event alone.
+6. Return engage, research, nurture, or skip with a reason and counterargument.
+
+An engage decision needs a verified stakeholder and a specific, evidence-supported implication. Research is correct when the event is strong but contact access is missing. Skip is correct when timing, fit, or context fails.
+
+Use [references/worked-watchlist.md](references/worked-watchlist.md) for subsidiary resolution and multi-stakeholder examples.
+
+## Govern activation
+
+Create a reviewable task containing the account, contact, event, source, recent history, hypothesis, and proposed channel. Require human approval before sending or bulk-creating records. Route active-deal evidence to the opportunity owner rather than starting parallel outreach.
+
+Record outcomes by account, contact, signal family, and hypothesis. Adjust weights only after sufficient volume; retain negative and skipped outcomes to prevent survivorship bias.
+
+## What good looks like
+
+- Every watched company has a canonical identity, fit reason, and owner.
+- Signal specifications name both expected implications and false positives.
+- The queue ranks account-event-contact combinations.
+- Strong events without stakeholder coverage become research, not blind outreach.
+- Active relationships and suppressions override campaign enthusiasm.
+- Outcome history improves prioritization without erasing human context.
+
+The mediocre version uploads company names, watches every available event, buys contacts after a signal, and sends generic messages before resolving subsidiaries or checking active relationships.
+
+## Rules
+
+- MUST resolve canonical account identity before monitoring or creating contacts.
+- MUST preserve exact event evidence, occurrence date, and stakeholder rationale.
+- MUST require approval before record creation or outreach.
+- NEVER treat activity volume as intent without a plausible implication.
+- NEVER launch parallel outreach against an active opportunity or customer conflict.
+- NEVER allow missing stakeholder coverage to become a domain-only send.

--- a/skills/ryan-iyengar/abm-signal-watchlist/references/watchlist-rubric.md
+++ b/skills/ryan-iyengar/abm-signal-watchlist/references/watchlist-rubric.md
@@ -1,0 +1,11 @@
+# Watchlist action rubric
+
+Score fit, event strength, and stakeholder coverage separately from 0–4.
+
+- Fit 4: priority ICP with verified evidence; 0: excluded.
+- Event 4: verified change inside 7 days with direct operational implication; 0: unverifiable or irrelevant.
+- Coverage 4: verified accountable stakeholder with relationship context; 0: no person.
+
+Engage requires at least 10 total, no dimension below 3, and no conflict. Research when fit and event total at least 6 but coverage is below 3. Nurture when fit is 3+ but event is early or weak. Skip on exclusion, stale evidence, active conflict, or total below 6.
+
+Review thresholds after at least 30 acted events in a signal family. Track positive replies and qualified progression, not opens alone.

--- a/skills/ryan-iyengar/abm-signal-watchlist/references/worked-watchlist.md
+++ b/skills/ryan-iyengar/abm-signal-watchlist/references/worked-watchlist.md
@@ -1,0 +1,7 @@
+# Worked watchlist cases
+
+A target list includes a global parent and three regional subsidiaries. Two subsidiaries buy independently and have distinct domains; the third shares procurement with the parent. Preserve the first two as operating accounts and map the third to the parent. Do not collapse all activity merely because the brands share ownership.
+
+A watched account posts several operations roles. The event is strong, but the only verified contact is in finance. Return research and identify the accountable operations leader; do not force the finance contact into an unrelated hypothesis.
+
+A leadership change occurs at an account with an active opportunity. Route the evidence to the opportunity owner with suggested stakeholder implications. Suppress new outbound even though the event score is high.

--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).


### PR DESCRIPTION
## What this skill does

Adds `abm-signal-watchlist` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile