### PR TITLE
add resolve-before-create by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).

--- a/skills/ryan-iyengar/resolve-before-create/SKILL.md
+++ b/skills/ryan-iyengar/resolve-before-create/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: resolve-before-create
+title: Resolve before creating CRM records
+description: |
+  Use this skill before importing, enriching, or manually creating contacts and accounts in a CRM. Produces a create, link, review, or reject decision that prevents duplicates while preserving uncertain matches for human resolution.
+category: RevOps
+tags: [RevOps]
+---
+
+Use this before any workflow creates CRM records. Produce an evidence-backed identity decision for every proposed contact or account.
+
+## Normalize without destroying evidence
+
+Retain the raw input, then derive normalized comparison values. Lowercase domains and emails, remove URL protocols and paths, standardize whitespace, and separate legal suffixes from company names. Do not strip meaningful subdomains, country distinctions, or name tokens merely to force a match.
+
+Identify the strongest available keys. For people, prioritize verified email, provider identity, account relationship, full name, and role. For accounts, prioritize canonical domain, verified external identity, legal entity, address, and normalized name. A company name alone is weak evidence; a shared consumer-email domain is not account identity.
+
+## Search broadly, decide narrowly
+
+Search active and archived records, alternate emails, former domains, aliases, parent-child relationships, and identifiers merged within the organization’s retention window. Search each strong key independently so a formatting error in one field does not hide an existing record.
+
+Build candidate pairs and compare corroborating and conflicting evidence. Return one of four decisions:
+
+- **Link:** one candidate is unambiguous and the new data belongs on it.
+- **Create:** no credible candidate exists after all strong keys are searched.
+- **Review:** multiple candidates remain or important evidence conflicts.
+- **Reject:** the input lacks minimum identity evidence or violates an exclusion rule.
+
+Use [references/match-rubric.md](references/match-rubric.md) for numeric scoring. The score supports the decision; it does not override a hard conflict.
+
+## Plan the action
+
+For a link decision, specify which existing record receives each new value and whether the update fills a blank or replaces data. Do not overwrite a verified value with an unverified enrichment.
+
+For a create decision, include the keys searched, search time, candidate count, proposed owner, source, consent or lawful-use context, and required relationships. Accounts should carry a stable domain where available. Contacts should not be created as ownerless, accountless records when those relationships are known.
+
+For review decisions, show the smallest evidence set a human needs: candidate identifiers, matching fields, conflicts, recent activity, ownership, and downstream relationships. Do not ask the reviewer to rediscover the match.
+
+Before applying the action, repeat the search. Another workflow may have created the record after planning. If a new candidate appears, invalidate the create decision and resolve again.
+
+Read [references/worked-resolution.md](references/worked-resolution.md) for common domain, email, and subsidiary cases.
+
+## Monitor the gate
+
+Track proposed creates, prevented duplicates, ambiguous reviews, false links, false creates, and resolution time. Sample both approved creates and links. A gate that prevents duplicates by routing everything to review is not working; neither is one that boasts high automation while creating costly false links.
+
+Investigate sudden increases by source. A spike often indicates a changed export format, upstream identifier loss, a new acquisition, or an integration searching a narrower population than it writes.
+
+## What good looks like
+
+- Every create decision lists the keys and populations searched.
+- Exact identifiers drive high-confidence matches, while names provide corroboration rather than proof.
+- Conflicts such as different legal entities or verified emails force review.
+- The action is re-resolved immediately before creation.
+- New records arrive with ownership, provenance, and known relationships.
+- Reviewers see actionable evidence rather than a vague “possible duplicate” warning.
+
+The mediocre version checks only exact email or company name, ignores archived records, creates first and deduplicates later, or links records because a fuzzy score crossed a threshold despite contradictory evidence.
+
+## Rules
+
+- MUST retain raw source values and record the search evidence.
+- MUST re-run resolution immediately before creation.
+- MUST require human review for conflicting strong identifiers or irreversible merges.
+- NEVER match accounts on normalized name alone.
+- NEVER replace verified data with weaker enrichment without approval.
+- NEVER create records to evade an ambiguous match.

--- a/skills/ryan-iyengar/resolve-before-create/references/match-rubric.md
+++ b/skills/ryan-iyengar/resolve-before-create/references/match-rubric.md
@@ -1,0 +1,12 @@
+# Match rubric
+
+Add evidence points: exact verified email +8; exact canonical domain +7; exact provider identity +8; exact legal entity and country +5; normalized name +2; matching address +3; matching phone +4; matching account relationship +3.
+
+Subtract conflicts: different verified email -8; different canonical domain with no documented rebrand -6; different legal entity or country -5; conflicting active ownership context -2.
+
+- Link at 8+ with at least one strong identifier and no hard conflict.
+- Review at 4–7, or whenever strong identifiers conflict.
+- Create below 4 only after all available strong keys and archived records are searched.
+- Reject when the input has no stable identity key.
+
+Never sum several weak name similarities into the equivalent of a verified identifier.

--- a/skills/ryan-iyengar/resolve-before-create/references/worked-resolution.md
+++ b/skills/ryan-iyengar/resolve-before-create/references/worked-resolution.md
@@ -1,0 +1,9 @@
+# Worked resolution cases
+
+An incoming contact has the same verified work email as an existing archived contact. Link and restore or update the existing identity; do not create a second record because the first is archived.
+
+An account name matches exactly, but its canonical domain and country differ. Route to review as a possible namesake or subsidiary. Name similarity cannot overcome the domain conflict.
+
+A company has rebranded. The old record contains the former domain, active opportunities, and a documented redirect to the new canonical domain. Link with the rebrand evidence and preserve the old domain as an alias.
+
+A contact uses a consumer email and shares a common name with two existing contacts. Reject or review until employer or another stable identifier is available.


### PR DESCRIPTION
## What this skill does

Adds `resolve-before-create` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile