### PR TITLE
Add avatarUrls: boaz-descalo, eliezer-cohen, ryan-iyengar

### DIFF
--- a/skills/boaz-descalo/author.md
+++ b/skills/boaz-descalo/author.md
@@ -1,5 +1,6 @@
 ---
 name: Boaz Descalo
+avatarUrl: "https://www.gtmskills.com/authors/boaz-descalo.jpg"
 title: Founder & CEO, Node8
 linkedinUrl: https://www.linkedin.com/in/descalo/
 companyDomain: node8.ai

--- a/skills/eliezer-cohen/author.md
+++ b/skills/eliezer-cohen/author.md
@@ -1,5 +1,6 @@
 ---
 name: Eliezer Cohen
+avatarUrl: "https://www.gtmskills.com/authors/eliezer-cohen.jpg"
 title: Head of Global Sales & Partnerships, GoPerfect
 linkedinUrl: https://www.linkedin.com/in/eliezercohen/
 companyDomain: goperfect.com

--- a/skills/ryan-iyengar/author.md
+++ b/skills/ryan-iyengar/author.md
@@ -1,5 +1,6 @@
 ---
 name: Ryan Iyengar
+avatarUrl: "https://www.gtmskills.com/authors/ryan-iyengar.jpg"
 title: CEO & Founder, Full Stack GTM
 linkedinUrl: https://www.linkedin.com/in/ryaniyengar
 companyDomain: fullstackgtm.com


### PR DESCRIPTION
Adds rehosted avatar URLs (www.gtmskills.com/authors/<slug>.jpg — images already deployed) to the three authors merged today, so the repo→DB sync creates their rows with real photos instead of the fallback face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)