### PR TITLE
add visual-argument-review by gali-firon

### DIFF
--- a/skills/gali-firon/visual-argument-review/SKILL.md
+++ b/skills/gali-firon/visual-argument-review/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: visual-argument-review
+title: Visual argument review
+description: |
+  Use this skill when a marketing design asset needs a senior review before it ships - a sales deck, a one-pager, a LinkedIn graphic or carousel, a case study, a landing section, a proposal slide. Produces a prioritized design read: what works, the ranked fixes with the commercial reason for each, brand and data-integrity checks, and one stronger idea. Reach for it when someone asks "what's wrong with this deck", "is this client-ready", "review this one-pager", "give me design feedback", or "why does this look off".
+category: Positioning
+tags: [Marketing]
+---
+
+Applies when a finished or near-finished marketing asset needs a critical read before it reaches a buyer, partner, or client. Produces a prioritized, fixable design read, not a vibe check.
+
+Review it the way a senior B2B designer would, not a generic assistant. The audience for these assets is brand marketers, media buyers, and agency planners: impatient, data-driven, risk-averse, looking at dashboards all day. They read clean, structured design as a signal of a reliable platform, and clutter or over-design as operational risk. The reviewer's job is to make the asset accelerate a business decision.
+
+## The lens
+
+One idea governs the whole review: design is the visual architecture of an argument, not a layer of polish on top of text. If an element does not speed comprehension, build credibility, or reduce perceived risk, it is clutter. Competent designers add; strong ones remove. You are reading for what should come off the page as much as what should change.
+
+Seven principles sit under that lens and decide most calls: design accelerates a decision; professional B2B before decorative; one idea per visual unit; proof-led hierarchy (the key stat or logo leads, supporting copy stays shorter); restraint beats decoration (whitespace is a tool, not wasted space); source every factual claim; hold one visual world per asset.
+
+## Run the review across eight dimensions
+
+Read the asset against eight dimensions, in this order, so the structural problems surface before the cosmetic ones. Each has concrete checks - the full checklist per dimension is in `references/review-rubric.md`.
+
+1. **Strategic fit** - who it is for and what decision it should move; does the hierarchy lead with the right proof for that audience.
+2. **Brand fidelity** - correct palette, logo, type, and one visual world; no near-match colors.
+3. **Story and hierarchy** - one message per unit, action titles not labels, a ten-second scan reveals the argument.
+4. **Layout craft** - grid alignment, consistent margins and repeated positions, roughly a third of the canvas breathing.
+5. **Typography craft** - a clear type scale, equivalent elements at equivalent sizes, readable at the real destination size, no overflow or orphans.
+6. **Proof and data design** - metrics real, sourced, and labelled; number first, label second; charts with units and sources; no 3D or misleading charts.
+7. **Imagery and assets** - real, sharp screenshots in the right orientation; device frames keep aspect ratio; logos at even weight; icons from one consistent set.
+8. **Polish and client-readiness** - would you send this to a top client without flinching; does it read as an intentional system, not a filled-in template.
+
+## Deliver the read
+
+Return a structured design read, not a wall of notes. Lead with the verdict, name what works, then rank the fixes by severity with the specific fix and the commercial reason for each, then the brand and data checks, then one stronger idea that improves the asset without reinventing it. The exact format and the feedback rules are in `references/output-format.md`.
+
+## Check the visual toolkit
+
+A cluster of failures comes from the wrong tool for a visual job, and they read as off-brand or machine-made. Verify the asset did not generate its own icons, mix icon sets, or generate or approximate a real logo, and that any photographic or hero imagery was produced deliberately, not improvised. The tool-discipline rules are in `references/visual-toolkit.md`.
+
+## What good looks like
+
+- **What the best reviewer notices first:** whether the asset leads with the right proof for its audience, and how much could be removed. The strongest single move is usually subtraction - a slide carrying one message reads as confident; a slide carrying three reads as unsure. Clutter is not a cosmetic issue in front of a data buyer, it is a credibility issue.
+- **The common mistake:** dumping twenty equal-weight notes with no priority and no fix, or reviewing for taste instead of the decision the asset has to move. A review that says "make it pop" or lists every misaligned pixel without ranking is noise; the designer cannot act on it and the important fix drowns.
+- **How you know the read is good:** every fix names the exact slide or element, states the specific change, and gives the commercial reason it matters; the list is ranked so the one thing that would most improve the asset is first; and a designer could execute the whole read without asking a follow-up question.
+
+## Rules
+
+- MUST lead the review with the audience and the decision the asset must move; judge everything against that, not against taste.
+- MUST rank fixes by severity and pair each with a specific fix and its commercial reason; never dump an unranked list.
+- MUST name the exact slide, section, or element for every issue.
+- MUST treat unsourced or invented metrics and misleading charts as blocking, not cosmetic, in any client-facing asset.
+- MUST flag a generated or approximated logo, generated icons, or mixed icon sets as a fix, not a nitpick.
+- NEVER approve on decoration; if an element does not speed comprehension, build credibility, or reduce risk, recommend cutting it.

--- a/skills/gali-firon/visual-argument-review/references/output-format.md
+++ b/skills/gali-firon/visual-argument-review/references/output-format.md
@@ -1,0 +1,45 @@
+# The design read: output format and feedback rules
+
+A review is only useful if the designer can act on it. The format below forces the two things most feedback misses: a priority order, and a fix with its reason attached to every issue. Deliver the read in this shape.
+
+## The format
+
+```markdown
+## Design Read
+**Asset:** [name or link if known]
+**Audience / job:** [who it is for and the decision it must move]
+**Verdict:** [Client-ready / Close, needs fixes / Not ready]
+
+### What works
+- [Specific strength tied to the argument, hierarchy, proof, or audience - not "looks clean"]
+
+### Priority fixes
+1. **[High/Medium/Low] [slide or element] - [the issue].** Fix: [the specific change]. Why: [the business or design reason].
+2. ...
+
+### Brand and data checks
+- Palette / type / logo: [pass or fail, with specifics]
+- Data integrity: [pass or fail - are metrics sourced, labelled, honestly charted]
+
+### Stronger idea
+[One concept that would materially improve the asset without reinventing it.]
+```
+
+Lead with the verdict so the reader knows the stakes before the detail. Name what works before the fixes: it is not padding, it tells the designer what to protect while they change the rest.
+
+## The feedback rules
+
+- **Name the exact element.** "Slide 4, the metric row" beats "the numbers". A fix the designer has to locate is a fix that does not happen.
+- **Give the fix, not just the criticism.** "Too busy" is not actionable. "Cut the three background shapes and the second chart; keep the one stat" is.
+- **Attach the commercial why.** Every fix earns its place by helping the asset move the decision. "Lead with the completion-rate stat because that is the number this buyer is evaluated on" tells the designer why it matters and helps them make the next call themselves.
+- **Prioritize; do not dump.** A ranked list of the five fixes that matter beats twenty equal-weight notes. Twenty notes with no order reads as noise, and the one fix that would save the asset drowns in it.
+- **Match the effort to the stakes.** A LinkedIn graphic does not need the scrutiny of a client proposal. Say when an asset is good enough to ship rather than gold-plating it.
+- **If the asset is not accessible, say so** before giving only general guidance. General advice dressed up as a specific review wastes the designer's time.
+
+## Calibrating the verdict
+
+- **Client-ready** - you would send it as is. Any remaining notes are optional polish.
+- **Close, needs fixes** - the argument and brand hold; a short, specific fix list gets it to ready.
+- **Not ready** - a structural problem (wrong audience, broken hierarchy, unsourced data, wrong brand) has to be solved before polish is worth doing.
+
+Do not soften a Not ready into a Close to be kind. A clear verdict early saves the designer from polishing an asset that needs restructuring.

--- a/skills/gali-firon/visual-argument-review/references/review-rubric.md
+++ b/skills/gali-firon/visual-argument-review/references/review-rubric.md
@@ -1,0 +1,69 @@
+# The eight-dimension review rubric
+
+Read the asset against these eight dimensions in order. Structure first (does the argument hold), craft second (is it built well), polish last (is it ready to send). A failure high on the list usually explains failures lower down, so fix the top of the list first.
+
+## 1. Strategic fit
+
+- Who is this asset for: a buyer, a partner, an investor, an agency planner, an internal team, a social audience?
+- What decision should it move them toward?
+- Does the hierarchy lead with the right proof for that audience? A buyer wants the mechanic and the result; an investor wants the trend; a planner wants the fit. The same facts get ordered differently per audience.
+
+If the asset does not know who it is for, nothing below matters yet. Fix this first.
+
+## 2. Brand fidelity
+
+- Correct brand, palette, logo, font, and visual world.
+- No near-match colors (an almost-right hex reads as a knock-off).
+- No mixed visual languages in one asset unless a combined presentation was explicitly briefed.
+
+## 3. Story and hierarchy
+
+- One clear message per slide, page, card, or graphic.
+- Action titles that state the point, not generic labels ("Reach that holds through Q4", not "Results").
+- A ten-second scan should reveal the argument without reading the body.
+- The reader's eye should land first on the most important thing on the page.
+
+## 4. Layout craft
+
+- Elements aligned to a grid.
+- Consistent margins, gutters, and repeated positions across slides.
+- Roughly a third of the canvas or more left to breathe. Whitespace is a design tool, not wasted space.
+- Nothing floating, crowded, or a few pixels off from its neighbours.
+
+## 5. Typography craft
+
+- A clear type scale, few weights, hierarchy from size, weight, spacing, and placement rather than from coloring everything.
+- Equivalent elements use equivalent sizes and weights.
+- Body copy is readable at the actual destination size (a slide seen across a room, a graphic seen on a phone).
+- No overflow, cut-off text, orphaned single words, inconsistent capitalization, or punctuation drift.
+
+## 6. Proof and data design
+
+- Metrics are real, sourced, labelled, and characterized accurately.
+- Metric cards show the number first, the precise label second.
+- Charts have labels, units, and a source.
+- No 3D, decorative, or misleading charts; no truncated axes that exaggerate.
+- Number formatting is consistent across the asset.
+
+In a client-facing asset, an unsourced or invented figure is a blocking failure, not a cosmetic one. One figure a sharp buyer can disprove discredits every honest number on the page.
+
+## 7. Imagery and assets
+
+- Screenshots are real, sharp, and placed in the correct orientation; device frames preserve aspect ratio.
+- Logos have even visual weight and clear space, never stretched or recolored.
+- Icons are from one consistent set, sharing one grid and stroke weight.
+- Stock or generated imagery, if used, feels authentic and on-brand, not improvised filler.
+
+## 8. Polish and client-readiness
+
+- Would you send this to a top client or agency contact without flinching?
+- Does it read as an intentional system, or as a filled-in template?
+- Is the fix list specific enough for a designer to execute without guessing?
+
+## The severity call
+
+Rank every issue you find:
+
+- **High** - breaks the argument, the brand, or data integrity. The asset is not ready until this is fixed.
+- **Medium** - weakens comprehension or credibility but does not break it. Fix before an important send.
+- **Low** - polish. Fix if time allows; never let a pile of lows bury a high.

--- a/skills/gali-firon/visual-argument-review/references/visual-toolkit.md
+++ b/skills/gali-firon/visual-argument-review/references/visual-toolkit.md
@@ -1,0 +1,35 @@
+# Visual toolkit: the right tool for each visual job
+
+A recognisable cluster of failures comes from using the wrong tool for a visual element. They are worth their own pass because they read as off-brand or machine-made even when the layout and copy are fine, and because they are easy to miss if you only review the composition. Check each of these on any asset that carries icons, logos, or generated imagery.
+
+## Icons: one set, never generated
+
+- Use a single, consistent vector icon set across the whole asset (for example Lucide, Phosphor, or Heroicons), so every icon shares one grid, one stroke weight, and one corner language. Recolor to the brand palette.
+- Never generate icons with an image model. Model-drawn icons wander in weight and style and read as robotic.
+- Never mix icon sets in one asset. Two sets side by side is one of the fastest tells that an asset was assembled, not designed.
+
+**Reviewing:** if the icons vary in stroke weight or style, or look illustrated rather than drawn to a grid, flag it. The fix is to replace them all with one real vector set.
+
+## Logos: always the real asset
+
+- Never generate or approximate a real logo with an image model. A model-rendered logo is subtly wrong in a way viewers feel even when they cannot name it, and using a mangled version of a real brand's mark is worse than using none.
+- Use the actual logo file. If it is missing, say so and use a clearly-labelled placeholder rather than a generated stand-in.
+- Logos keep even visual weight and clear space; never stretched, recolored, or dropped in at low resolution.
+
+**Reviewing:** any logo that looks even slightly off is a high-severity flag. Verify it is the real asset, correct brand, and undistorted.
+
+## Photographic and hero imagery: generate deliberately
+
+- A generative image model is the right tool for photographic, illustrative, hero, background, or product-mockup imagery - not for icons or logos.
+- When a set of images has to feel like one system (a formats row, a series of cards), generate one anchor image and then edit variations from it, rather than re-prompting each from scratch, so the set shares one look.
+- Do not bake headline text into a generated image; model-rendered text is unreliable. Leave deliberate space for a headline and set the real copy over it afterward.
+
+**Reviewing:** if hero images in a set look unrelated to each other, or a headline is rendered inside the image, flag it.
+
+## Hierarchy comes from structure, not color
+
+A common self-inflicted failure: solving hierarchy by coloring everything. Hierarchy should come from size, weight, spacing, and placement. If a slide uses five colors to signal importance, the fix is usually one accent color and a real type scale, not more color.
+
+## Density is about information, not size
+
+Dense should mean information-dense, never small-and-cramped. If an asset is hard to read, shrinking type to fit more in makes it worse. The fix is to cut what does not carry the argument and give the rest room, not to reduce the type size.


### PR DESCRIPTION
## Skill: visual-argument-review

A senior B2B design review for marketing assets - decks, one-pagers, LinkedIn graphics and carousels, case studies, landing sections. Reads the asset the way a top marketing designer would and returns a prioritized design read: what works, ranked fixes each with its commercial reason, brand and data-integrity checks, and one stronger idea.

Built on one thesis: design is the visual architecture of an argument, not polish on top of text. For a data-driven, risk-averse buyer, clutter reads as operational risk and clean structure reads as a reliable platform; the review exists to make the asset accelerate a decision.

**Files:** `SKILL.md` (spine + `What good looks like`) and three references: `review-rubric.md` (the eight-dimension rubric with concrete checks and severity model), `output-format.md` (the structured design read + the feedback rules: give the fix, attach the commercial why, prioritize don't dump), `visual-toolkit.md` (right-tool-for-the-job discipline: one icon set never generated, never generate or approximate a real logo, generative models only for photographic/hero imagery, hierarchy from structure not color).

### Review-gate checklist
- **Convention:** `node tools/validate.mjs` passes; name == folder, kebab-case, unique.
- **Security:** pure judgment/review skill; no endpoints, secrets, external URLs, prompt-injection, or destructive/bulk actions.
- **Judgment, not steps:** built on the subtractive lens (what to remove), the audience insight (clutter as risk to a data buyer), the twenty-equal-notes failure mode, and a concrete definition of an actionable read; depth in three references.
- **Tool-agnostic:** no design-tool or brand names (icon libraries appear only as parenthetical examples); no dates; no first-person plural.
- **Author identity:** existing `gali-firon` creator profile (author.md already on main).

Category `Positioning`.