### PR TITLE
add trigger-based-outbound by ryan-iyengar

### DIFF
--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,0 +1,9 @@
+---
+name: Ryan Iyengar
+title: CEO & Founder, Full Stack GTM
+linkedinUrl: https://www.linkedin.com/in/ryaniyengar
+companyDomain: fullstackgtm.com
+email: ryan@fullstackgtm.com
+---
+
+Ryan Iyengar is the CEO and founder of Full Stack GTM. He previously led go-to-market organizations as a CMO, CRO, and President, most recently as President of Helium 10, and now builds governed data and AI systems for GTM teams. He shares open-source work on [GitHub](https://github.com/ryanfsgtm).

--- a/skills/ryan-iyengar/trigger-based-outbound/SKILL.md
+++ b/skills/ryan-iyengar/trigger-based-outbound/SKILL.md
@@ -2,7 +2,7 @@
 name: trigger-based-outbound
 title: Trigger-based outbound
 description: |
-  Use this skill when an account-level change creates a timely reason to engage. Produces a ranked send, nurture, or skip decision, a verified contact target, a trigger-grounded opener, and an outcome record that improves future signal selection.
+  Use this skill to qualify one already-detected account event for an outreach decision; use abm-signal-watchlist to operate persistent monitoring across a fixed account list. Produces a ranked send, nurture, or skip decision, a verified contact target, a trigger-grounded opener, and an outcome record that improves future signal selection.
 category: Signals
 tags: [Sales, Demand Gen]
 ---

--- a/skills/ryan-iyengar/trigger-based-outbound/SKILL.md
+++ b/skills/ryan-iyengar/trigger-based-outbound/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: trigger-based-outbound
+title: Trigger-based outbound
+description: |
+  Use this skill when an account-level change creates a timely reason to engage. Produces a ranked send, nurture, or skip decision, a verified contact target, a trigger-grounded opener, and an outcome record that improves future signal selection.
+category: Signals
+tags: [Sales, Demand Gen]
+---
+
+Use this when a fresh account change may create a credible reason to start or resume a conversation. Produce a ranked decision and a reviewable message task; do not treat a detected event as automatic permission to send.
+
+## Qualify the trigger
+
+1. Capture the event, source, observed date, account, and exact evidence. Prefer primary evidence over summaries.
+2. Verify freshness against the date the event occurred, not the date an aggregator surfaced it.
+3. Translate the event into a plausible operational implication. A job posting matters only when the role, seniority, volume, or language connects to the problem being solved.
+4. Compare the account with the ICP and exclusion rules. Record why the signal changes priority now.
+5. Check recent activity, open opportunities, suppression rules, customer status, and previous replies before deciding to engage.
+
+Score the event using [references/signal-rubric.md](references/signal-rubric.md). A high event score cannot rescue poor fit or missing contact access.
+
+## Resolve the person
+
+Start with the account, then identify the person whose responsibility is closest to the observed change. Confirm that the contact belongs to the account and that the role evidence is current. Prefer an existing relationship or known stakeholder over a newly found senior title.
+
+If the signal exists only at domain level and no appropriate person is verified, return “acquire or research contact” rather than drafting a send. If several stakeholders are relevant, name a primary contact and a distinct reason for involving each additional contact. Do not send the same message to an entire buying group.
+
+## Decide send, nurture, or skip
+
+- **Send:** strong fit, material and fresh trigger, verified person, no suppression, and a specific implication.
+- **Nurture:** credible fit but the trigger is weak, early, ambiguous, or lacks a reachable stakeholder.
+- **Skip:** poor fit, stale or generic evidence, active conflict, recent negative reply, customer-sensitive context, or no defensible connection.
+
+Record the decision and the strongest counterargument. This exposes weak enthusiasm disguised as scoring.
+
+## Draft the opener
+
+Write one opener around the observed change, its likely implication, and a low-friction question. State only what the evidence supports. The trigger should explain why this account and why now; it should not be used as surveillance theater.
+
+Keep the first message focused on one hypothesis. Do not lead with congratulations unless the event is genuinely celebratory. Do not pretend to know internal priorities. Read [references/worked-signals.md](references/worked-signals.md) for send, nurture, and skip examples.
+
+Before creating a send task, show the account, contact, evidence, recent-touch check, message, and channel to a human reviewer. Sending remains a separate approved action.
+
+## Learn from outcomes
+
+Record delivered, replied, positive reply, meeting, disqualified, and negative feedback against the account, contact, trigger type, and message hypothesis. Evaluate trigger types over a meaningful sample; do not rewrite weights after one win.
+
+Review both precision and coverage. A signal program that never makes mistakes because it selects almost nothing is not necessarily useful. Preserve negative outcomes so future ranking does not repeat avoidable touches.
+
+## What good looks like
+
+- The exact evidence, event date, and source are inspectable.
+- The contact’s responsibility makes the hypothesis credible.
+- The opener would still make sense if the recipient knew exactly how the event was found.
+- “Skip” and “nurture” remain common, legitimate outputs.
+- Recent conversations and customer context suppress inappropriate outreach.
+- Outcome history changes priorities only after enough observations to distinguish a pattern from noise.
+
+The mediocre version alerts on every funding story or job post, targets the most senior available title, produces generic congratulations, and measures messages sent rather than useful conversations.
+
+## Rules
+
+- MUST verify the event date, account identity, contact identity, and recent-touch history.
+- MUST keep drafting and sending as separate actions with human approval before send.
+- NEVER fabricate an implication, quote, relationship, or internal initiative.
+- NEVER contact a domain-only target without resolving an appropriate person.
+- NEVER evade suppression, consent, or channel-policy requirements.

--- a/skills/ryan-iyengar/trigger-based-outbound/references/signal-rubric.md
+++ b/skills/ryan-iyengar/trigger-based-outbound/references/signal-rubric.md
@@ -1,0 +1,18 @@
+# Signal scoring rubric
+
+Score four dimensions from 0–3.
+
+| Dimension | 0 | 1 | 2 | 3 |
+| --- | --- | --- | --- | --- |
+| Fit | outside ICP | partial fit | clear ICP | priority segment |
+| Materiality | no relevant change | weak proxy | relevant change | change directly creates urgency |
+| Freshness | over 90 days | 31–90 days | 8–30 days | 0–7 days |
+| Contactability | no person | possible role | verified relevant person | relevant person with relationship/context |
+
+Apply a conflict penalty of minus 4 for an active opportunity owned by another seller, an unresolved negative reply, or customer-sensitive context. Apply minus 2 when the account was touched inside the team’s normal cooldown.
+
+- Send: 9 or more, no zero dimension, and no unresolved conflict.
+- Nurture: 6–8, or 9+ with missing contact access.
+- Skip: 5 or less, any disqualifying conflict, or unverifiable evidence.
+
+Treat these as starting thresholds. Recalibrate after at least 30 decisions per trigger family and report positive-reply rate alongside total volume.

--- a/skills/ryan-iyengar/trigger-based-outbound/references/worked-signals.md
+++ b/skills/ryan-iyengar/trigger-based-outbound/references/worked-signals.md
@@ -1,0 +1,13 @@
+# Worked signal decisions
+
+## Send
+
+A priority-segment account posts five senior operations roles in seven days, each naming a workflow the offer supports. A verified operations leader owns the function and has not been contacted in 120 days. The opener cites the hiring pattern, frames the scaling implication as a hypothesis, and asks whether consistency across the new team is already a priority.
+
+## Nurture
+
+A good-fit account announces funding, but the announcement is 45 days old and no relevant stakeholder is verified. Preserve the account and research the operating plan; do not send generic congratulations.
+
+## Skip
+
+A hiring signal scores highly, but an active opportunity exists with a different owner. Route the evidence to that owner. Creating parallel outbound would damage the account even though the signal itself is valid.


### PR DESCRIPTION
## What this skill does

Adds `trigger-based-outbound` by Ryan Iyengar. This is one of the follow-on skill submissions to #80.

The identical `skills/ryan-iyengar/author.md` is included so this branch validates independently while #80 is still pending. Once #80 merges, it should drop from this PR's effective diff.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/ryan-iyengar/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution profile is pending in #80; the identical `author.md` is included here for independent validation
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile