### PR TITLE
add crm-health-scoring by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).

--- a/skills/ryan-iyengar/crm-health-scoring/SKILL.md
+++ b/skills/ryan-iyengar/crm-health-scoring/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: crm-health-scoring
+title: Score CRM health over time
+description: |
+  Use this skill when leaders need a repeatable measure of CRM reliability, its trend, and the defects driving it. Produces a deterministic health score, object- and rule-level diagnostics, a confidence statement, and a prioritized remediation queue.
+category: RevOps
+tags: [RevOps, Leadership]
+---
+
+Use this when a team needs to measure whether CRM reliability is improving. Produce a reproducible score and diagnosis, not a decorative grade.
+
+## Define health as rules
+
+Translate “clean CRM” into explicit checks across identity, ownership, completeness, pipeline integrity, process conformance, and integration drift. Every rule must declare its population, condition, severity, evidence, exclusions, and owner.
+
+Measure only fields and relationships that influence execution or decisions. Do not reward filling optional fields merely because they are easy to count. Keep rule definitions versioned; a changed rule creates a new baseline and must not be presented as organic improvement or decline.
+
+## Score the population
+
+Calculate rule failure rates on eligible records. Weight by business impact, not raw finding count. A handful of duplicate accounts splitting live opportunities can matter more than thousands of missing optional fields.
+
+Score objects separately before rolling them up. Contacts, accounts, opportunities, and activities have different populations and failure modes. Use [references/scoring-model.md](references/scoring-model.md) for a deterministic 0–100 model and minimum sample rules.
+
+Report the score with:
+
+- evaluated and excluded record counts;
+- rule failures and rates;
+- object-level scores;
+- top contributors to lost points;
+- rule-set version and snapshot time;
+- confidence or coverage limitations.
+
+Never hide an unevaluable rule by scoring it as passing. Mark it unknown and explain what data is missing.
+
+## Diagnose the movement
+
+Compare snapshots only when the rule set and eligible population are comparable. Decompose change into corrected records, newly introduced defects, population changes, and definition changes.
+
+Look for source concentration. Break failures down by integration, form, import, owner, segment, record age, and pipeline stage. A worsening score caused by one new source calls for a source control; a broad decline may indicate incentives or process design.
+
+Read [references/worked-health-review.md](references/worked-health-review.md) for an example where the overall score improves while opportunity health worsens.
+
+## Prioritize remediation
+
+Rank rule-source combinations by severity, affected share, recurrence, and downstream reach. Fix ongoing creation of defects before paying down the backlog. Prioritize identity and ownership defects that contaminate routing, signals, and reporting across several workflows.
+
+For every remediation item, name the source, accountable owner, immediate containment, durable control, target metric, and review date. Keep corrective writes in a separate reviewed plan; a health report does not authorize changes.
+
+## Establish the cadence
+
+Save snapshots on a consistent schedule and after material migrations or cleanups. Use weekly measurement for operational databases and monthly leadership review unless the data changes more slowly. Annotate migrations, acquisitions, new integrations, and rule changes.
+
+Set targets by critical rule as well as total score. A 95 overall score is unacceptable if customer suppressions or ownership routing still fail. Trend the number of recurring defects, not only the remaining backlog.
+
+## What good looks like
+
+- Another operator can reproduce the score from the rule definitions and snapshot.
+- Object-level results reveal where the system is unhealthy.
+- Unknown and excluded records remain visible.
+- Trend explanations separate fixes, new defects, population movement, and rule changes.
+- The remediation queue points to sources and owners.
+- Critical safety and routing rules have explicit targets independent of the composite score.
+
+The mediocre version averages field completeness, awards a green badge, changes definitions without rebasing, and celebrates improvement caused by excluding difficult records.
+
+## Rules
+
+- MUST version rules and preserve eligible, excluded, failed, and unknown counts.
+- MUST report object- and rule-level results with the composite score.
+- MUST require separate approval before applying any remediation.
+- NEVER score unevaluated records as passing.
+- NEVER compare incompatible snapshots without a visible rebaseline.
+- NEVER let a composite score mask a failing critical rule.

--- a/skills/ryan-iyengar/crm-health-scoring/references/scoring-model.md
+++ b/skills/ryan-iyengar/crm-health-scoring/references/scoring-model.md
@@ -1,0 +1,9 @@
+# CRM health scoring model
+
+Give every rule an impact weight from 1–5. For a rule, calculate `pass rate = 1 - failures / eligible records`. Exclude unknowns from the denominator but report their rate; if unknowns exceed 10%, mark the rule low confidence.
+
+Object score is the weighted mean of its rule pass rates × 100. Composite score weights objects by business relevance, not record count. A starting model is accounts 30%, contacts 25%, opportunities 35%, activities 10%.
+
+Do not publish an object score with fewer than 30 eligible records without a small-sample warning. Set critical-rule floors separately: suppression conflicts 100% pass, active ownership at least 99%, and unresolved duplicate accounts tied to open opportunities 0 tolerated.
+
+Version weights, populations, and thresholds together. When any changes, calculate the prior snapshot under both versions if possible and label the rebaseline.

--- a/skills/ryan-iyengar/crm-health-scoring/references/worked-health-review.md
+++ b/skills/ryan-iyengar/crm-health-scoring/references/worked-health-review.md
@@ -1,0 +1,7 @@
+# Worked health review
+
+The composite score rises from 82 to 86 after contact completeness improves. However, opportunity health falls from 91 to 78 because a new import creates past-due close dates and ownerless open deals.
+
+Do not report “CRM health improved four points” without the object split. Identify the new import as the source, contain it, and prioritize live opportunity ownership above remaining contact enrichment.
+
+The following week, a rule definition changes to exclude test records. Recalculate the prior snapshot under the new definition and label the result as a rebaseline. The apparent improvement from exclusions is not operational progress.


### PR DESCRIPTION
## What this skill does

Adds `crm-health-scoring` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile