### PR TITLE
add gtm-command-center by gali-firon

### DIFF
--- a/skills/gali-firon/gtm-command-center/SKILL.md
+++ b/skills/gali-firon/gtm-command-center/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: gtm-command-center
+title: GTM command center
+description: |
+  Use this skill when a GTM operator is losing time hopping between tools to see their own work - the task board in one tab, the outreach queue in another, research in a third, the content calendar in a fourth. Produces one personal operating surface that aggregates those lanes, plus a single daily "what needs me now" roll-up. Reach for it when someone says "I'm drowning in tabs", "I need one place to work from", "build me a dashboard", "a command center", "a morning operating view", or "I keep missing things across my tools".
+category: RevOps
+tags: [RevOps]
+---
+
+Applies when one operator's work is scattered across many tools and nothing shows the whole day in one place. Produces a single personal operating surface - the lanes that matter, refreshed on a cadence - and one daily roll-up of only what needs that person today.
+
+A command center is not another tool to maintain. It is a read-mostly mirror: it pulls the current state of each lane you already work in and lays it on one screen, so you stop tab-hopping to reconstruct your own day. The discipline that makes it work is subtractive - what you leave off matters more than what you put on.
+
+## Build it
+
+1. **List the lanes, then cut half.** Write down every surface you check in a normal day. Keep only the lanes where you personally take action - the task board, the outreach queue, the research digest, the content/publishing queue, the events or presence lane, a pipeline snapshot. Drop anything you only monitor. The lane catalogue and the data contract each lane needs are in `references/lanes.md`.
+2. **One source of truth per lane.** Each lane points at exactly one system of record and mirrors it. Never let a lane hold state that also lives somewhere else - the moment two places disagree, you stop trusting the surface and go back to the tabs. The build patterns (read-mostly aggregation, refresh cadence, single-source rule) are in `references/build-guide.md`.
+3. **Keep it read-mostly.** The surface shows and links out; it does not become the place you edit everything. A dashboard that turns into another editing tool is just one more thing to keep in sync. Allow only the few low-friction actions that keep you on the surface (mark done, add a note); everything heavier links back to the system of record.
+4. **Wall off anything teammate-facing.** If any part of this surface is ever shown to teammates, a boss, or clients, it must carry none of your private working notes, raw scores, or internal labels. The clean-room separation - private working surface vs shareable view - is in `references/clean-room.md`.
+
+## Run it daily
+
+The payoff is one morning read that answers a single question: what needs me today. Assemble the roll-up across lanes, rank by what only you can move and what has a clock on it, and suppress everything that is merely in progress. The assembly method, the ranking rule, and what to surface vs suppress are in `references/morning-rollup.md`.
+
+## What good looks like
+
+- **What the best operator notices first:** the value is in what the surface leaves off. A command center that shows everything is a second inbox - you scan it once, feel behind, and go back to your tools. The skill is ruthless triage: only lanes you act in, only items that need you, only today. If a section never changes what you do, cut it.
+- **The common mistake:** building a dashboard that becomes another place to maintain. Two failure shapes - a lane that holds its own copy of state and drifts out of sync with the real system, and a surface that slowly turns into a full editing tool with its own stale data. Both end the same way: you stop trusting it. Read-mostly, one source of truth per lane, or it dies in a month.
+- **How you know it worked:** for a week, you start the day on this one surface instead of opening five tabs, and you stop being surprised by things you owned. The morning roll-up is short enough to read in under two minutes and every item on it is genuinely yours to move. If it is long, or full of other people's work, the triage is too loose.
+
+## Rules
+
+- MUST include only lanes where the operator personally takes action; monitoring-only surfaces stay off.
+- MUST point each lane at exactly one system of record and mirror it, never hold a second copy of state.
+- MUST keep the surface read-mostly - show and link out, do not rebuild every tool inside it.
+- MUST separate the private working surface from any teammate-facing view; internal notes, scores, and labels never appear on a shared version.
+- The daily roll-up MUST carry only items that need this person and have a reason to act now; in-progress work stays off it.
+- NEVER let the command center become the system of record for work that lives elsewhere.

--- a/skills/gali-firon/gtm-command-center/references/build-guide.md
+++ b/skills/gali-firon/gtm-command-center/references/build-guide.md
@@ -1,0 +1,47 @@
+# Build guide: read-mostly, one source of truth, sane refresh
+
+How to construct the surface on any stack without it turning into a maintenance burden. These are the three patterns that decide whether a command center survives past its first month.
+
+## Pattern 1: mirror, do not own
+
+Every lane reflects a system of record you already keep. The command center reads that system and lays the current state on one screen. It does not become the place the data lives.
+
+Why this is the whole game: the fastest way to kill a personal dashboard is to let it hold state that also lives elsewhere. The two copies drift within days, you catch the surface being wrong once, and you never trust it again. Mirror and link out, and the surface can be wrong only if the source is wrong.
+
+Concretely:
+- Read from the source on a schedule; render a view; link each item back.
+- Store nothing on the surface except the few interaction bits below.
+- If a lane needs data no system currently holds, fix that in the source system first, then mirror it. Do not let the dashboard become the shadow database.
+
+## Pattern 2: read-mostly, with a few kept-here actions
+
+A pure read-only board sends you back to the source tool for every small thing, which defeats the point. Allow a short list of low-friction actions that keep you on the surface, and push everything heavier back to the source.
+
+- Keep on the surface: mark an item done, add a short note, attach a link, snooze or flag.
+- Send back to the source: composing a real deliverable, editing a record's core fields, anything a teammate also touches.
+
+Give every item a stable id so a kept-here action (a done toggle, a note) attaches to the right item across refreshes instead of creating a duplicate.
+
+## Pattern 3: a refresh cadence you can reason about
+
+Decide, per lane, how fresh it needs to be, and make the refresh boring and predictable.
+
+- Fast-moving lanes (inbound, replies) refresh often; slow lanes (events, content calendar) refresh daily.
+- Show a last-refreshed marker so you know whether you are looking at live state or a cache.
+- If the surface runs unattended (a scheduled job assembling it), assume the job cannot reach every source every time; degrade gracefully, show the stale marker, and never present a cache as live.
+
+## Assembly options
+
+You do not need a bespoke app. In rough order of effort:
+
+1. A single page your existing tools already offer (a saved board view, a filtered list) - start here if one tool holds most of your lanes.
+2. A lightweight page that pulls from each source's export or API on a schedule and renders one view.
+3. A small local service that aggregates and serves the page, if you want interaction (done toggles, notes) and offline resilience.
+
+Start at the lowest rung that covers your lanes. Build up only when a real gap forces it.
+
+## What not to build
+
+- A second CRM. If you are re-entering deal data, stop.
+- A universal inbox that also sends. Sending and composing belong in the source tools with their approval rails.
+- A metrics warehouse. Trend analysis is a weekly review artefact, not a daily operating surface.

--- a/skills/gali-firon/gtm-command-center/references/clean-room.md
+++ b/skills/gali-firon/gtm-command-center/references/clean-room.md
@@ -8,7 +8,7 @@ The moment any slice of the surface is shown to someone else, it has to be a cle
 
 - **Raw scores and rankings.** Your internal 1-to-10 on an item, your "why this is deprioritised" note.
 - **Blunt working notes.** The candid version of why a deal is stuck or a person went quiet.
-- **Internal labels and process names.** The names of the tools, scripts, agents, or steps that generate your work. A teammate-facing view names outcomes, not machinery.
+- **Process detail.** How the work got made - the tools, steps, or helpers involved - is noise to the recipient, who needs the outcome and its status, not a narration of the process. Describe work by what it is and where it stands, not by how it was produced.
 - **Unapproved drafts.** Anything not yet cleared to be seen.
 - **Anything about people that you would not say to their face or in front of them.**
 
@@ -16,7 +16,7 @@ The moment any slice of the surface is shown to someone else, it has to be a cle
 
 The same work, described by outcome and status in plain language:
 
-- "Draft ready for review", not "Sofia pass complete, score 7".
+- "Draft ready for review", not "second editing pass done, score 7/10".
 - "Waiting on client", not your private note about why the client is difficult.
 - Functional owner labels, not internal code names.
 - Committed and in-flight work, not your raw backlog and scores.
@@ -30,4 +30,4 @@ The same work, described by outcome and status in plain language:
 
 ## Why this matters more than it looks
 
-Two failure modes this prevents. The obvious one: a raw note or a candid score reaches the person it was about. The quieter one: internal machinery leaks - the names of your tools, helpers, or process steps - and what was meant to read as your judgment now reads as automated output. The clean-room view protects both the people in your notes and the credibility of the work.
+Two failure modes this prevents. The obvious one: a raw note or a candid score reaches the person it was about. The quieter one: process detail clutters a view that should be about outcomes - the recipient gets a narration of how the work was made instead of the decision or status they came for. A shareable view describes work by outcome and status, which is what the recipient can actually use.

--- a/skills/gali-firon/gtm-command-center/references/clean-room.md
+++ b/skills/gali-firon/gtm-command-center/references/clean-room.md
@@ -1,0 +1,33 @@
+# Clean-room: private working surface vs shareable view
+
+Your command center is a private working surface. It carries the raw material of how you operate: blunt notes, priority scores, half-formed drafts, internal labels, the names of whatever systems and helpers produce your work. None of that is meant for teammates, a boss, clients, partners, or an audience.
+
+The moment any slice of the surface is shown to someone else, it has to be a clean-room view: the same underlying facts, with every private working artefact stripped. Building this separation in from the start is far cheaper than retrofitting it the first time someone asks to see your board.
+
+## What is private and never travels
+
+- **Raw scores and rankings.** Your internal 1-to-10 on an item, your "why this is deprioritised" note.
+- **Blunt working notes.** The candid version of why a deal is stuck or a person went quiet.
+- **Internal labels and process names.** The names of the tools, scripts, agents, or steps that generate your work. A teammate-facing view names outcomes, not machinery.
+- **Unapproved drafts.** Anything not yet cleared to be seen.
+- **Anything about people that you would not say to their face or in front of them.**
+
+## What a shareable view shows instead
+
+The same work, described by outcome and status in plain language:
+
+- "Draft ready for review", not "Sofia pass complete, score 7".
+- "Waiting on client", not your private note about why the client is difficult.
+- Functional owner labels, not internal code names.
+- Committed and in-flight work, not your raw backlog and scores.
+
+## How to build the split
+
+1. **Tag every field as private or shareable when you design the lane**, not later. A field with no tag defaults to private.
+2. **Generate the shareable view from the private one by suppression**, never by hand-copying. Hand-copying drifts and leaks.
+3. **Make the shareable view a distinct surface** - a separate page or export - so there is no way to accidentally show the private one by turning your screen around.
+4. **Review the shareable view once as if you were the recipient.** If a single line would embarrass you or expose how the sausage is made, it is mistagged.
+
+## Why this matters more than it looks
+
+Two failure modes this prevents. The obvious one: a raw note or a candid score reaches the person it was about. The quieter one: internal machinery leaks - the names of your tools, helpers, or process steps - and what was meant to read as your judgment now reads as automated output. The clean-room view protects both the people in your notes and the credibility of the work.

--- a/skills/gali-firon/gtm-command-center/references/lanes.md
+++ b/skills/gali-firon/gtm-command-center/references/lanes.md
@@ -1,0 +1,37 @@
+# The lanes and their data contracts
+
+A lane is one horizontal strip on the command center: one area of your work, mirrored from one system of record. This page lists the lanes a cross-function GTM operator usually needs, what each shows, and the minimum data contract that keeps the lane cheap to build and hard to break.
+
+## The rule for adding a lane
+
+A lane earns its place only if you take action in it. If you only watch it, it is a report, not a lane, and it belongs in a weekly review, not on your daily surface. When in doubt, leave it off; an empty-feeling command center you trust beats a full one you skim.
+
+## The common lanes
+
+| Lane | What it shows | System of record | You act by |
+|---|---|---|---|
+| Task board | Your open deliverables, owner-labelled, with a done state | Your project/task tool | Marking done, reprioritising |
+| Outreach queue | Drafts and sends awaiting your review or follow-up | Your outreach/sequence tool or drafts folder | Approving, editing, sending by hand |
+| Content / publishing queue | Posts, articles, or assets waiting on you to draft, approve, or schedule | Your content calendar or draft store | Approving, scheduling |
+| Research digest | The latest signal on your beat - competitor moves, news, mentions | Your research feed or saved searches | Deciding what to act on |
+| Events / presence | Upcoming events, who is going, what is committed vs a candidate | Your calendar and events tracker | Deciding attendance, prep |
+| Pipeline snapshot | The few deals or opportunities that need you now | Your CRM | One next action per item |
+
+Pick the four to six that match your role. A content-and-comms operator leans on the outreach, content, research, and events lanes; a seller leans on pipeline, tasks, and outreach. Do not ship all six by default.
+
+## The data contract per lane
+
+Keep each lane's contract to the smallest set of fields that lets you act without opening the source tool. A workable default per item:
+
+- a **title** that is legible on its own,
+- a **stable id** so the item can be toggled or annotated without duplicating,
+- a **state** (for example: waiting on you, in progress, done),
+- an **owner or lane label** so a shared view can be built cleanly later,
+- a **link** back to the system of record for anything heavier than a glance,
+- optionally a **why-now** note or a small score, kept behind the item, not shown as a wall of numbers.
+
+The contract is the boundary between the lane and its source tool. If you find yourself wanting a seventh and eighth field, you are rebuilding the source tool inside the lane - stop, and link out instead.
+
+## Candidate events vs commitments
+
+One subtlety that trips people up: a lane that lists candidate events (things happening that quarter you could attend) is not a plan. Keep candidates visibly separate from commitments (things you have actually said yes to or spent money on). Collapsing the two makes the surface lie to you about what is real. Label the state, do not infer it.

