### PR TITLE
add build-and-fill-a-tam by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).

--- a/skills/ryan-iyengar/build-and-fill-a-tam/SKILL.md
+++ b/skills/ryan-iyengar/build-and-fill-a-tam/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: build-and-fill-a-tam
+title: Build and fill a TAM
+description: |
+  Use this skill when a team needs a defensible total addressable market and a governed plan to cover it over time. Produces a sourced account estimate, revenue model, contact target, CRM coverage baseline, and measured population plan.
+category: Prospecting
+tags: [Sales, RevOps, Leadership]
+---
+
+Use this when the team needs to size a market and turn that estimate into an executable account-coverage program. Produce labeled assumptions, real account counts where possible, and a burn-up plan that never confuses loaded records with valid TAM coverage.
+
+## Freeze the ICP definition
+
+Write the account inclusion and exclusion rules before counting. Specify industry, company size, geography, business model, technology or operating conditions, and disqualifiers. Separate required filters from preferences and mark which filters can actually be measured by each source.
+
+Define the unit of analysis. Count companies, not people, when estimating account TAM. Decide how subsidiaries, franchises, agencies, parent companies, and multi-brand groups are treated. Preserve one canonical domain per operating account and document exceptions.
+
+## Estimate the account universe
+
+Prefer a bottom-up count from a source capable of returning the matching companies. Record the source, query date, applied filters, omitted filters, caps, sampling, and estimated duplication. If the source exposes only a count, label the result as a count estimate rather than a verified account list.
+
+Cross-check with a second method: industry registry, known-account sample, CRM classification, or another data source. Investigate large differences instead of averaging incompatible populations. A provider cap is a floor, not the size of the market.
+
+Use [references/tam-model.md](references/tam-model.md) for the calculation and uncertainty bands.
+
+## Add revenue and contact targets
+
+Use a real annual contract value: the median or trimmed mean of comparable closed-won deals, annualized from the recorded contract period. Do not substitute a price-page maximum or an unlabeled band.
+
+Calculate:
+
+- account TAM = eligible accounts;
+- revenue TAM = eligible accounts × annual contract value;
+- contact target = eligible accounts × required buying roles per account.
+
+Report the sources for each number independently. CRM presence can measure coverage; it does not establish annual contract value unless closed-won data is explicitly used.
+
+## Measure current coverage
+
+Classify CRM accounts as in-TAM, out-of-TAM, or unknown against the same ICP. Only in-TAM accounts count toward coverage. Unknown records expose missing data; out-of-TAM records are not progress merely because they exist.
+
+Deduplicate accounts by stable identity before measuring. Report account coverage, contact coverage, and role coverage separately. An account with one irrelevant contact is not fully covered.
+
+If verified in-TAM accounts already exceed the estimated universe, treat the estimate as a floor and revise it upward. Do not force the CRM count down to preserve the original story.
+
+## Fill the gap in governed batches
+
+Prioritize uncovered accounts by ICP strength and evidence quality. Resolve identity before creating records. Every proposed account should include source, domain, fit evidence, owner, and acquisition cost where applicable. Every proposed contact should link to a resolved account and required buying role.
+
+Plan small batches, review cost and sample quality before acquisition, and require approval before records are created. Track attempted, resolved, created, rejected, and ambiguous records. Schedule research and planning freely; keep creation and spend gated.
+
+Read [references/worked-tam.md](references/worked-tam.md) for a model that is revised when CRM evidence exceeds an initial capped estimate.
+
+## Track burn-up honestly
+
+Save dated coverage snapshots using the same definitions. Calculate net new verified in-TAM accounts per period and project time to target only after at least three comparable observations. Show losses from deduplication, disqualification, and stale contacts.
+
+## What good looks like
+
+- Every number names its source, date, unit, and major limitation.
+- Account, revenue, contact, and role coverage are not conflated.
+- The CRM is classified against the ICP instead of counted wholesale.
+- Provider caps and missing filters appear as uncertainty, not false precision.
+- Population batches are deduplicated, owner-stamped, costed, and approved.
+- The estimate changes when stronger bottom-up evidence contradicts it.
+
+The mediocre version multiplies an arbitrary database count by aspirational pricing, calls every CRM account covered TAM, and buys a large list without resolving identities or measuring role depth.
+
+## Rules
+
+- MUST define the ICP and counting unit before estimating.
+- MUST use a confirmed annual contract value and label every source.
+- MUST resolve records and review spend before acquisition or creation.
+- NEVER treat a capped result as the full universe.
+- NEVER count unknown or out-of-TAM CRM records as coverage.
+- NEVER project an ETA from fewer than three comparable snapshots.

--- a/skills/ryan-iyengar/build-and-fill-a-tam/references/tam-model.md
+++ b/skills/ryan-iyengar/build-and-fill-a-tam/references/tam-model.md
@@ -1,0 +1,11 @@
+# TAM model
+
+Use three scenarios rather than one falsely precise number.
+
+1. Low: verified eligible accounts after known exclusions.
+2. Base: verified count adjusted for measured source coverage and duplication.
+3. High: base plus populations hidden by unavailable ICP filters or source caps.
+
+For each scenario calculate accounts, annual contract value, revenue TAM, buyers per account, and contact target. Use median annualized closed-won value from the closest segment when at least 20 comparable deals exist. With fewer than 20, report the sample size and sensitivity at minus and plus 25% ACV.
+
+Coverage equals verified in-TAM CRM accounts divided by the scenario’s eligible accounts. Role coverage equals filled required buying-role slots divided by total required slots. Report both.

--- a/skills/ryan-iyengar/build-and-fill-a-tam/references/worked-tam.md
+++ b/skills/ryan-iyengar/build-and-fill-a-tam/references/worked-tam.md
@@ -1,0 +1,7 @@
+# Worked TAM revision
+
+An ICP query returns 42,000 companies, but the source documents a 40,000-result cap. Label 42,000 as a floor, not a complete universe. A second registry contributes 8,500 eligible companies with only 2,000 overlapping the first source, producing a base estimate of at least 48,500 after deduplication.
+
+Comparable closed-won deals have a median annual value of $24,000. Base revenue TAM is therefore $1.164B. With three required buying roles, the contact target is 145,500.
+
+The CRM contains 19,000 accounts: 11,500 in-TAM, 4,000 out-of-TAM, and 3,500 unknown. Account coverage is 23.7%, not 39.2%. Investigate unknowns separately. If later classification proves 52,000 CRM accounts are in-TAM, revise the external estimate upward rather than reporting coverage above 100%.

--- a/skills/ryan-iyengar/build-and-fill-a-tam/references/worked-tam.md
+++ b/skills/ryan-iyengar/build-and-fill-a-tam/references/worked-tam.md
@@ -1,7 +1,7 @@
 # Worked TAM revision
 
-An ICP query returns 42,000 companies, but the source documents a 40,000-result cap. Label 42,000 as a floor, not a complete universe. A second registry contributes 8,500 eligible companies with only 2,000 overlapping the first source, producing a base estimate of at least 48,500 after deduplication.
+An ICP query reaches the source's documented 40,000-result cap. Label 40,000 as a floor, not a complete universe. A second registry contributes 8,500 eligible companies with only 2,000 overlapping the first source, producing a base estimate of at least 46,500 after deduplication.
 
-Comparable closed-won deals have a median annual value of $24,000. Base revenue TAM is therefore $1.164B. With three required buying roles, the contact target is 145,500.
+Comparable closed-won deals have a median annual value of $24,000. Base revenue TAM is therefore $1.116B. With three required buying roles, the contact target is 139,500.
 
-The CRM contains 19,000 accounts: 11,500 in-TAM, 4,000 out-of-TAM, and 3,500 unknown. Account coverage is 23.7%, not 39.2%. Investigate unknowns separately. If later classification proves 52,000 CRM accounts are in-TAM, revise the external estimate upward rather than reporting coverage above 100%.
+The CRM contains 19,000 accounts: 11,500 in-TAM, 4,000 out-of-TAM, and 3,500 unknown. Account coverage is 24.7%, not 40.9%. Investigate unknowns separately. If later deduplicated research across the CRM and external sources identifies 52,000 eligible companies, revise the external estimate upward rather than reporting coverage above 100%.


### PR DESCRIPTION
## What this skill does

Adds `build-and-fill-a-tam` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile