### PR TITLE
add evidence-based-call-scoring by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).

--- a/skills/ryan-iyengar/evidence-based-call-scoring/SKILL.md
+++ b/skills/ryan-iyengar/evidence-based-call-scoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evidence-based-call-scoring
-title: Evidence-based sales call scoring
+title: Score sales calls on evidence
 description: |
   Use this skill when reviewing sales calls for coaching, qualification, deal inspection, or CRM updates. Produces an evidence-quoted scorecard, calibrated dimension scores, uncertainty flags, and a reviewable set of deal insights and next actions.
 category: Sales

--- a/skills/ryan-iyengar/evidence-based-call-scoring/SKILL.md
+++ b/skills/ryan-iyengar/evidence-based-call-scoring/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: evidence-based-call-scoring
+title: Evidence-based sales call scoring
+description: |
+  Use this skill when reviewing sales calls for coaching, qualification, deal inspection, or CRM updates. Produces an evidence-quoted scorecard, calibrated dimension scores, uncertainty flags, and a reviewable set of deal insights and next actions.
+category: Sales
+tags: [Sales, Leadership]
+---
+
+Use this after a sales call when the team needs defensible coaching or deal evidence. Produce a rubric-based scorecard tied to transcript evidence; do not grade confidence, charisma, or transcript summaries.
+
+## Establish the evidence
+
+Confirm the participants, account, opportunity, call type, date, and transcript quality. Separate buyer speech from seller speech. Mark inaudible sections, uncertain speakers, transcription errors, and missing call segments before scoring.
+
+Link the call to a deal only when account, participants, timing, and context agree. If several opportunities could match, preserve the ambiguity. Do not write insights to the nearest deal merely because its name resembles the account.
+
+Extract evidence as short verbatim spans with speaker and timestamp. Distinguish buyer-stated facts, seller claims, hypotheses, commitments, and unanswered questions. A seller describing the buyer’s pain is not buyer confirmation.
+
+## Score against observable behaviors
+
+Choose the rubric for the call type before reading the outcome. Score discovery, validation, stakeholder coverage, business impact, decision process, next steps, and seller execution only where they apply. Use [references/call-rubric.md](references/call-rubric.md) for a four-level scale.
+
+For each dimension provide:
+
+- score and definition;
+- supporting evidence;
+- strongest contradictory or missing evidence;
+- confidence in the score;
+- one coaching action or deal question.
+
+Award credit for observable behavior, not vocabulary. A scripted question earns little if the seller ignores the answer. A concise call can score highly when the buyer supplies clear evidence and next steps.
+
+## Separate coaching from deal truth
+
+Create two outputs. The coaching view evaluates seller behavior and the next skill to practice. The deal view records buyer-confirmed problem, impact, stakeholders, process, risks, commitments, and open questions.
+
+Do not convert inference into CRM fact. Proposed field updates should quote the supporting buyer evidence and remain reviewable. Human decisions include opportunity stage, forecast category, amount, close date, and any interpretation that materially affects reporting.
+
+Read [references/worked-scorecard.md](references/worked-scorecard.md) for an example where polished seller execution does not compensate for missing buyer confirmation.
+
+## Calibrate reviewers
+
+Have two reviewers independently score a sample of at least ten calls. Compare dimension-level differences and discuss evidence, not total scores. Clarify rubric anchors when reviewers differ by more than one level on the same dimension.
+
+Maintain benchmark calls for each call type and score level. Re-score a stable benchmark set when the rubric changes. Report model or reviewer consistency separately from seller performance.
+
+## Produce the review
+
+Lead with the three most important findings, then the scorecard, evidence, risks, next actions, and proposed record updates. Preserve timestamps so a manager can verify conclusions quickly. Name what cannot be concluded from the call.
+
+Prefer one behaviorally specific coaching priority over a long list. Tie it to the next call: the question to ask, evidence to obtain, or commitment to secure.
+
+## What good looks like
+
+- Every material claim traces to a speaker and timestamp.
+- Buyer statements are distinguished from seller narration and reviewer inference.
+- Scores use behavioral anchors and expose contradictory evidence.
+- Coaching and deal inspection remain separate but consistent.
+- Ambiguous opportunity links and low-quality transcripts reduce confidence visibly.
+- Reviewers can reproduce scores within one level after calibration.
+
+The mediocre version summarizes the call, rewards talk-track compliance, infers qualification from seller statements, and writes optimistic fields without review.
+
+## Rules
+
+- MUST preserve speaker, timestamp, transcript-quality, and call-context evidence.
+- MUST separate buyer-confirmed facts, seller claims, and reviewer inference.
+- MUST require human approval for material CRM or forecast changes.
+- NEVER invent quotes, timestamps, participants, or commitments.
+- NEVER force an ambiguous call-to-deal link.
+- NEVER score a dimension that the call type or available evidence cannot support.

--- a/skills/ryan-iyengar/evidence-based-call-scoring/references/call-rubric.md
+++ b/skills/ryan-iyengar/evidence-based-call-scoring/references/call-rubric.md
@@ -1,0 +1,12 @@
+# Sales call rubric
+
+Score applicable dimensions from 0–3:
+
+- 0 absent: no observable attempt or evidence.
+- 1 attempted: behavior appears, but remains generic, seller-led, or unresolved.
+- 2 established: buyer-confirmed evidence is specific enough to guide the deal.
+- 3 advanced: evidence is specific, quantified or multi-stakeholder, tested for contradiction, and converted into a mutual commitment.
+
+Apply this scale to problem clarity, business impact, stakeholder coverage, decision process, urgency, next steps, and listening/follow-through. Mark not applicable instead of zero when a dimension does not belong to the call type.
+
+Overall score is the mean of applicable dimensions, but never hide a zero in next steps, decision process, or buyer-confirmed problem behind a strong average. Confidence is high only when the transcript is complete, speakers are reliable, and at least two evidence spans support material dimensions.

--- a/skills/ryan-iyengar/evidence-based-call-scoring/references/worked-scorecard.md
+++ b/skills/ryan-iyengar/evidence-based-call-scoring/references/worked-scorecard.md
@@ -1,0 +1,7 @@
+# Worked scorecard
+
+A seller delivers a polished demo and asks about timing. The buyer says the current process is “annoying,” but gives no quantified impact, names no other stakeholder, and declines to schedule a next meeting until speaking internally.
+
+Score seller presentation separately from qualification. Problem clarity is 1: a pain statement exists but is not developed. Business impact is 0: no buyer-confirmed consequence. Stakeholder coverage is 0. Next steps is 1 because an action exists, but it is unilateral and undated.
+
+The deal view should record the exact pain quote and the missing evidence. It should not infer urgency from the seller’s strong delivery or advance the stage automatically. The coaching priority is to follow the buyer’s pain language with impact and decision-process questions before continuing the demo.


### PR DESCRIPTION
## What this skill does

Adds `evidence-based-call-scoring` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile