### PR TITLE
add rfp-response by gali-firon

### DIFF
--- a/skills/gali-firon/rfp-response/SKILL.md
+++ b/skills/gali-firon/rfp-response/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rfp-response
+title: RFP response
+description: |
+  Use this skill when an inbound RFP, RFI, or brief lands and a proposal has to go back by a deadline - "an RFP just came in", "should we bid on this", "build the response", "the proposal is due Friday", "set up the RFP", "where are we on the [brand] RFP", "what's the status of our RFPs", "what's at risk in the pipeline". Produces a bid/no-bid call, a structured response built to the evaluator's criteria, a work plan sequenced backward from the deadline, and a status read across every live RFP.
+category: Deals
+tags: [Sales]
+---
+
+Applies from the moment a request for proposal lands until the proposal is submitted and tracked. Produces a qualify decision, a response built to how the buyer will actually score it, a deadline-driven work plan, and a pipeline status read.
+
+An RFP is a timed exam someone else wrote. Two things lose winnable deals: bidding on the ones you were never going to win, and losing track of the clock on the ones you could. This skill front-loads the qualify decision so effort goes where it can pay off, then keeps every live RFP visible against its deadline.
+
+## Qualify before you invest
+
+Before anyone writes a slide, decide whether to bid. A response is expensive; a reflexive yes to every RFP burns the team and lowers the win rate on the ones that mattered. Score fit, winnability, and whether the request is even real (some RFPs exist to justify an incumbent already chosen). The bid/no-bid rubric, the disqualifiers, and how to route ownership once you commit are in `references/qualify-and-route.md`.
+
+## Anchor on the deadline, not the flight dates
+
+Read the request for the one date that governs everything: when the proposal is due. Keep it separate from the campaign or engagement dates the RFP also lists - people routinely record the flight dates as the deadline and miss the submission by a week. Put the proposal deadline at the top of every working artefact, above the engagement dates, so no one has to hunt for it.
+
+## Structure the response to the scorecard
+
+Buyers score RFPs against stated (and unstated) criteria; the response is built to that scorecard, not to your standard pitch. Answer every question they asked, fully, in their order; lead each section with the criterion it satisfies; and start from a clean canonical template, never from the last deal's response. The full response structure, the "answer what they asked" discipline, and why you never reuse a previous RFP's deck are in `references/response-structure.md`.
+
+## Work backward from the deadline
+
+Sequence the work from the due date, not forward from today. Identify the long-pole items (custom pricing, creative, security or legal review, exec sign-off), start those first, and leave a buffer for the review round that always runs late. Nothing goes out without a human owner approving the final submission. The reverse timeline, the long-pole checklist, and the status model are in `references/timeline-and-status.md`.
+
+## Status discipline across the pipeline
+
+When several RFPs are live at once, the failure is not any single proposal - it is losing track of which one is at what stage. For each live RFP, know the stage, the next action, who owes it, and the days to deadline. A weekly sweep against that model surfaces the one about to slip while there is still time to move.
+
+## What good looks like
+
+- **What the best operator notices first:** whether the RFP is real and winnable, before the team invests a week. The strongest signal is fit against the disqualifiers and any sign an incumbent is already chosen. A disciplined no-bid on an unwinnable RFP protects the win rate on the ones you should chase; a team that bids on everything wins less.
+- **The common mistake:** treating the RFP as a pitch instead of an exam. The mediocre response leads with the company, reuses the last deal's deck (dragging in the wrong logos, metrics, and claims), answers the questions it wishes had been asked, and discovers the real deadline was the submission date, not the flight dates, a day late. Each of those loses points a stronger competitor banks.
+- **How you know it worked:** every question in the RFP is answered in the buyer's order, each section opens on the criterion it satisfies, the proposal deadline sat at the top of the working file the whole time, a human approved the final submission, and it went in with buffer to spare. Across the pipeline, you can name the stage and next action for every live RFP without opening each one.
+
+## Rules
+
+- MUST make an explicit bid/no-bid decision before production starts; capacity is finite and a reflexive bid lowers the win rate elsewhere.
+- MUST record the proposal submission deadline at the top of every working artefact, distinct from the engagement or flight dates.
+- MUST answer every question the RFP asks, in the buyer's order, built to their evaluation criteria.
+- MUST start each response from a clean canonical template, never from a previous deal's response.
+- MUST route the final submission through a human owner who approves before it is sent; nothing submits automatically.
+- NEVER submit past the deadline; a late proposal is usually disqualified regardless of quality.

--- a/skills/gali-firon/rfp-response/references/qualify-and-route.md
+++ b/skills/gali-firon/rfp-response/references/qualify-and-route.md
@@ -1,0 +1,40 @@
+# Qualify and route: the bid/no-bid decision
+
+The most valuable decision in the whole process happens before any writing: whether to bid at all. A response costs real hours across sales, creative, pricing, and leadership. Spend them on the RFPs you can win, and say no cleanly to the rest.
+
+## The bid/no-bid rubric
+
+Score the RFP on four questions. A weak answer on any one is a reason to pause; weak answers on two is usually a no-bid.
+
+| Question | Bid signal | No-bid signal |
+|---|---|---|
+| **Fit** | The ask maps to what you actually do well | You would be stretching into an offer you cannot deliver confidently |
+| **Winnability** | You have a real angle, a relationship, or proof in this space | No relationship, no differentiator, cold against entrenched competitors |
+| **Is it real** | Open process, genuine evaluation, multiple vendors in contention | Signs an incumbent is pre-chosen and the RFP exists to justify them |
+| **Worth the cost** | Deal size and strategic value justify the effort | High-effort custom response for a small or low-probability deal |
+
+## Disqualifiers
+
+Some signals are strong enough to decline on their own:
+
+- The requirements describe a specific competitor's product in detail (the spec was written for them).
+- The timeline is too short to produce a response you would be proud of, with no flexibility.
+- Mandatory terms you cannot meet (compliance, exclusivity, pricing floor).
+- No access to the buyer for questions, and the brief has gaps you cannot responsibly guess at.
+
+A clean, prompt no-bid is a professional answer, and it preserves the relationship for a better-fit RFP later. It beats a rushed, half-hearted response that signals you do not understand the ask.
+
+## Routing once you commit
+
+The moment the decision is bid, assign ownership so nothing falls between people. Keep it to a few clear roles, however your team is structured:
+
+- **Owner of the response** - drives the whole thing to the deadline, holds the timeline, and is accountable for submission.
+- **Identifier / qualifier** - the person who read the RFP first, understands what is being asked, and briefs the rest of the team so no one re-reads from scratch.
+- **Contributors** - whoever supplies pricing, creative, technical answers, security or legal review.
+- **Approver** - the human who signs off on the final proposal before it is submitted.
+
+Write these down on the RFP's working record on day one. The single most common coordination failure is an unassigned long-pole item (custom pricing, a security questionnaire) that no one realises they own until the deadline is close.
+
+## Capturing the decision
+
+Record the bid/no-bid call and the reason, even for a no. A logged no-bid is not wasted: it is the pattern that tells you, over a quarter, which RFP sources are worth your time and which routinely send unwinnable requests.

--- a/skills/gali-firon/rfp-response/references/response-structure.md
+++ b/skills/gali-firon/rfp-response/references/response-structure.md
@@ -1,0 +1,46 @@
+# Response structure: build to the scorecard
+
+The buyer evaluates every response against a set of criteria, some stated in the RFP and some implicit. A winning proposal is built to that scorecard, in the buyer's language and order, not shaped like your standard pitch.
+
+## Answer what they asked, in their order
+
+The single highest-leverage discipline: answer every question the RFP asks, fully, in the order they asked it. Evaluators often score section by section against a checklist; a response that reorders or skips questions loses points mechanically, before anyone judges the quality of the idea.
+
+- Map every question and requirement in the RFP to a section of your response. Nothing unanswered.
+- Keep their numbering and their wording. If they call it "audience verification", do not answer under "brand safety".
+- Answer the question actually asked, not the one you wish they had asked. A strong answer to an adjacent question still scores zero on the one they wrote down.
+
+## Lead each section with the criterion it satisfies
+
+Open each section by naming the buyer's need it addresses, then deliver. The evaluator should never have to hunt for where you answered their requirement. Put the answer first and the supporting narrative second, not the reverse.
+
+## Start from a clean canonical template
+
+Always build from a clean, current template, never from a previous deal's response. Reusing the last proposal is the most common self-inflicted wound in RFP work:
+
+- It drags in the wrong client's logos, screenshots, and case numbers, which a sharp evaluator notices immediately and reads as carelessness.
+- It carries stale pricing and claims you may no longer stand behind.
+- It anchors the new response to the old deal's structure instead of this buyer's questions.
+
+Keep one maintained master template per response type. Start there every time, and pull in proof assets deliberately, matched to this buyer.
+
+## The proposal deadline sits at the top
+
+Record the submission deadline at the very top of the working file, above the engagement or flight dates the RFP also lists. These are different dates and they get confused constantly: the flight dates say when the work would run; the deadline says when the proposal is due. Missing the second because you tracked the first loses the deal with a great response sitting finished on your drive.
+
+## Proof, matched not carpeted
+
+Include proof, but matched to this buyer's situation, not every case study you own. One or two relevant, verifiable proof points beat a stack of loosely related ones (the same restraint the case-study discipline calls for). Anchor claims to real, defensible numbers; an evaluator who catches one inflated figure discounts the whole proposal.
+
+## A workable section order
+
+Adapt to the RFP's own structure, but a reliable default when they do not prescribe one:
+
+1. A short executive summary that restates their objective in their words and names your angle.
+2. A point-by-point response to their requirements, in their order.
+3. The approach or solution, led by the criteria it satisfies.
+4. Proof matched to their situation.
+5. Pricing, exactly as they asked it to be presented.
+6. Team, timeline, and next steps.
+
+If they gave a required format, theirs wins over this one, every time.

--- a/skills/gali-firon/rfp-response/references/timeline-and-status.md
+++ b/skills/gali-firon/rfp-response/references/timeline-and-status.md
@@ -1,0 +1,43 @@
+# Timeline and status: work backward, then keep it visible
+
+Two clocks decide RFP outcomes: the countdown on each proposal, and your view across all of them at once. This page covers sequencing a single response from its deadline, and reading status across a pipeline of live RFPs.
+
+## Build the timeline backward from the deadline
+
+Start at the submission deadline and work backward, not forward from today. Forward planning quietly assumes you have all the time between now and the due date; backward planning exposes where you do not.
+
+1. **Deadline.** Fix the submission date and time, including the buyer's time zone.
+2. **Submission buffer.** Reserve the last slot before the deadline for final assembly and upload. Portals fail, files are large, and formatting takes longer than anyone expects. Never plan to finish at the deadline.
+3. **Final approval.** Before that, the human owner reviews and approves the complete proposal. Nothing submits without this.
+4. **Review round.** Before approval, a full internal review. Assume it surfaces changes and always runs a little late.
+5. **Long poles first.** Identify the items with the longest lead time and start them on day one.
+
+## The long-pole checklist
+
+These are the items that blow deadlines because they depend on someone outside the core team:
+
+- Custom or non-standard pricing that needs leadership sign-off.
+- Bespoke creative, mockups, or a custom-built demo.
+- Security, privacy, or legal questionnaires and reviews.
+- Executive sign-off on commitments or terms.
+- Anything requiring a clarifying answer from the buyer (ask early; their reply has its own lag).
+
+Start every long pole at the beginning. A response is rarely late because the writing was slow; it is late because one dependency was picked up three days before the deadline.
+
+## The status model for a pipeline of RFPs
+
+When several RFPs run at once, track each against the same small model so the one about to slip is obvious:
+
+| Field | What it captures |
+|---|---|
+| Stage | Where it is: qualifying, briefed, in production, in review, submitted, won/lost |
+| Next action | The single next thing that has to happen |
+| Owner of next action | Who owes that action |
+| Days to deadline | The countdown to submission |
+| Risk | Anything threatening the deadline or the quality |
+
+## The weekly sweep
+
+Once a week, read every live RFP against that model and ask one question per row: is this on track to submit on time at the quality we want. The sweep exists to catch the RFP that is quietly stalling while there is still time to intervene. Sort by days-to-deadline, and give the one with a stalled next action and a near deadline attention first.
+
+The point is not a tidy tracker. It is that no winnable RFP is ever lost to a clock nobody was watching.


### PR DESCRIPTION
## Skill: rfp-response

End-to-end judgment for winning inbound RFPs: the bid/no-bid call, a response built to the buyer's evaluation criteria, a work plan sequenced backward from the deadline, and status discipline across a pipeline of live RFPs.

**Files:** `SKILL.md` (spine + `What good looks like`) and three references: `qualify-and-route.md` (bid/no-bid rubric, disqualifiers, ownership roles), `response-structure.md` (answer-what-they-asked, build-to-scorecard, never reuse the last deal's deck), `timeline-and-status.md` (reverse timeline, long-pole checklist, pipeline status model + weekly sweep).

No RFP / proposal-response skill exists in the library yet; this fills an open slot in the `Deals` category.

### Review-gate checklist
- **Convention:** `node tools/validate.mjs` passes; name == folder, kebab-case, unique.
- **Security:** methodology skill; no endpoints, secrets, external URLs, prompt-injection, or destructive/bulk actions. Explicit human-approves-before-submit rule; nothing submits automatically.
- **Judgment, not steps:** built on the bid/no-bid discipline, the deadline-vs-flight-dates trap, the never-reuse-the-last-deck failure mode, and a concrete definition of a winning response; depth in three references.
- **Tool-agnostic:** "your pipeline board / shared drive / proposal template / the deal team" throughout; no vendor or brand names; no dates; no first-person plural.
- **Author identity:** existing `gali-firon` creator profile (author.md already on main).

Category `Deals`.