### PR TITLE
add competitor-monitoring

### DIFF
--- a/skills/alon-goldenberg/author.md
+++ b/skills/alon-goldenberg/author.md
@@ -1,0 +1,9 @@
+---
+name: Alon Goldenberg
+title: Technical Product Manager, Nimbleway
+linkedinUrl: https://www.linkedin.com/in/alongoldenberg/
+companyDomain: nimbleway.com
+email: along@nimbleway.com
+---
+
+Alon is a technical product manager at Nimbleway, building live-web research and monitoring workflows for GTM teams — competitor intelligence, meeting prep, brand and launch monitoring — and turns the ones that work repeatedly into reusable agent skills. The skills here encode those field-tested plays in a tool-agnostic form.

--- a/skills/alon-goldenberg/competitor-monitoring/SKILL.md
+++ b/skills/alon-goldenberg/competitor-monitoring/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: competitor-monitoring
+title: Competitor monitoring
+description: |
+  Use this skill when you need to know what rival companies are doing — "what are
+  my competitors doing", "competitor update", "competitor news", "competitive
+  landscape", "market intel", "what's new with [company]", "track [company]",
+  "competitor briefing", "who's making moves", "we keep losing deals to
+  [company]" — or before a board meeting, battlecard refresh, or strategy session
+  that needs competitive context. Produces a structured intelligence briefing —
+  funding, M&A, leadership moves, product launches, hiring waves, partnerships —
+  with every signal date-verified against its primary source and deduped against
+  a running memory file per competitor, so each run surfaces only what is new.
+category: Research
+tags: [Sales, Marketing]
+---
+
+# Competitor monitoring
+
+Runs whenever someone needs a current read on the competitive landscape — on a cadence, before a strategy conversation, or the moment a rival's name comes up in a lost deal. Produces a dated, source-linked intelligence briefing of genuinely new competitor moves, plus an updated running memory per competitor so the next run starts where this one ended.
+
+The failure mode this skill exists to prevent: a briefing that confidently reports last quarter's funding round as this week's news because a recap article was published yesterday. Everything below is built around one distinction — **when a page was published vs. when the event actually happened** — and a memory that remembers what you already reported.
+
+## Set up the profile (first run only)
+
+1. Ask for the company's website domain, then search the live web for the domain to confirm you have the right company. Confirm with the user before proceeding.
+2. Build the competitor list one of two ways: the user names them, or you propose them — run three parallel searches ("[Company] competitors", "[Company] vs", "[Company] alternatives"), synthesize a candidate list, and get explicit confirmation. Never research a competitor list the user hasn't approved.
+3. For each confirmed competitor, capture name, domain, and category (direct, adjacent, incumbent). Also capture 2–3 industry keywords for trend searches.
+4. Save all of this to a profile file in your workspace, alongside a `competitors/` directory that will hold one running memory file per competitor and a `briefings/` directory for saved runs.
+
+## Pick the run mode
+
+Check the profile's last-run date before searching anything:
+
+- **Full mode** — first run, or last run more than 14 days ago. Search window: the past 14 days. Output: the full briefing.
+- **Quick refresh** — last run within 14 days. Search window: since the last run, but never narrower than 7 days (too-narrow windows return empty results and read as false quiet). Output: the short delta format.
+- **Same-day repeat** — a report already exists for today. Ask before re-running: "Already ran today — run again for fresh data?" Never silently re-run; it burns effort to produce a near-identical report.
+
+## Load memory before searching
+
+Read each competitor's running memory file and collect the signals already reported. These known signals are the dedup baseline: anything you find that matches one is not news, no matter how fresh the article covering it looks. Pass the known-signal list into each research thread so it can skip them at the source.
+
+## Fan out the research
+
+Research each competitor in parallel — one thread per competitor if your setup supports parallel work, sequentially otherwise. Per competitor, run the five-query fan-out: news, funding/M&A/hiring, their own changelog or release-notes page, real-time social announcements, and review-site movement. Read `references/query-patterns.md` for the exact query shapes, the changelog-extraction step, fallbacks for thin results, and scope caps.
+
+In the same pass, run two industry-trend searches from the profile's keywords, and two searches on the user's own company (site-restricted product updates + news) so the briefing can contrast "them" with "you."
+
+## Validate every signal before it enters the report
+
+This is the gate that separates intelligence from noise. For each candidate signal, record both dates — article date and event date — classify its source type, assign a priority (P1: M&A, leadership changes, major funding, direct product competition; P2: launches, partnerships, hiring waves; P3: blog posts, comparison articles, minor hires), then classify it NEW, UPDATED, STALE, or UNCERTAIN. Only NEW and UPDATED survive. Any P1 signal sourced only from derivative coverage must be corroborated against a primary source before it can appear — this is a hard gate, not a preference. Read `references/signal-validation.md` for the date-extraction rules, source hierarchy, freshness table, verification budget, and the per-signal record format.
+
+Extract the full page (not just the search snippet) for every P1 signal and for any signal whose date you can't pin down from the snippet. Determine the event date from the article body — datelines, "last September", "today announces" — not the page header.
+
+## Build the briefing
+
+Full mode gets the structured briefing (TL;DR of 3–5 P1 signals, per-competitor sections with a "where they win vs. where you win" read, industry trends, your-company update, cross-competitor patterns, strategic implications). Quick refresh gets the short delta: new signals, explicit "nothing new" list, action items only if something demands attention. Read `references/briefing-format.md` for the section-by-section spec of both formats.
+
+If a competitor produced nothing new, say exactly that. "Nothing notable this period" is a valid, valuable finding; padding it with stale context destroys the reader's trust in every future briefing.
+
+## Save and remember
+
+Persist only signals that passed validation — STALE and UNCERTAIN signals never enter memory, or they'd pollute every future dedup. Save the full briefing to `briefings/`, append validated signals to each competitor's memory file in the entry format from `references/briefing-format.md`, and update the profile's last-run date. When this run covered 3+ competitors, also refresh the cross-competitor landscape synthesis described there.
+
+Offer to share the briefing wherever the team reads updates — but only send it after the user explicitly approves the destination.
+
+## Follow-ups
+
+Go deeper on one competitor (focused searches on the thread that mattered), add a competitor (update the profile, create a memory stub), or skip one going forward (record the preference in the profile).
+
+## What good looks like
+
+- The best operator's first move on any exciting headline is to find the event date, not to write the bullet. A syndicated article published yesterday about a funding round from March is the single most common way competitor briefings lie — and the first thing an expert screens out.
+- The mediocre version is a pasted list of search-result headlines: undated, unsourced, half of them repeats of last month's report, padded with "competitor X continues to invest in AI" filler. If the reader can't tell what's actually new since last time, the run failed.
+- A good briefing passes three checks: every TL;DR item carries a verified event date and a clickable source; a reader who saw the previous report finds zero repeated signals; and quiet competitors are explicitly listed as quiet rather than inflated with background context.
+- A good quick refresh is short. Shrinking output when nothing happened is the skill working, not the skill failing.
+
+## Rules
+
+- MUST verify the event date of every reported signal from page content — never trust the article's publication date alone.
+- MUST corroborate every P1 signal that is only derivative-sourced against a primary source (company blog, press release, official filing) before reporting it. No corroboration → drop it.
+- MUST dedup against per-competitor memory and surface only NEW or UPDATED signals.
+- MUST get explicit user confirmation of the competitor list before the first research run, and explicit approval before distributing a briefing anywhere.
+- NEVER include STALE or UNCERTAIN signals in a report or in memory — not as footnotes, not as "background context."
+- NEVER pad a quiet period. Better to miss a real signal than to report a stale one as new — trust is the product.

--- a/skills/alon-goldenberg/competitor-monitoring/references/briefing-format.md
+++ b/skills/alon-goldenberg/competitor-monitoring/references/briefing-format.md
@@ -1,0 +1,81 @@
+# Briefing and memory formats
+
+The two output formats (full briefing, quick refresh), the workspace memory layout that makes dedup possible, and the run-mode windowing rules that decide between them.
+
+## Run modes and date windowing
+
+Decided from the profile's last-run date, before any searching:
+
+| Last run | Mode | Search window |
+|---|---|---|
+| Never (first run) | **Full** | Past 14 days |
+| More than 14 days ago | **Full** | Past 14 days |
+| 3–14 days ago | **Quick refresh** | Since the last run date |
+| Under 3 days ago | **Quick refresh** | Past 7 days (never narrower — near-empty windows read as false quiet) |
+| Today, and today's briefing exists | **Same-day repeat** | Ask before re-running; never silently duplicate |
+
+Tune the 14-day boundary to the market's tempo — weekly for fast-moving spaces, monthly for slow ones — but keep the structure: a wide window with the full format, a narrow window with the delta format.
+
+## Full briefing format
+
+Sections in this order:
+
+1. **TL;DR** — 3–5 P1 signals, most recent first. Every line: what happened, the verified event date, a clickable source link. If there are fewer than 3 genuine P1s, list fewer — never promote a P2 to fill space.
+2. **Per competitor** (one section each):
+   - **Recent** — NEW/UPDATED signals from this run, dated and sourced, P1s first.
+   - **Older context** — 1–3 lines of standing context from memory (only what's needed to make Recent legible; this is the one place prior-run material may appear, clearly labeled as context, never as news).
+   - **Where they win vs. where you win** — a short two-column table; honest on both sides.
+   - **What this means** — 1–2 sentences of interpretation, not summary.
+3. **Industry trends** — signals from the industry-keyword searches; only what's dated and real.
+4. **Your company update** — releases and news from the own-company searches, so readers see both sides of the contrast.
+5. **Cross-competitor patterns** — moves converging across 2+ competitors (everyone shipping the same feature category, hiring the same role, chasing the same segment). This section is often the most valuable and only exists because the research ran in parallel across all of them.
+6. **What this means for [Company]** — strategic implications plus 2–4 suggested actions, each tied to a specific signal above.
+
+Tone: terse, dated, sourced. Interpretation is welcome; padding is not. P3 signals get one line or nothing.
+
+## Quick refresh format
+
+Three sections, short by design:
+
+1. **New signals** — each with competitor name, priority, event date, one-line description, clickable source URL.
+2. **Nothing new** — explicit list of competitors with no validated new signals. Naming the quiet ones is what makes the reader trust the loud ones.
+3. **Action items** — only if a signal genuinely demands attention; omit the section otherwise.
+
+A quick refresh with one new signal and five quiet competitors is a successful run. Do not decorate it.
+
+## Workspace memory layout
+
+Keep everything in a dedicated directory in your workspace (never a shared or third-party location):
+
+```
+competitive-intel/
+  profile.md               # company, competitor list (name/domain/category),
+                           # industry keywords, preferences, last-run date
+  competitors/
+    <competitor-name>.md   # one running file per competitor — the dedup baseline
+  briefings/
+    briefing-<YYYY-MM-DD>.md
+  competitive-landscape.md # synthesis page (see below)
+```
+
+### Per-competitor memory file
+
+Append one entry per validated signal (NEW and UPDATED only — STALE/UNCERTAIN must never be written, or they poison every future dedup):
+
+```
+## [EVENT_DATE] — [SIGNAL one-liner]
+- type: [news|product|funding|hiring|partnership|review]  priority: [P1|P2|P3]
+- source: [URL]  ([SOURCE_TYPE])
+- reported: [run date]
+- notes: [optional 1–2 lines: corroboration found, what it updates, implications]
+```
+
+Keep a short header block at the top of each file (domain, category, one-line positioning, standing strengths/weaknesses) and update it only when a signal genuinely changes the picture. On each run, load these files first — the entries are the known-signals list passed to research threads.
+
+### Saved briefings
+
+Save the **full briefing text** to `briefings/`, not a summary — it is the local source of truth for "what did we already tell people," and the thing you diff against when someone asks what changed.
+
+### Landscape synthesis
+
+When a run researches 3+ competitors, or competitor files have changed since the synthesis was last generated, refresh `competitive-landscape.md` from all competitor files: a market map (who plays where), a feature comparison, a pricing comparison where known, key cross-competitor patterns, and strategic implications. Keep a short backlog list at the bottom for unanswered questions (competitors with unknown pricing, unverified funding) — these seed the next run's "go deeper" follow-ups.

--- a/skills/alon-goldenberg/competitor-monitoring/references/query-patterns.md
+++ b/skills/alon-goldenberg/competitor-monitoring/references/query-patterns.md
@@ -1,0 +1,52 @@
+# Query patterns — the research fan-out
+
+How to structure the searches for each run. All of this is tool-agnostic: run these with whatever live-web search and page-extraction capability you have. Where your tool supports date filters, domain restriction, or a news focus, use them as noted; where it doesn't, put the constraint in the query text ("since [date]", "site:[domain]").
+
+## Per-competitor fan-out (five queries, run in parallel)
+
+For each competitor, run all five simultaneously. Each query hunts a different signal class — skipping one leaves a blind spot.
+
+| # | Query | What it catches | Notes |
+|---|---|---|---|
+| 1 | "[Competitor] news" — news-focused, scoped to the run's date window | Press coverage: funding, M&A, launches | The workhorse. ~10 results. |
+| 2 | "[Competitor] funding OR acquisition OR hiring" — scoped to the date window | P1 events that miss generic news queries | ~5 results. |
+| 3 | "release notes OR changelog OR what's new" — restricted to the competitor's own domain | Their changelog / release-notes page | See changelog extraction below. |
+| 4 | "[Competitor]" — restricted to x.com and linkedin.com, past week only | Real-time announcements | Social posts land days before press articles. Keep the window tight or it's all noise. |
+| 5 | "[Competitor] reviews G2 OR Capterra" | Review-site movement, positioning shifts, customer sentiment | ~5 results; usually P3. |
+
+**Changelog extraction (the highest-signal move in the fan-out).** If query 3 returns a URL that looks like the competitor's own changelog (`example.com/changelog`, `docs.example.com/release-notes`, `/whats-new`), extract that page's full content as text. It yields dated feature releases straight from the primary source — no date verification needed, no derivative-source risk. This is the cheapest primary-source signal you will get all run.
+
+**Fallback for thin results.** If queries 1–2 together return fewer than 3 results, re-run them without the date filter, then apply the date discipline manually — the filter sometimes hides original sources that recent coverage points back to.
+
+**Scope cap.** Keep each competitor to roughly 8 research actions (searches + extractions) per run. Beyond that you're deep-diving one company, which is a different job — note it as a follow-up instead of blowing the budget mid-run.
+
+## Parallelizing across competitors
+
+- One research thread per competitor; if running threads in parallel, batch them (about 4 at a time) rather than launching all at once.
+- Give each thread the competitor's name, domain, the run's date window, and the **known-signals list from that competitor's memory file** so it skips already-reported items at the source instead of returning them for you to dedup later.
+- Require each thread to return signals in the per-signal record format from the signal-validation reference — free-form prose answers can't be validated or deduped.
+
+## Own-company queries (two, run alongside)
+
+The briefing should contrast competitor moves with your own — run these on the user's company:
+
+1. "product updates OR changelog OR releases" — restricted to the company's own domain, scoped to the date window
+2. "[Company] news" — news-focused, scoped to the date window
+
+Fallback if under 3 results: search "blog" restricted to the company domain, undated.
+
+## Industry-trend queries (two, run alongside)
+
+Using the profile's industry keywords:
+
+1. "[industry keyword] AI agents OR automation" — news-focused, date-scoped
+2. "[industry keyword] regulation OR compliance OR pricing" — news-focused, date-scoped
+
+Swap the OR-terms for whatever axes actually move this market (adjust once in the profile, not per run).
+
+## Query construction tips
+
+- **Domain-restrict when the name is ambiguous.** For competitors with generic names ("Notion", "Monday", "Attio" vs "Atrio"), restrict to their domain or add the category to the query — otherwise half the results are noise.
+- **Discovery searches stay lightweight.** Use your tool's cheapest/fastest search tier for the fan-out; reserve full-content extraction for the signals that earn it under the verification budget.
+- **Date filters reduce noise but never establish truth.** A date-filtered search returns pages by *publication* date, which include fresh articles about old events. The event date always comes from the page content (see the signal-validation reference).
+- **Inline concrete dates** ("since [YYYY-MM-DD]") rather than relative language ("last two weeks") wherever a query accepts text — relative phrasing is interpreted inconsistently across tools.

--- a/skills/alon-goldenberg/competitor-monitoring/references/signal-validation.md
+++ b/skills/alon-goldenberg/competitor-monitoring/references/signal-validation.md
@@ -1,0 +1,100 @@
+# Signal validation — dates, sources, priorities
+
+The rules that decide whether a candidate finding may appear in a briefing. Apply them to every signal, every run. The core problem they solve: syndicated and recap content carries fresh publication dates on old events, and a briefing that misses this reports history as news.
+
+## Priority tiers
+
+Assign every signal exactly one priority. Priority drives the verification budget and the report's ordering.
+
+| Priority | Signal types | Why it matters |
+|---|---|---|
+| **P1** | M&A, leadership changes (C-suite/VP in or out), major funding (>$10M), a launch that competes directly with your product | Changes the competitive landscape; a rep or exec may act on it same-day |
+| **P2** | Product launches, strategic partnerships, major hiring waves, pricing changes | Shapes positioning and battlecards |
+| **P3** | Blog posts, comparison articles, minor hires, event appearances, opinion pieces, review-site movement | Context; mention briefly or omit when the report runs long |
+
+## Article date vs. event date
+
+Every signal carries two dates:
+
+| | What it is |
+|---|---|
+| **Article date** | When the page was published |
+| **Event date** | When the underlying event actually happened |
+
+A signal is "new" only if its **event date** falls inside the run's freshness window. The article date is never sufficient — syndication, regulatory recaps, and industry roundups routinely publish weeks or months after the event.
+
+### Extracting the event date from content
+
+1. **Explicit past reference** — "launched in Q3", "appointed last October" → event date is in the past, regardless of article date.
+2. **Temporal language** — "last quarter", "months ago", "earlier this year" → resolve relative to the article date.
+3. **Present-tense announcement** — "today announces", "is launching" → event date ≈ article date.
+4. **Dateline** — "NEW YORK, March 15 —" → event date = the dateline date.
+5. **Still ambiguous from the snippet** — extract the full page and read the body; check the on-page date, not the search result's date.
+
+## Source-type hierarchy
+
+When the same event appears in multiple places, classify each source and prefer the one closest to the event:
+
+1. **PRIMARY** — the company's own domain, official press release, regulatory filing
+2. **WIRE** — AP, Reuters, Bloomberg
+3. **MAJOR** — original reporting with a byline at a major outlet
+4. **DERIVATIVE** — syndicated copies, aggregators, recap articles, anything that attributes its facts to another source
+
+If the *only* source for a signal is DERIVATIVE, it cannot be reported as-is — corroborate it (below) or drop it.
+
+## Freshness classification
+
+After the event date is determined and memory has been checked:
+
+| Classification | Meaning | Action |
+|---|---|---|
+| **NEW** | Event date inside the window, not in memory | Include |
+| **UPDATED** | Known event with genuinely new information | Include, marked as an update |
+| **STALE** | Old event under a fresh article | **Drop entirely** |
+| **UNCERTAIN** | Event date can't be determined even after extracting the page | **Drop, with a one-line note if P1** |
+
+**Hard rule:** only NEW and UPDATED signals may appear in reports or be written to memory. STALE and UNCERTAIN are dropped entirely — not downgraded, not footnoted, not smuggled in as "background context." A signal that can't be verified as genuinely recent does not exist as far as the report is concerned.
+
+## Verification budget
+
+Full-page extraction costs time; spend it by priority:
+
+| Priority | Verification |
+|---|---|
+| **P1** | Always extract the page AND corroborate (below) — no exceptions |
+| **P2** | Extract when the date is uncertain or the only source is derivative |
+| **P3** | Trust a plausible date; drop if obviously stale. Never spend an extraction on a P3 |
+
+## P1 corroboration (mandatory gate)
+
+Any P1 signal that is derivative-only sourced, or whose date confidence is low, must be corroborated before it can enter the report:
+
+1. Search the live web for "[Company] [event summary]".
+2. Look for the primary source — company blog, press release, official or regulatory filing.
+3. **Primary source dates the event inside the window** → NEW, include.
+4. **Primary source dates it outside the window** → reclassify STALE, drop.
+5. **No primary source found** → reclassify UNCERTAIN, drop.
+
+Never report a P1 that fails corroboration. Better to miss a real signal than to report a stale one as new.
+
+## Per-signal record format
+
+Have every research thread return signals in this exact shape — free-form prose can't be validated, deduped, or filed to memory:
+
+```
+SIGNAL: [one-line description]
+ARTICLE_DATE: [YYYY-MM-DD or ~YYYY-MM]
+EVENT_DATE: [YYYY-MM-DD or ~YYYY-MM]
+URL: [source url]
+SOURCE_TYPE: [PRIMARY|WIRE|MAJOR|DERIVATIVE]
+DATE_CONFIDENCE: [HIGH|MEDIUM|LOW]
+NEEDS_CORROBORATION: [true|false]
+TYPE: [news|product|funding|hiring|partnership|review]
+PRIORITY: [P1|P2|P3]
+```
+
+`NEEDS_CORROBORATION` is true when: PRIORITY is P1 AND (SOURCE_TYPE is DERIVATIVE OR DATE_CONFIDENCE is LOW) AND no primary source has been found yet.
+
+## Deduplicating the same event across sources
+
+Within one run, the same event often arrives from several queries and outlets. Merge before classifying: match on the event (company + event type + approximate date), keep the highest-ranked source as the record's URL, and count the distinct sources — multi-source signals are higher confidence. Dedup against *memory* (events already reported in previous runs) happens separately and turns would-be NEW signals into UPDATED or drops them.


### PR DESCRIPTION
## What this skill does

Recurring competitor monitoring: fans out per-competitor research across news, funding/M&A/hiring, changelog, social, and review-site movement; validates every signal's event date (not article date) with a primary-source corroboration gate for high-priority signals; dedups against a running memory file per competitor; and produces a briefing containing only what is genuinely new.

Named `competitor-monitoring` because `competitor-intel` already exists in the library.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn (avatarUrl intentionally omitted per the template note — please use my LinkedIn photo)
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

- Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment (date-validation rules, dedup/windowing logic, source hierarchy) and dropping all product plumbing.
- This is the first of nine skills I'm submitting; `author.md` rides only with this PR per CONTRIBUTING — the sibling PRs will fail the validator's author.md check until this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
