### PR TITLE
add won-deal-icp-finder

### DIFF
--- a/skills/erwann-lefevre/author.md
+++ b/skills/erwann-lefevre/author.md
@@ -1,0 +1,10 @@
+---
+name: Erwann Lefevre
+avatarUrl: https://avatars.githubusercontent.com/u/215829310?v=4&size=460
+title: Growth & GTM Engineer, La Growth Machine
+linkedinUrl: https://www.linkedin.com/in/erwann-lefevre/
+companyDomain: lagrowthmachine.com
+email: erwann@lagrowthmachine.com
+---
+
+I work as a Growth & GTM Engineer at La Growth Machine, where I run outreach, CRO and acquisition — and spend most of my time turning the parts that work into something repeatable. I build GTM System, an open-source library of Claude skills for the go-to-market motion: sourcing and list building, campaign copy, reply handling, and the analytics that tell you which of it actually produced revenue. My skills encode the operator judgment underneath that work — the thresholds I really use, the checks that catch a bad list before it ships, and the failure modes I've hit often enough to write down.

--- a/skills/erwann-lefevre/won-deal-icp-finder/SKILL.md
+++ b/skills/erwann-lefevre/won-deal-icp-finder/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: won-deal-icp-finder
+title: Won-deal ICP finder
+description: |
+  Use this skill when someone wants to know who actually pays them — auditing closed-won deals to
+  derive a proven ideal customer profile instead of an aspirational one, then building a look-alike
+  target list from it. Produces a revenue-ranked deal table, two to four named ICP archetypes with
+  searchable criteria, and a ranking of the acquisition sources that produced the money. Trigger
+  phrasings: "audit my biggest deals", "which customers made us the most money", "analyse my
+  closed-won", "what's my real ICP", "find more customers like my best ones", "look-alike accounts",
+  "revenue by account", "which channel produced our best deals", "ICP refresh before planning".
+category: Prospecting
+tags: [RevOps, Sales]
+---
+
+Applies when the ICP on the slide was written before the revenue arrived. Produces a proven profile, derived from deals that closed, plus the search criteria to find more of them.
+
+## Most stated ICPs are aspirational
+
+Teams write their ICP at the start, from the market they want. Then they close deals, and the deals quietly disagree — smaller, in an adjacent vertical, in a country nobody targeted. Nobody rewrites the slide, so prospecting keeps aiming at the market that never paid. This skill re-derives the profile from the ledger instead of the plan.
+
+## Select on money, not on stage names
+
+The first move is picking which deals count, and it is where this play usually breaks.
+
+The obvious approach — filter on a "Closed Won" stage — assumes a stage that a surprising number of pipelines don't have, or don't use consistently, or spell in another language. When it silently matches nothing, the fallback is worse: pull the most recent deals instead, which are the newest and emptiest ones, and the analysis runs on rows with no value in them.
+
+Select on **deal value being populated**, over the last twelve months. A won signal, where one genuinely exists, is a filter you add on top — not the thing you rely on. Read the CRM's own conventions before pulling anything: which field actually holds value (the standard amount field is often abandoned in favour of a custom ARR or ACV one), and whether a won status exists at all. If you can't tell, ask one specific question and stop. Guessing here doesn't produce a slightly-off answer, it produces a confident answer about empty rows. See `references/deal-data-extraction.md` for the field-discovery sequence, the CSV fallback, and how to keep the pull bounded.
+
+## Do the arithmetic in code
+
+Sums, revenue shares, concentration ratios, and frequency rankings across a hundred-odd deals are exactly the work a language model gets quietly and unfixably wrong — and a wrong ranking sends a team after the wrong accounts for a quarter.
+
+`scripts/analyze.py` does the counting. It parses both European and US amount formats, applies the window, excludes lost deals always, detects a won signal when present, aggregates revenue per company, and returns segments and source rankings as JSON. Run it, then reason over what it returns. It refuses rather than improvises when it can't find a value field, a company, or any deal in the window — a refusal is a question for the user, not a problem to code around. `references/analysis-engine.md` covers the flags, the output schema, and how to read each block.
+
+The judgment — which companies form a coherent archetype, whether a source ranking can be trusted, what to flag — is the part that stays yours.
+
+## Cluster on revenue, not on logos
+
+Group the companies behind the top deals into **two to four** named archetypes, built by intersecting the revenue-dominant industry, size and geography segments: "mid-market FinTech in FR/DE", not "B2B in Europe". Each needs objective criteria a search can consume — one or two values per dimension, a typical deal size, and how many won companies fit.
+
+Read revenue share, never deal count. Three large deals in one vertical beat twenty small ones in another, and counting logos rewards whichever segment is cheapest to sell to. Above roughly a quarter of revenue in a single account, you have a whale rather than a pattern — say so plainly instead of building an archetype around one customer.
+
+Before promoting any segment to an archetype, count the distinct companies inside it. A segment can sit third on the revenue table and consist entirely of one customer who renewed; the table makes it look like a market and it isn't. Fewer than two companies means concentration to report, not a profile to search. Past four archetypes you are slicing noise; collapse the thin ones. The clustering rubric, the anti-pattern table and a worked example are in `references/archetype-clustering.md`.
+
+## Then say where they came from
+
+Rank the acquisition sources behind these deals by frequency, with the revenue attached. Report the coverage alongside the ranking: below about 70% of deals carrying a source, the ranking is a sample, and should be described as one.
+
+Most CRMs carry the channel but not the campaign — you learn that outbound worked, not which sequence worked. That gap is worth naming explicitly, because it's the difference between knowing a channel pays and being able to scale the thing inside it that paid.
+
+## What good looks like
+
+The tell of a good operator: before touching the data they ask how this team marks a won deal, and they don't assume the answer is a stage. They know their own pipeline has three abandoned value fields and one real one, and they check which is which — because everything downstream inherits that choice.
+
+The mediocre version ranks accounts by deal count, produces five or six archetypes that are really just a list of the biggest customers with the serial numbers filed off, and quotes a channel ranking built from the 40% of deals that happened to have a source filled in. It reads as rigorous and points at the wrong market.
+
+Good output is falsifiable. Every archetype names the companies it was built from and how many there were, every rate carries its denominator, and anything inferred rather than observed — a buyer persona the CRM never recorded — is labelled as inferred. If the profile can't be handed to someone building a prospecting list and used without further interpretation, it isn't finished.
+
+## Rules
+
+- MUST select deals on a populated value field, never on the assumption that a won stage exists.
+- MUST run the aggregations in code and reason over the result, never total revenue by reading rows.
+- MUST state the selection basis when no won status was found, and confirm it maps to what the team calls won.
+- MUST report source coverage next to any acquisition ranking, and label inferred attributes as inferred.
+- MUST count the distinct companies behind a segment before turning it into an archetype.
+- NEVER rank or cluster by deal count.
+- NEVER build an archetype from firmographics the data didn't carry — an absent dimension is a gap to flag, not a blank to fill.
+- NEVER present a single dominant account as a repeatable profile.

--- a/skills/erwann-lefevre/won-deal-icp-finder/examples/sample-deals.json
+++ b/skills/erwann-lefevre/won-deal-icp-finder/examples/sample-deals.json
@@ -1,0 +1,16 @@
+[
+  {"Company": "Northwind Logistics", "Amount": "48000", "Deal Stage": "Closed Won", "Industry": "Logistics", "Number of Employees": "320", "Country": "France", "Original Source": "LinkedIn outreach", "Close Date": "2026-01-12"},
+  {"Company": "Northwind Logistics", "Amount": "22000", "Deal Stage": "Closed Won", "Industry": "Logistics", "Number of Employees": "320", "Country": "France", "Original Source": "LinkedIn outreach", "Close Date": "2026-04-03"},
+  {"Company": "Velora SaaS", "Amount": "36000", "Deal Stage": "Closed Won", "Industry": "SaaS", "Number of Employees": "140", "Country": "Germany", "Original Source": "LinkedIn outreach", "Close Date": "2026-02-08"},
+  {"Company": "Brightpath Consulting", "Amount": "31000", "Deal Stage": "Closed Won", "Industry": "Consulting", "Number of Employees": "85", "Country": "United Kingdom", "Original Source": "Email outreach", "Close Date": "2026-03-19"},
+  {"Company": "Cobalt FinTech", "Amount": "54000", "Deal Stage": "Closed Won", "Industry": "FinTech", "Number of Employees": "210", "Country": "France", "Original Source": "LinkedIn outreach", "Close Date": "2026-02-27"},
+  {"Company": "Cobalt FinTech", "Amount": "18000", "Deal Stage": "Closed Won", "Industry": "FinTech", "Number of Employees": "210", "Country": "France", "Original Source": "LinkedIn outreach", "Close Date": "2026-05-05"},
+  {"Company": "Atlas Retail Group", "Amount": "12000", "Deal Stage": "Closed Won", "Industry": "Retail", "Number of Employees": "1200", "Country": "Spain", "Original Source": "Inbound demo", "Close Date": "2026-01-30"},
+  {"Company": "Meridian SaaS", "Amount": "29000", "Deal Stage": "Closed Won", "Industry": "SaaS", "Number of Employees": "160", "Country": "Germany", "Original Source": "LinkedIn outreach", "Close Date": "2026-03-11"},
+  {"Company": "Solis Agency", "Amount": "9000", "Deal Stage": "Closed Won", "Industry": "Consulting", "Number of Employees": "45", "Country": "United Kingdom", "Original Source": "Email outreach", "Close Date": "2026-04-22"},
+  {"Company": "Ferro Manufacturing", "Amount": "15000", "Deal Stage": "Closed Won", "Industry": "Manufacturing", "Number of Employees": "2400", "Country": "Italy", "Original Source": "", "Close Date": "2026-02-02"},
+  {"Company": "Vantage FinTech", "Amount": "41000", "Deal Stage": "Closed Won", "Industry": "FinTech", "Number of Employees": "190", "Country": "Germany", "Original Source": "LinkedIn outreach", "Close Date": "2026-04-14"},
+  {"Company": "Quill SaaS", "Amount": "27000", "Deal Stage": "Closed Won", "Industry": "SaaS", "Number of Employees": "110", "Country": "France", "Original Source": "LinkedIn outreach", "Close Date": "2026-05-09"},
+  {"Company": "Harbor Insurance", "Amount": "7000", "Deal Stage": "Closed Lost", "Industry": "Insurance", "Number of Employees": "600", "Country": "France", "Original Source": "Cold call", "Close Date": "2026-01-05"},
+  {"Company": "Tideway Media", "Amount": "6000", "Deal Stage": "Discovery", "Industry": "Media", "Number of Employees": "70", "Country": "United Kingdom", "Original Source": "Inbound demo", "Close Date": ""}
+]

--- a/skills/erwann-lefevre/won-deal-icp-finder/references/analysis-engine.md
+++ b/skills/erwann-lefevre/won-deal-icp-finder/references/analysis-engine.md
@@ -1,0 +1,71 @@
+# The analysis engine
+
+`scripts/analyze.py` does the arithmetic. No dependencies beyond the standard library.
+
+```bash
+python3 scripts/analyze.py /path/to/deals.json --since-days 365
+```
+
+Accepts `.json`, `.csv`, or `-` for stdin. Returns a single JSON object.
+
+## Flags
+
+| Flag | When you need it |
+|---|---|
+| `--value-field "ARR"` | The money lives somewhere other than the standard amount column |
+| `--won-stage "Closed Won,Gagné"` | A real won stage exists — restrict to it. Comma-separated, exact labels, localised spellings welcome |
+| `--source-field "Lead Source"` | Acquisition source is in a custom column |
+| `--since-days N` | Window length; default 365, `0` disables windowing |
+| `--as-of YYYY-MM-DD` | Anchor the window to a fixed date rather than today |
+| `--top N` | How many deals and accounts to return |
+| `--test` | Run the golden-case self-test |
+
+Column matching is alias-based, so raw CRM exports with human-readable headers usually run with no flags at all. Amounts parse in both European (`1.234,56`) and US (`1,234.56`) notation.
+
+## Reading the output
+
+**`summary`** — the framing numbers, and two fields that govern how strongly you may phrase everything else:
+
+- `selection_basis` — either a detected won stage or flag, or `value-in-window` when no won signal exists. When it's `value-in-window`, state the basis in one line and ask the user to confirm it maps to their definition of won.
+- `excluded` — what was dropped and why (`dropped_no_value`, `out_of_window`, `lost_excluded`, `not_won_excluded`, `no_date`). Check this first when a total looks wrong. A large `dropped_no_value` usually means the wrong value field.
+
+**`top_deals`** — individual deals ranked by size. The headline table.
+
+**`top_accounts`** — revenue aggregated per company, so a customer with four deals appears once at its true weight. This, not `top_deals`, is the input to clustering.
+
+**`concentration`** — `top_1_account_share`, `top_5_accounts_share`, `top_10_accounts_share`, and `accounts_for_80pct_revenue`. A `top_1_account_share` above roughly 25% means revenue leans on one customer; report that rather than fitting an archetype to it. A low `accounts_for_80pct_revenue` says the same thing in the other direction.
+
+**`segments`** — revenue and counts broken out by `industry`, `size_bucket` and `country`. The raw material for archetypes. Read revenue share, not counts.
+
+**`acquisition`** —
+
+- `top_sources_by_frequency` — the ranking, with revenue attached.
+- `source_coverage_pct` — the share of deals carrying a source at all. Below ~70%, the ranking describes a sample; say so.
+- `source_field_present` — false means no source field was found anywhere on deal, company or contact.
+- `campaign_field_present` / `campaign_values_present` — when either is false, the data shows channel but not campaign. Name that gap: the team can see outbound produced revenue but not which sequence did.
+
+**`data_quality.warnings`** — surface these plainly. They set the ceiling on how confidently anything can be stated.
+
+## When it refuses
+
+The engine exits with an error rather than guessing when there is no usable value field, no company column, or nothing left after filtering. Each refusal names the cause.
+
+A refusal is a question for the user — where does deal value live, how do you mark a deal won — not a condition to work around by loosening the filters until something comes back.
+
+## Self-test
+
+```bash
+python3 scripts/analyze.py --test
+```
+
+Golden cases cover deal-size ranking, revenue aggregation across multi-deal companies, European and US amount parsing, the `value-in-window` selection path including the newest-deals-are-empty failure mode, windowing, won-signal detection, always excluding lost deals, custom field overrides, source-frequency ranking, campaign-field detection, and each refusal.
+
+## Worked example
+
+`examples/sample-deals.json` is a fictional 14-row export — 12 won, 1 lost, 1 open, across 10 companies — carrying a channel-level source but no campaign field, so it exercises the campaign-gap path.
+
+```bash
+python3 scripts/analyze.py examples/sample-deals.json --since-days 3650
+```
+
+The rows carry a stage label, so the won signal is detected and the lost and open deals are excluded. Revenue concentrates in FinTech and SaaS; the leading source by frequency is LinkedIn. The wide window is only because the sample dates are fixed — use 365 on real data.