--- a/skills/gali-firon/gtm-command-center/references/morning-rollup.md
+++ b/skills/gali-firon/gtm-command-center/references/morning-rollup.md
@@ -1,0 +1,38 @@
+# The morning roll-up: what needs me now
+
+The command center is the surface; the roll-up is the ritual. Once a day it collapses every lane into one short list that answers a single question: what needs me today. If you build only one thing from this skill, build this.
+
+## The single question
+
+Not "what is happening" - that is the whole surface. The roll-up asks "what needs *me*, *today*". An item qualifies only if both are true:
+
+1. **It needs you specifically.** You are the person who has to move it, not a teammate, not an automated step. Work owned by someone else, even if you care about it, stays off.
+2. **It has a reason to act now.** A clock, a dependency, a decision someone is waiting on. Work with no near-term trigger stays in its lane, not on the roll-up.
+
+Everything that is merely in progress, or interesting, or someone else's, is suppressed. Suppression is the feature.
+
+## How to assemble it
+
+1. Scan each lane for items in a "waiting on you" state. Ignore in-progress and done.
+2. From those, keep only items that also have a why-now: a deadline, a blocked teammate, a time-sensitive reply, a live decision.
+3. Rank the survivors by leverage: what only you can move, and what breaks if it slips today, first.
+4. Cut to a length you can read in under two minutes. If more than a handful survive, your "needs me now" test is too loose - tighten it, do not lengthen the list.
+5. Present as a flat, ranked list. Each line: the item, the one action, the why-now. No sections, no scores, no preamble.
+
+## What to surface vs suppress
+
+| Surface | Suppress |
+|---|---|
+| A draft awaiting your approval before it can send | A draft still being written by someone else |
+| A reply a prospect or reporter is waiting on today | A thread that is progressing fine without you |
+| A decision a teammate is blocked on | A decision with no deadline you can make any time |
+| An event whose deadline (on-sale, RSVP, submission) is this week | An event on the calendar with no near action |
+| A deliverable due today or overdue | A deliverable due next week, on track |
+
+## The trap: the roll-up that is just the surface again
+
+The most common failure is a roll-up that lists everything on the board with a fresh header. That is not triage; it is a second copy of the surface, and it trains you to skim. If your roll-up is long, the fix is always to cut, never to reformat. A roll-up of three real items you will act on today beats a roll-up of thirty you will scroll past.
+
+## Cadence
+
+Run it once at the start of the day, from the live surface. Running it more often turns it into a notification stream, which is the thing the command center exists to replace. One assembled read, then work from it.


### PR DESCRIPTION
## Skill: gtm-command-center

A personal, stack-agnostic operating surface for a cross-function GTM operator - the task board, outreach queue, content/publishing queue, research digest, events/presence, and pipeline snapshot in one place, plus a single daily "what needs me now" roll-up.

**Files:** `SKILL.md` (spine + `What good looks like`) and four references: `lanes.md` (lane catalogue + data contract), `build-guide.md` (read-mostly / one-source-of-truth / refresh patterns), `morning-rollup.md` (the daily triage ritual), `clean-room.md` (private working surface vs shareable view).

### Review-gate checklist
- **Convention:** `node tools/validate.mjs` passes; name == folder, kebab-case, unique.
- **Security:** pure methodology skill; no endpoints, secrets, external URLs, prompt-injection, or destructive/bulk actions. It is explicitly read-mostly and links out rather than acting.
- **Judgment, not steps:** built on the subtractive discipline (what to leave off), the maintenance-trap failure mode, and a concrete week-long success test; depth in four references.
- **Tool-agnostic:** GTM verbs and "your CRM / your outreach tool / your research feed" throughout; no vendor or brand names; no dates; no first-person plural.
- **Author identity:** existing `gali-firon` creator profile (author.md already on main).

Category `RevOps`; open to a different home if you'd prefer.