--- a/skills/erwann-lefevre/won-deal-icp-finder/references/archetype-clustering.md
+++ b/skills/erwann-lefevre/won-deal-icp-finder/references/archetype-clustering.md
@@ -1,0 +1,75 @@
+# Building the archetypes
+
+The engine returns segments. Turning them into two to four profiles a prospector can actually search is the judgment half.
+
+## What an archetype is
+
+A named, criteria-based company profile that several won customers fit — not a description of one customer, and not a vibe.
+
+Each one needs:
+
+- **A title** a seller would use out loud. "Mid-market FinTech in FR/DE", not "Segment B".
+- **Objective criteria**: one or two industries, one or two size buckets, one or two geographies. More values per dimension and it stops being searchable.
+- **A typical deal size**, taken from the deals in the group.
+- **The evidence**: how many won companies fit, and which ones.
+- **A buyer persona** where the motion supports inferring one — seniority and function — explicitly labelled as inferred when the data never recorded it.
+
+## How to build them
+
+Intersect the revenue-dominant segments rather than reading each dimension separately. The leading industry and the leading size bucket are frequently the same set of companies; treating them as two findings double-counts them and produces archetypes that overlap.
+
+Aim for groups that are distinct from each other and each tight enough to hand to someone building a prospecting list. Two sharp archetypes beat four blurry ones.
+
+Cap at four. Past that you are slicing noise, and the thin groups are usually one customer each. Collapse them.
+
+## Anti-patterns
+
+| Trap | Why it misleads | Do instead |
+|---|---|---|
+| Ranking or clustering by deal count | Rewards whichever segment is cheapest to sell to, which is rarely the one that pays | Cluster on revenue share |
+| One archetype per top account | A whale is not a repeatable profile | Group on shared firmographics; report the concentration instead |
+| Reading a channel ranking off a thin source field | Coverage below ~70% describes a sample, not the book | State coverage next to the ranking |
+| An archetype broad enough to match anyone | "B2B in Europe" returns the whole market | One or two values per dimension |
+| Filling in firmographics the data didn't carry | Absent is not the same as free to guess | Flag the gap; label inferences as inferred |
+| Building on the top ten deals rather than the top ten accounts | A customer with four deals gets counted four times | Cluster from per-account revenue |
+
+## The concentration caveat
+
+When one account holds more than roughly a quarter of the revenue, the honest reading is that the book leans on one customer. Say that first, then build archetypes from what remains.
+
+Two teams get this wrong in opposite directions: one builds an "ICP" that is a portrait of its single largest customer, and the other drops the whale entirely and describes a business it doesn't have. Report the concentration, keep the account visible in the evidence, and don't let one logo set the criteria.
+
+## Worked example
+
+Run `examples/sample-deals.json` and the engine returns 12 won deals across 10 companies, 342,000 total, `top_1_account_share` 21.1%.
+
+The industry segment reads:
+
+| Industry | Revenue | Share |
+|---|---|---|
+| FinTech | 113,000 | 33.0% |
+| SaaS | 92,000 | 26.9% |
+| Logistics | 70,000 | 20.5% |
+| Consulting | 40,000 | 11.7% |
+
+Size concentrates in 51–200 (48.0%) and 201–500 (41.5%); geography in France (49.4%) and Germany (31.0%).
+
+The naive reading takes the top three industries and produces three archetypes. Check the accounts before you do, because the third one dissolves:
+
+**A — Mid-market FinTech, FR/DE.** 51–500 employees. Cobalt FinTech (FR, 72,000 across 2 deals) and Vantage FinTech (DE, 41,000). Two companies, 33.0% of revenue, typical deal 36–41k.
+
+**B — Growth-stage SaaS, DE/FR.** 51–200 employees. Velora (DE, 36,000), Meridian (DE, 29,000), Quill (FR, 27,000). Three companies, 26.9% of revenue, typical deal 27–36k.
+
+**Logistics is not archetype C.** That 20.5% is Northwind Logistics — one company, two deals, no second example anywhere in the book. It looks like a top-three segment in the industry table and it is a single customer. Report it as concentration, not as a profile: a segment whose entire revenue sits in one account tells you that account renewed, not that a market exists.
+
+The remaining four companies span Consulting, Manufacturing and Retail with one deal each and sit in different size buckets. That's the tail. Saying so is more useful than manufacturing a "Segment D — Other".
+
+Note the shape of the check: the industry table alone would have produced three archetypes, one of which is a mirage. Cross-referencing every candidate segment against the account list — *how many distinct companies is this?* — is what catches it. Do it every time; a segment backed by fewer than two companies is a customer, not a pattern.
+
+Note also what the example doesn't do: it doesn't claim a buyer persona, because this dataset never carried contact roles. Inferring one here and labelling it "(inferred)" would still be inventing it.
+
+## Handing it off
+
+The output is finished when someone building a prospecting list can use it without asking a follow-up question. That means each archetype restates cleanly as a single line of search criteria — industries, size range, geographies, target function — with nothing left to interpret.
+
+If a criteria line needs a paragraph of explanation to be usable, the archetype is still too vague.

--- a/skills/erwann-lefevre/won-deal-icp-finder/references/deal-data-extraction.md
+++ b/skills/erwann-lefevre/won-deal-icp-finder/references/deal-data-extraction.md
@@ -1,0 +1,66 @@
+# Getting the deal data
+
+Read this before pulling anything. The extraction is where the analysis is won or lost — every downstream number inherits the field choices made here.
+
+## Learn the conventions before you pull
+
+Three questions, answered from **one** sample: a single deal with its associated company and primary contact, properties listed. Don't keep probing; one well-chosen sample answers all three.
+
+**1. Which field actually holds deal value?**
+
+The CRM's standard amount field is frequently abandoned. Teams migrate to a custom ARR, ACV, MRR or "contract value" field and leave the original empty on every record. Check whether the standard field is populated on real deals before trusting it. If it's empty or sparsely filled, find the field that carries the money and pass it explicitly to the engine.
+
+Watch for a value field that holds monthly figures while the team talks in annual ones, or the reverse. It doesn't change the ranking, but it changes every number you quote back.
+
+**2. How does this team mark a deal won — if at all?**
+
+Four possibilities, in descending order of convenience:
+
+- A clean won stage in the pipeline.
+- A boolean closed-won flag maintained by the CRM.
+- A custom label the team applies by hand — often inconsistently, often localised.
+- Nothing. Some teams never mark won; a populated value field is the only signal a deal was real.
+
+The fourth case is common and is not a blocker. When no won signal exists, the engine analyses value-bearing deals in the window and reports the selection basis as `value-in-window`. Surface that basis in one line and ask the user to confirm it matches what they'd call a won deal. Lost deals are excluded in every mode.
+
+The trap: assuming a won stage exists, matching nothing, and falling back to "the most recent N deals". Recent deals are the newest and therefore the emptiest. That failure produces a complete, confident, entirely worthless analysis.
+
+**3. Where does acquisition source live?**
+
+It sits on the deal, the company, or the contact, and it varies by setup. Check the standard analytics-source properties, then the custom ones — a "Lead Source", "Channel" or "Origin" field the team maintains manually. Note which object carries it.
+
+While you're there, check whether any **campaign-level** field exists as well, and whether it has values in it. Channel without campaign is the normal state of affairs, and it's worth reporting: the team can see that outbound produced revenue but not which sequence did.
+
+## The pull
+
+Deals whose value field is populated, from the last 365 days, by close date where available and create date otherwise, with company firmographics attached — industry, headcount or size bucket, country.
+
+**Do not pull the newest N deals regardless of value.** This is the single most common way this analysis goes wrong.
+
+Write the rows to a file before analysing. The engine reads JSON or CSV from disk; going through a file means the analysis is reproducible and the pull happens exactly once.
+
+## Keep it bounded
+
+This is a handful of calls, not an investigation.
+
+- Discover the schema from one sample. Stop.
+- Pull the window in as few paginated calls as possible, requesting only the properties needed.
+- Enrich company firmographics for the **top ~30 deals by value only**. They carry the revenue and they define the archetypes; the long tail changes nothing and costs real time.
+- Persist once, analyse once. Don't re-pull, don't re-read files already in hand.
+
+## The export fallback
+
+Works with no connector at all, and is often faster than negotiating API access.
+
+Ask for an export of deals carrying a value, from the last twelve months, including company industry, size and country plus whatever source or campaign column the team uses. Most CRM exports use human-readable column labels; the engine matches them by alias, so a raw export usually runs without any flags.
+
+## When to stop and ask
+
+Ask one short, specific question — where deal value lives, and how they mark a deal won — rather than guessing, whenever:
+
+- No candidate value field is populated.
+- Several value fields are populated and they disagree.
+- The won signal is ambiguous or localised in a way you can't confirm.
+- The engine refuses.
+
+An engine refusal is a question for the user, not an obstacle to route around. One question costs a minute; a wrong field choice costs the whole analysis and isn't visible in the output.

--- a/skills/erwann-lefevre/won-deal-icp-finder/scripts/analyze.py
+++ b/skills/erwann-lefevre/won-deal-icp-finder/scripts/analyze.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""analyze.py — turn a deal dataset into a proven-ICP analysis.
+
+Deterministic engine. It does the arithmetic the LLM must NOT improvise:
+rank deals by size, aggregate revenue per company, measure concentration,
+break revenue down by firmographics, and rank acquisition sources by
+frequency. It validates the input and REFUSES to emit a best-effort result
+on garbage — a wrong revenue number discovered downstream is exactly the
+silent failure this tier exists to prevent.
+
+SELECTION (this is the part that matters — pipelines differ wildly):
+A deal is included if it has a deal VALUE (not null, > 0) AND falls inside the
+time window (default: last 365 days, by close date, else create date). On top
+of that:
+  • Deals in a clearly "lost" stage are always excluded.
+  • If the team marks won deals (a won stage label or a won flag), only won
+    deals are kept.
+  • If there is NO won signal at all, every value-bearing deal in the window is
+    kept — and `selection_basis` says so, so the caller can tell the user.
+This is why pulling "the newest N deals" is wrong: new deals are often empty.
+Pull value-bearing deals in the window instead.
+
+The engine produces NUMBERS. Clustering companies into named ICP archetypes is
+the model's job, on top of this output.
+
+Usage
+    python3 analyze.py deals.json --since-days 365
+    python3 analyze.py deals.csv --value-field "Deal value"   # value isn't in `amount`
+    python3 analyze.py deals.csv --won-stage "Closed Won,Gagné"  # restrict to won stages
+    python3 analyze.py deals.csv --source-field "Lead Source"
+    python3 analyze.py deals.csv --since-days 0                # no time window
+    cat deals.json | python3 analyze.py -
+    python3 analyze.py --test
+
+Output: a JSON report on stdout. Errors go to stderr with exit code 2 — when
+the engine refuses, the caller should ASK the user, not guess.
+"""
+import sys, csv, json, argparse, io, re
+from datetime import datetime, date, timedelta
+
+TOP_DEFAULT = 25
+SINCE_DAYS_DEFAULT = 365
+
+SYNONYMS = {
+    "amount":   ["amount", "deal amount", "deal value", "value", "montant",
+                 "weighted amount", "hs_acv", "acv", "arr", "mrr",
+                 "total revenue", "revenue", "ca", "chiffre d'affaires"],
+    "account":  ["company", "company name", "associated company",
+                 "associated company (primary)", "account", "account name",
+                 "company domain", "domain", "company id", "companyid",
+                 "société", "entreprise"],
+    "stage":    ["dealstage", "deal stage", "stage", "pipeline stage",
+                 "étape", "etape"],
+    "won":      ["is_won", "hs_is_closed_won", "is closed won", "closed won",
+                 "won", "gagné", "gagne"],
+    "close":    ["closedate", "close date", "date closed", "won date",
+                 "date de clôture", "date de cloture"],
+    "create":   ["createdate", "create date", "created", "creation date",
+                 "date de création", "date de creation"],
+    "industry": ["industry", "company industry", "secteur",
+                 "secteur d'activité", "vertical"],
+    "employees":["numberofemployees", "number of employees", "no. of employees",
+                 "employees", "employee count", "headcount", "company size",
+                 "size", "effectif", "effectifs"],
+    "country":  ["country", "company country", "hs_country", "pays", "geo",
+                 "region", "région"],
+    "source":   ["hs_analytics_source", "hs_analytics_source_data_1",
+                 "original source", "original source type", "source",
+                 "latest source", "deal source", "lead source",
+                 "acquisition channel", "channel", "canal"],
+    "campaign": ["campaign", "campaign name", "hs_campaign", "utm_campaign",
+                 "utm campaign", "outreach campaign", "sequence",
+                 "prospecting campaign", "hs_analytics_source_data_2"],
+}
+
+WON_PATTERNS = ["closed won", "closedwon", "closed-won", "closed_won", "won",
+                "gagné", "gagne", "client", "signed"]
+LOST_PATTERNS = ["closed lost", "closedlost", "closed-lost", "closed_lost",
+                 "lost", "perdu", "abandoned", "disqualified", "nurturing-lost"]
+
+SIZE_BUCKETS = [(1, 10, "1-10"), (11, 50, "11-50"), (51, 200, "51-200"),
+                (201, 500, "201-500"), (501, 1000, "501-1000"),
+                (1001, 5000, "1001-5000"), (5001, 10**9, "5001+")]
+
+
+class ValidationError(Exception):
+    pass
+
+
+def parse_amount(raw):
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    s = str(raw).strip()
+    if not s:
+        return None
+    s = re.sub(r"[^\d,.\-]", "", s)
+    if not s or s in ("-", ".", ","):
+        return None
+    if "," in s and "." in s:
+        if s.rfind(",") > s.rfind("."):
+            s = s.replace(".", "").replace(",", ".")
+        else:
+            s = s.replace(",", "")
+    elif "," in s:
+        s = s.replace(",", ".") if re.search(r",\d{1,2}$", s) else s.replace(",", "")
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def parse_int(raw):
+    if raw is None:
+        return None
+    s = re.sub(r"[^\d]", "", str(raw))
+    return int(s) if s else None
+
+
+def size_bucket(n):
+    if n is None:
+        return None
+    for lo, hi, label in SIZE_BUCKETS:
+        if lo <= n <= hi:
+            return label
+    return None
+
+
+def norm_date(raw):
+    if not raw:
+        return None
+    s = str(raw).strip()
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S.%fZ",
+                "%Y-%m-%dT%H:%M:%SZ", "%d/%m/%Y", "%m/%d/%Y", "%d-%m-%Y"):
+        try:
+            return datetime.strptime(s[:len(fmt) + 6] if "%f" in fmt else s[:len(fmt)],
+                                     fmt).date().isoformat()
+        except ValueError:
+            continue
+    return s[:10] if len(s) >= 10 else s
+
+
+ISO = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def build_field_map(headers):
+    lower = {h.strip().lower(): h for h in headers}
+    fmap = {}
+    for canon, syns in SYNONYMS.items():
+        for syn in syns:
+            if syn in lower:
+                fmap[canon] = lower[syn]
+                break
+    return fmap
+
+
+def load_records(raw_text):
+    raw_text = raw_text.strip()
+    if not raw_text:
+        raise ValidationError("Empty input: no deal data provided.")
+    if raw_text[0] in "[{":
+        try:
+            data = json.loads(raw_text)
+            if isinstance(data, dict):
+                data = data.get("deals") or data.get("results") or data.get("rows")
+            if not isinstance(data, list):
+                raise ValidationError("JSON must be a list of deals or {\"deals\":[...]}.")
+            return [(r.get("properties", r) if isinstance(r, dict) else r) for r in data]
+        except json.JSONDecodeError:
+            pass
+    rows = list(csv.DictReader(io.StringIO(raw_text)))
+    if not rows:
+        raise ValidationError("Could not parse input as JSON or CSV with a header row.")
+    return rows
+
+
+def analyze(records, value_field=None, won_stages=None, source_field=None,
+            since_days=SINCE_DAYS_DEFAULT, as_of=None, top=TOP_DEFAULT):
+    if not records:
+        raise ValidationError("No deal rows found in the input.")
+
+    headers = set()
+    for r in records:
+        if isinstance(r, dict):
+            headers.update(r.keys())
+    fmap = build_field_map(headers)
+    if value_field:
+        fmap["amount"] = value_field
+    if source_field:
+        fmap["source"] = source_field
+
+    if "amount" not in fmap:
+        raise ValidationError(
+            "No deal-value field found. `amount` isn't present and no known value "
+            "column (deal value, ARR, MRR, ACV…) was detected. Inspect a sample deal "
+            "to find the field that holds deal value, then pass --value-field \"<column>\".")
+    if "account" not in fmap:
+        raise ValidationError(
+            "No company/account column found. Each deal must carry the company it "
+            "belongs to (column: company, account, associated company, domain…).")
+
+    has_stage = "stage" in fmap
+    has_wonflag = "won" in fmap
+    won_stage_set = ({s.strip().lower() for s in won_stages.split(",") if s.strip()}
+                     if won_stages else None)
+
+    # pre-scan: is there ANY won signal in this dataset?
+    won_signal_detected = has_wonflag
+    if has_stage and not won_signal_detected:
+        for rec in records:
+            st = str(rec.get(fmap["stage"], "")).strip().lower()
+            if any(p in st for p in WON_PATTERNS):
+                won_signal_detected = True
+                break
+
+    # time window
+    as_of_date = (datetime.strptime(as_of, "%Y-%m-%d").date() if as_of else date.today())
+    cutoff = ((as_of_date - timedelta(days=since_days)).isoformat()
+              if since_days and since_days > 0 else None)
+
+    def deal_date(rec):
+        d = norm_date(rec.get(fmap["close"])) if "close" in fmap else None
+        if not d:
+            d = norm_date(rec.get(fmap["create"])) if "create" in fmap else None
+        return d
+
+    counts = {"dropped_no_value": 0, "out_of_window": 0, "lost_excluded": 0,
+              "not_won_excluded": 0, "no_date": 0}
+    deals = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        val = parse_amount(rec.get(fmap["amount"]))
+        if val is None or val <= 0:
+            counts["dropped_no_value"] += 1
+            continue
+        dd = deal_date(rec)
+        if cutoff is not None:
+            if dd and ISO.match(dd):
+                if dd < cutoff:
+                    counts["out_of_window"] += 1
+                    continue
+            else:
+                counts["no_date"] += 1  # keep, but flag we couldn't window it
+        stage = str(rec.get(fmap["stage"], "")).strip().lower() if has_stage else ""
+        if has_stage and any(p in stage for p in LOST_PATTERNS):
+            counts["lost_excluded"] += 1
+            continue
+        # won filtering
+        if won_stage_set is not None:
+            if stage not in won_stage_set:
+                counts["not_won_excluded"] += 1
+                continue
+        elif has_wonflag:
+            v = str(rec.get(fmap["won"], "")).strip().lower()
+            if v not in ("true", "1", "yes", "won", "oui", "y"):
+                counts["not_won_excluded"] += 1
+                continue
+        elif won_signal_detected and has_stage:
+            if not any(p in stage for p in WON_PATTERNS):
+                counts["not_won_excluded"] += 1
+                continue
+        # else: no won signal → value-in-window basis → include
+
+        acct = str(rec.get(fmap["account"], "")).strip() or "(unknown account)"
+        emps = parse_int(rec.get(fmap["employees"])) if "employees" in fmap else None
+        deals.append({
+            "account": acct, "key": acct.lower(), "amount": val,
+            "industry": (str(rec.get(fmap["industry"], "")).strip() if "industry" in fmap else ""),
+            "employees": emps, "size_bucket": size_bucket(emps),
+            "country": (str(rec.get(fmap["country"], "")).strip() if "country" in fmap else ""),
+            "source": (str(rec.get(fmap["source"], "")).strip() if "source" in fmap else ""),
+            "campaign": (str(rec.get(fmap["campaign"], "")).strip() if "campaign" in fmap else ""),
+            "close": dd,
+        })
+
+    if not deals:
+        raise ValidationError(
+            f"No usable deals after filtering (value > 0, within {since_days} days, not "
+            f"lost). Dropped: {counts['dropped_no_value']} without a value, "
+            f"{counts['out_of_window']} outside the window, {counts['lost_excluded']} lost, "
+            f"{counts['not_won_excluded']} not won. Confirm the value field "
+            "(--value-field), widen the window (--since-days), or check how this team "
+            "marks won deals — then re-run. If unclear, ASK the user.")
+
+    if won_stage_set is not None:
+        basis = "won-stage (explicit filter)"
+    elif has_wonflag:
+        basis = "won-flag"
+    elif won_signal_detected and has_stage:
+        basis = "won-stage (detected)"
+    else:
+        basis = "value-in-window (no won status found — verify with the user)"
+
+    won_revenue = sum(d["amount"] for d in deals)
+    won_count = len(deals)
+
+    def share(v):
+        return round(100 * v / won_revenue, 1) if won_revenue else 0.0
+
+    accounts = {}
+    for d in deals:
+        a = accounts.setdefault(d["key"], {
+            "account": d["account"], "revenue": 0.0, "deals": 0,
+            "first_close": None, "last_close": None, "industry": "",
+            "employees": None, "size_bucket": None, "country": "", "source": ""})
+        a["revenue"] += d["amount"]
+        a["deals"] += 1
+        for f in ("industry", "country", "source"):
+            if d[f] and not a[f]:
+                a[f] = d[f]
+        if d["employees"] and not a["employees"]:
+            a["employees"], a["size_bucket"] = d["employees"], d["size_bucket"]
+        if d["close"] and ISO.match(d["close"]):
+            if not a["first_close"] or d["close"] < a["first_close"]:
+                a["first_close"] = d["close"]
+            if not a["last_close"] or d["close"] > a["last_close"]:
+                a["last_close"] = d["close"]
+    ranked = sorted(accounts.values(), key=lambda x: x["revenue"], reverse=True)
+    acct_count = len(ranked)
+
+    cum, pareto_n = 0.0, 0
+    for a in ranked:
+        cum += a["revenue"]; pareto_n += 1
+        if cum >= 0.8 * won_revenue:
+            break
+
+    def topslice(n):
+        return share(sum(a["revenue"] for a in ranked[:n]))
+
+    seg = {"industry": {}, "size_bucket": {}, "country": {}}
+    for d in deals:
+        if d["industry"]:
+            seg["industry"][d["industry"]] = seg["industry"].get(d["industry"], 0.0) + d["amount"]
+        if d["size_bucket"]:
+            seg["size_bucket"][d["size_bucket"]] = seg["size_bucket"].get(d["size_bucket"], 0.0) + d["amount"]
+        if d["country"]:
+            seg["country"][d["country"]] = seg["country"].get(d["country"], 0.0) + d["amount"]
+
+    def seg_table(dd):
+        return [{"value": k, "revenue": round(v, 2), "revenue_share": share(v)}
+                for k, v in sorted(dd.items(), key=lambda kv: kv[1], reverse=True)]
+
+    by_source, revenue_with_source = {}, 0.0
+    for d in deals:
+        if d["source"]:
+            s = by_source.setdefault(d["source"], {"revenue": 0.0, "deals": 0})
+            s["revenue"] += d["amount"]; s["deals"] += 1
+            revenue_with_source += d["amount"]
+    acquisition_sources = [
+        {"source": s, "won_deals": v["deals"], "revenue": round(v["revenue"], 2),
+         "revenue_share": share(v["revenue"])}
+        for s, v in sorted(by_source.items(),
+                           key=lambda kv: (kv[1]["deals"], kv[1]["revenue"]), reverse=True)]
+    campaign_field_present = "campaign" in fmap
+    campaign_values_present = any(d["campaign"] for d in deals)
+    top_deals = sorted(deals, key=lambda d: d["amount"], reverse=True)[:top]
+
+    report = {
+        "summary": {
+            "total_deal_value": round(won_revenue, 2),
+            "deals_analyzed": won_count,
+            "account_count": acct_count,
+            "avg_deal_size": round(won_revenue / won_count, 2) if won_count else 0,
+            "selection_basis": basis,
+            "won_signal_detected": won_signal_detected,
+            "window_days": since_days,
+            "as_of": as_of_date.isoformat(),
+            "value_field": fmap["amount"],
+            "rows_in_input": len(records),
+            "excluded": counts,
+        },
+        "top_deals": [
+            {"account": d["account"], "amount": round(d["amount"], 2),
+             "amount_share": share(d["amount"]),
+             "industry": d["industry"] or None, "employees": d["employees"],
+             "size_bucket": d["size_bucket"], "country": d["country"] or None,
+             "source": d["source"] or None, "campaign": d["campaign"] or None,
+             "close": d["close"]}
+            for d in top_deals],
+        "concentration": {
+            "top_1_account_share": topslice(1),
+            "top_5_accounts_share": topslice(5),
+            "top_10_accounts_share": topslice(10),
+            "accounts_for_80pct_revenue": pareto_n},
+        "top_accounts": [
+            {"account": a["account"], "revenue": round(a["revenue"], 2),
+             "revenue_share": share(a["revenue"]), "deals": a["deals"],
+             "avg_deal_size": round(a["revenue"] / a["deals"], 2),
+             "industry": a["industry"] or None, "employees": a["employees"],
+             "size_bucket": a["size_bucket"], "country": a["country"] or None,
+             "source": a["source"] or None,
+             "first_close": a["first_close"], "last_close": a["last_close"]}
+            for a in ranked[:top]],
+        "segments": {dim: seg_table(d) for dim, d in seg.items() if d},
+        "acquisition": {
+            "source_field_present": "source" in fmap,
+            "campaign_field_present": campaign_field_present,
+            "campaign_values_present": campaign_values_present,
+            "source_coverage_pct": (round(100 * revenue_with_source / won_revenue, 1)
+                                    if won_revenue else 0.0),
+            "top_sources_by_frequency": acquisition_sources[:5],
+            "all_sources": acquisition_sources},
+        "data_quality": {"warnings": []},
+    }
+
+    w = report["data_quality"]["warnings"]
+    aq = report["acquisition"]
+    if basis.startswith("value-in-window"):
+        w.append("No closed-won status found on these deals. Analyzing every deal that "
+                 "carries a value in the window — confirm with the user that this maps "
+                 "to their won deals (not open or lost pipeline).")
+    if counts["no_date"]:
+        w.append(f"{counts['no_date']} deal(s) had no usable date — kept, but not "
+                 "time-filtered.")
+    if not aq["source_field_present"]:
+        w.append("No acquisition-source field detected — inspect a sample deal + company "
+                 "+ contact for a custom field, then re-run with --source-field.")
+    elif aq["source_coverage_pct"] < 70:
+        w.append(f"Only {aq['source_coverage_pct']}% of value carries a source — channel "
+                 "attribution is partial.")
+    if not (campaign_field_present and campaign_values_present):
+        w.append("No campaign-level detail — you can see the channel, not WHICH campaign "
+                 "produced each deal.")
+    if "industry" not in fmap:
+        w.append("No industry field — vertical clustering unavailable.")
+    if "employees" not in fmap:
+        w.append("No employee-count field — size-bucket clustering unavailable.")
+    if acct_count < 10:
+        w.append(f"Only {acct_count} companies — archetypes are directional, not "
+                 "statistically strong.")
+    return report
+
+
+def _selftest():
+    failures = total = 0
+
+    def check(name, cond):
+        nonlocal failures, total
+        total += 1
+        if not cond:
+            failures += 1
+            print(f"FAIL: {name}", file=sys.stderr)
+
+    def must_raise(name, fn):
+        nonlocal failures, total
+        total += 1
+        try:
+            fn(); failures += 1
+            print(f"FAIL: {name} (no error raised)", file=sys.stderr)
+        except ValidationError:
+            pass
+
+    AS_OF = "2026-05-25"
+    won = [
+        {"Company": "Acme",   "Amount": "1,000.00", "Deal Stage": "Closed Won",
+         "Industry": "SaaS", "Number of Employees": "120", "Country": "France",
+         "Original Source": "LinkedIn", "Close Date": "2026-01-10"},
+        {"Company": "Acme",   "Amount": "500",      "Deal Stage": "Closed Won",
+         "Industry": "SaaS", "Number of Employees": "120", "Country": "France",
+         "Original Source": "LinkedIn", "Close Date": "2026-03-02"},
+        {"Company": "Globex", "Amount": "2 000,50", "Deal Stage": "Closed Won",
+         "Industry": "FinTech", "Number of Employees": "800", "Country": "Germany",
+         "Original Source": "Email", "Close Date": "2026-02-15"},
+        {"Company": "Initech","Amount": "$300",     "Deal Stage": "closedwon",
+         "Industry": "SaaS", "Number of Employees": "40", "Country": "France",
+         "Original Source": "", "Close Date": "2026-02-20"},
+        {"Company": "Umbrella","Amount": "1200",    "Deal Stage": "Closed Won",
+         "Industry": "FinTech", "Number of Employees": "5000", "Country": "Germany",
+         "Original Source": "Email", "Close Date": "2026-04-01"},
+        {"Company": "LostCo", "Amount": "9999",     "Deal Stage": "Closed Lost",
+         "Industry": "SaaS", "Number of Employees": "10", "Country": "Spain",
+         "Original Source": "LinkedIn", "Close Date": "2026-01-01"},
+    ]
+    r = analyze(won, as_of=AS_OF)
+    check("won_total_5000_5", r["summary"]["total_deal_value"] == 5000.5)
+    check("won_count_5", r["summary"]["deals_analyzed"] == 5)
+    check("lost_excluded", r["summary"]["excluded"]["lost_excluded"] == 1)
+    check("lost_not_in_accounts", all(a["account"] != "LostCo" for a in r["top_accounts"]))
+    check("basis_detected", r["summary"]["selection_basis"] == "won-stage (detected)")
+    check("top_deal_globex", r["top_deals"][0]["account"] == "Globex" and r["top_deals"][0]["amount"] == 2000.5)
+    check("fr_parse", any(d["amount"] == 2000.5 for d in r["top_deals"]))
+    acme = next(a for a in r["top_accounts"] if a["account"] == "Acme")
+    check("acme_agg", acme["revenue"] == 1500.0 and acme["deals"] == 2)
+
+    # --- Brice's setup: NO won/lost stage, value-bearing recent deals ---
+    brice = [
+        {"Company": "Alpha", "Amount": "8000", "Close Date": "2026-04-10", "Industry": "SaaS"},
+        {"Company": "Beta",  "Amount": "3000", "Close Date": "2026-02-01", "Industry": "FinTech"},
+        {"Company": "Gamma", "Amount": "",     "Create Date": "2026-05-20"},  # new, empty → drop
+    ]
+    rb = analyze(brice, as_of=AS_OF)
+    check("brice_total", rb["summary"]["total_deal_value"] == 11000.0)
+    check("brice_count", rb["summary"]["deals_analyzed"] == 2)
+    check("brice_basis", rb["summary"]["selection_basis"].startswith("value-in-window"))
+    check("brice_dropped_empty", rb["summary"]["excluded"]["dropped_no_value"] == 1)
+    check("brice_warns_basis", any("No closed-won status" in x for x in rb["data_quality"]["warnings"]))
+
+    # --- the original bug: newest deals empty, older ones valued → must NOT refuse ---
+    bug = [
+        {"Company": "NewCo", "Amount": "", "Create Date": "2026-05-24"},
+        {"Company": "RealCo", "Amount": "5000", "Close Date": "2026-03-01"},
+    ]
+    rbug = analyze(bug, as_of=AS_OF)
+    check("bug_proceeds", rbug["summary"]["total_deal_value"] == 5000.0
+          and rbug["summary"]["deals_analyzed"] == 1)
+
+    # --- time window: a valued deal older than 365d is excluded ---
+    old = [
+        {"Company": "Recent", "Amount": "1000", "Close Date": "2026-03-01"},
+        {"Company": "Ancient", "Amount": "9000", "Close Date": "2024-01-01"},
+    ]
+    ro = analyze(old, as_of=AS_OF, since_days=365)
+    check("window_excludes_old", ro["summary"]["deals_analyzed"] == 1
+          and ro["summary"]["excluded"]["out_of_window"] == 1)
+    # since_days 0 disables the window → both kept
+    ro0 = analyze(old, as_of=AS_OF, since_days=0)
+    check("window_off", ro0["summary"]["deals_analyzed"] == 2)
+
+    # --- custom value field (amount column absent) ---
+    custom_val = [{"Company": "X", "Deal value": "4200", "Close Date": "2026-04-01"}]
+    rc = analyze(custom_val, as_of=AS_OF)  # "deal value" is a known synonym → auto
+    check("custom_value_auto", rc["summary"]["total_deal_value"] == 4200.0)
+    rco = analyze([{"Company": "X", "MyVal": "4200", "Close Date": "2026-04-01"}],
+                  value_field="MyVal", as_of=AS_OF)
+    check("value_field_override", rco["summary"]["total_deal_value"] == 4200.0)
+
+    # --- custom source-field override + campaign detection ---
+    rsrc = analyze([{"Company": "X", "Amount": "100", "Close Date": "2026-04-01",
+                     "Lead Source": "Webinar"}], source_field="Lead Source", as_of=AS_OF)
+    check("source_override", rsrc["acquisition"]["top_sources_by_frequency"][0]["source"] == "Webinar")
+    rcamp = analyze([{"Company": "X", "Amount": "100", "Close Date": "2026-04-01",
+                      "Campaign": "Q2 Outbound"}], as_of=AS_OF)
+    check("campaign_present", rcamp["acquisition"]["campaign_field_present"] is True
+          and rcamp["acquisition"]["campaign_values_present"] is True)
+
+    # --- won-stage explicit restrict ---
+    rws = analyze(won, won_stages="Closed Won", as_of=AS_OF)
+    # Initech stage is "closedwon" (no space) → excluded by explicit "Closed Won"
+    check("won_stage_explicit", rws["summary"]["selection_basis"].startswith("won-stage (explicit")
+          and all(d["account"] != "Initech" for d in rws["top_deals"]))
+
+    # --- refusals ---
+    must_raise("empty", lambda: analyze([]))
+    must_raise("no_value_field", lambda: analyze([{"Company": "X", "Close Date": "2026-04-01"}], as_of=AS_OF))
+    must_raise("no_account", lambda: analyze([{"Amount": "100", "Close Date": "2026-04-01"}], as_of=AS_OF))
+    must_raise("all_empty_value", lambda: analyze(
+        [{"Company": "X", "Amount": "", "Close Date": "2026-04-01"}], as_of=AS_OF))
+    must_raise("all_out_of_window", lambda: analyze(
+        [{"Company": "X", "Amount": "100", "Close Date": "2020-01-01"}], as_of=AS_OF, since_days=365))
+
+    print(f"{total - failures}/{total} checks passed")
+    return 1 if failures else 0
+
+
+def main():
+    p = argparse.ArgumentParser(description="Proven-ICP analysis from closed-won deals.")
+    p.add_argument("spec", nargs="?", help="path to .json/.csv, or - for stdin")
+    p.add_argument("--value-field", "--amount-field", dest="value_field",
+                   help="the column holding deal value (if not the standard `amount`)")
+    p.add_argument("--won-stage", help="comma-separated exact won stage labels to restrict to")
+    p.add_argument("--source-field", help="override the acquisition-source column (custom field)")
+    p.add_argument("--since-days", type=int, default=SINCE_DAYS_DEFAULT,
+                   help="time window in days (default 365; 0 = no window)")
+    p.add_argument("--as-of", help="reference date YYYY-MM-DD for the window (default: today)")
+    p.add_argument("--top", type=int, default=TOP_DEFAULT, help="top-N deals/accounts to return")
+    p.add_argument("--test", action="store_true")
+    a = p.parse_args()
+
+    if a.test:
+        sys.exit(_selftest())
+    if not a.spec:
+        print("error: provide a deals file (.json/.csv) or - for stdin", file=sys.stderr)
+        sys.exit(2)
+    raw = sys.stdin.read() if a.spec == "-" else open(a.spec, encoding="utf-8-sig").read()
+    try:
+        records = load_records(raw)
+        report = analyze(records, value_field=a.value_field, won_stages=a.won_stage,
+                         source_field=a.source_field, since_days=a.since_days,
+                         as_of=a.as_of, top=a.top)
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    except ValidationError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this skill does

Re-derives an ICP from the deals that actually closed rather than the one written before the revenue arrived: selects won deals on a populated value field (not on a "Closed Won" stage that many pipelines don't have), aggregates revenue per company in code, and clusters the result into two to four named archetypes with searchable criteria — plus a ranking of the acquisition sources behind the money.

First contribution, so `author.md` is included.

**Ships a working engine.** `scripts/analyze.py` is dependency-free, parses European and US amount formats, and has a golden-case self-test:

```
python3 scripts/analyze.py --test   →  26/26 checks passed
```

`examples/sample-deals.json` is a fictional 14-row export that exercises the campaign-gap path; the worked example in `references/archetype-clustering.md` is written against its real output, including the case where a segment sits third on the revenue table and turns out to be one customer who renewed.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/erwann-lefevre/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Note on the four that follow

I have four more skills ready on branches in my fork — `audience-icp-filter`, `multichannel-campaign-builder`, `campaign-challenger`, `weekly-performance-advisor` — held back so this one lands first, per the one-skill-per-PR guidance in AGENTS.md. I'll open them once `author.md` is merged, so they don't each carry a duplicate of it. Happy to reorder or hold any of them if you'd rather review at a different pace.
