### PR TITLE
add competitor-positioning

### DIFF
--- a/skills/alon-goldenberg/competitor-positioning/SKILL.md
+++ b/skills/alon-goldenberg/competitor-positioning/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: competitor-positioning
+title: Competitor positioning
+description: |
+  Use this skill when you need to know how competitors present themselves to the
+  market — homepage messaging, value props, CTAs, pricing models, content themes —
+  and how that evolves over time. Produces a marketing briefing: a messaging matrix,
+  per-competitor positioning profiles, content gap analysis, a positioning white
+  space map, and battlecard inputs, with before/after tracking of every shift.
+  Reach for it when someone says "competitor positioning", "messaging comparison",
+  "content gap", "what changed on their site", "landing page teardown", "marketing
+  battlecard", "how do they describe their product", or "counter-messaging".
+category: Positioning
+tags: [Marketing]
+---
+
+Runs when a marketing team needs to see how competitors position themselves on their own websites and content — on a recurring cadence, before a messaging refresh, or ahead of a launch.
+
+Produces a marketing briefing, not a signal feed: messaging matrix, positioning profiles, content gaps, white space, and recommended actions — every insight answering "what does this mean for our messaging?"
+
+## Pick the mode before doing anything
+
+Keep a running file per competitor in your workspace (format: `references/snapshot-format.md`). At the start of every run, load those files and check when you last ran:
+
+- **Full snapshot** — first run, or no prior snapshots, or last run more than 14 days ago. Capture everything.
+- **Delta mode** — last run within 14 days. Research the same pages, but the output reports only what changed. A delta run that re-narrates the whole landscape buries the one tagline change that matters.
+- **Same-day repeat** — already ran today? Ask before re-running; don't silently burn research effort on pages that haven't changed since the morning.
+
+If you also keep business-signal notes on these companies (funding, hiring, leadership changes), load those too — they often explain *why* positioning shifted, e.g. a funding round preceding an enterprise-messaging pivot.
+
+## Confirm scope
+
+Work from {{COMPETITOR_LIST}}. Four or fewer competitors: analyze all. More: ask which to focus on this run — group them by category and let the user pick. Every competitor costs real research time; don't spend it on companies nobody asked about.
+
+## Capture your own baseline first
+
+Before touching any competitor, capture your own positioning from {{YOUR_DOMAIN}} the exact same way you'll capture theirs — otherwise the messaging matrix has an empty row where "us" should be, and the comparison collapses into a list.
+
+1. Map the site (sitemap or crawl) to find the real features/product and pricing URLs — don't guess paths.
+2. Extract the homepage, features page, and pricing page as clean text: tagline, hero copy, primary CTA, value props, tier names.
+3. If a page won't extract, note "page not accessible" and continue — a partial baseline beats none.
+
+## Research each competitor in parallel
+
+Run one research thread per competitor, all in parallel — the protocol is identical per company and none depends on another. Give each thread the competitor's name, domain, and its previous snapshot from your workspace (or "first run — no comparison"). The full per-competitor protocol — discovery, extraction order, search queries, and the exact output sections each thread must return — is in `references/research-protocol.md`. Read it before launching.
+
+The shape: map the site structure first (what pages exist and don't exist is itself a positioning signal — no public pricing page usually means sales-led), then extract homepage / features / pricing, then find and read 2–3 recent blog posts and the case-study pages, then diff against the previous snapshot.
+
+If a thread fails outright, run its steps directly yourself rather than dropping the competitor. If its blog haul is thin (fewer than 2 posts), pull additional posts from its search results before analyzing.
+
+## Analyze for a marketing audience
+
+Frame everything in the language the team works in: messaging hierarchy, battlecard inputs, content calendar implications. When reading blog content, look for recurring narratives, audience targeting (developers vs. executives vs. practitioners), whether they name competitors or position against a category, the keywords their titles chase, and content maturity (original research vs. generic how-tos).
+
+Assemble the briefing using the exact structure in `references/briefing-formats.md` — full-snapshot layout or delta layout depending on mode. The non-negotiables:
+
+- **Verbatim quotes** for taglines, CTAs, and value props. Paraphrase destroys the evidence — "streamline your workflow" and "ship faster" are different positioning even if they feel the same.
+- **Every claim links to its source page.**
+- **Deduplicate against the snapshots.** In delta mode, surface only genuinely new changes; say "no positioning changes detected" rather than padding.
+
+## Save the snapshots
+
+After the briefing, update your workspace — this is what makes the next run a delta instead of another cold start:
+
+- Save the full briefing (not a summary) as the dated report of record.
+- Update each competitor's snapshot file per `references/snapshot-format.md`, appending a dated entry to its History section describing what changed. The History section is the before/after trail battlecards and "when did they pivot?" questions draw on.
+- Note the run date so the next run can pick its mode.
+
+## Battlecards on demand
+
+When someone asks for a battlecard on a specific competitor, build it from that competitor's snapshot plus your own baseline using the battlecard layout in `references/briefing-formats.md`. If the snapshot is missing or older than 14 days, refresh that one competitor first — a battlecard built on stale messaging gets a rep corrected in a live call. The battlecard must include a "Where they win" section written honestly; a battlecard that claims you win everywhere is one sales will stop trusting.
+
+## What good looks like
+
+- The best operator reads the site *structure* before the copy: a pricing page that disappeared, a new `/enterprise` path, a docs subdomain appearing — architecture shifts telegraph strategy quarters before the blog admits it.
+- The mediocre version is a screenshot tour: paraphrased taglines, no baseline row for your own company, no memory between runs, every run a "full snapshot" that never says what changed — and insights with no "so what" for the messaging team.
+- Output is good when the messaging matrix quotes are verbatim and sourced, delta mode reads in under two minutes because it contains only changes, each recommended action names a competitor claim and the counter-move, and a snapshot file's History section lets you reconstruct exactly when a competitor's story pivoted.
+
+## Rules
+
+- MUST use verbatim quotes for taglines, CTAs, and value props — never paraphrase quoted messaging.
+- MUST link every claim in the briefing to the source page it came from.
+- MUST capture your own baseline in every full-snapshot run before comparing.
+- MUST update the per-competitor snapshot files after every run, including a dated History entry.
+- NEVER present a guess about an inaccessible page as extracted data — write "page not accessible" and move on.
+- NEVER pad a delta report with unchanged material; "no positioning changes detected" is a valid, complete finding.
+- NEVER produce a battlecard without a "Where they win" section.
+- NEVER analyze business signals like funding, hiring, or product launches here — that's a separate research motion; this skill covers only how companies present themselves.

--- a/skills/alon-goldenberg/competitor-positioning/references/briefing-formats.md
+++ b/skills/alon-goldenberg/competitor-positioning/references/briefing-formats.md
@@ -1,0 +1,91 @@
+# Briefing and battlecard formats
+
+Three output layouts: the full-snapshot briefing, the delta briefing, and the on-demand battlecard. Pick by mode; never mix layouts.
+
+## Full-snapshot briefing
+
+Order matters — decision-makers read top-down and stop when they have enough.
+
+### 1. TL;DR for Marketing
+3–5 key positioning insights the team should act on, each with a specific implication. Not observations — implications: "Competitor X shifted tagline from developer-focused to enterprise — check whether our messaging still differentiates" beats "Competitor X changed their tagline."
+
+### 2. Messaging Matrix
+One comparison table, rows: **Tagline · Primary CTA · Value Props · Target Audience · Pricing Model**. Columns: every competitor in scope **plus your own company** (the baseline row is mandatory). Taglines and CTAs verbatim, in quotes.
+
+### 3. Per-competitor positioning profile
+For each competitor, in this order:
+- **Site structure signals** — what pages exist/don't, subdomains, what the architecture implies
+- **Homepage messaging** — tagline, hero, CTAs, value props
+- **Features page** — what they emphasize, differentiation claims
+- **Pricing positioning** — model, tier strategy, enterprise signals
+- **Content strategy** — blog themes, cadence, audience, content types
+- **Social proof strategy** — who they showcase, what outcomes they highlight
+
+### 4. Content Gap Analysis
+What competitors publish that you don't: topics they cover, formats they use (case studies, benchmarks, ROI calculators), audience segments they address in content.
+
+### 5. Positioning White Space
+Messaging angles no competitor has claimed strongly: unclaimed value props, underserved audience segments, narrative gaps. This section is only credible if section 3 was thorough — white space is an absence claim, and absence claims require having actually looked.
+
+### 6. Recommended Actions
+Specific next steps for the marketing team, each naming a competitor claim and the counter-move: "Draft counter-messaging for X's new enterprise positioning", "Prioritize case studies targeting [segment] — 3 competitors already own this space."
+
+## Delta briefing (changes only)
+
+### 1. What Changed
+Per competitor, before/after per shift:
+- "Tagline: '[old]' → '[new]'"
+- "New feature category added: [name]"
+- "Pricing model shifted from [old] to [new]"
+- "New blog theme emerging: [topic] ([N] posts in the window)"
+- "Page added/removed: [url] — [significance]"
+
+### 2. Nothing Changed
+Explicitly list competitors with no positioning shifts. An empty "what changed" without this list reads as a failed run, not a quiet fortnight.
+
+### 3. Marketing Implications
+What the changes mean for the team's priorities. If nothing changed anywhere: "no positioning changes detected" and stop — never pad.
+
+## Battlecard
+
+Built from one competitor's snapshot plus your own baseline. Refresh the snapshot first if it's older than 14 days.
+
+```markdown
+# Battlecard: [Your Company] vs [Competitor]
+## As of [date]
+
+### Competitor Overview
+- Tagline: [verbatim]
+- Primary CTA: [verbatim]
+- Target audience: [who their messaging speaks to]
+- Pricing model: [type and entry price if known]
+
+### Their Key Claims
+[Each value prop / differentiator they emphasize, verbatim, with source URL]
+
+### Our Counter-Positioning
+[For each claim above: the response, proof points, and messaging angle]
+
+### Feature Comparison
+| Capability | Us | Them | Advantage |
+|---|---|---|---|
+
+### Where They Win (acknowledge honestly)
+[Where their positioning is stronger or they have genuine advantages]
+
+### Where We Win
+[Unique advantages, with evidence]
+
+### Objection Handling
+| Prospect Says | Respond With |
+|---|---|
+
+### Recommended Talking Points
+[3–5 concise talking points for sales/marketing conversations]
+```
+
+## Cross-cutting rules
+
+- Every claim in every layout links to its source page.
+- Verbatim quotes for taglines, CTAs, value props, and differentiation claims.
+- Tone: decisive and operational — written for a team planning next quarter's messaging, not an archive. Every insight carries its "so what."

--- a/skills/alon-goldenberg/competitor-positioning/references/research-protocol.md
+++ b/skills/alon-goldenberg/competitor-positioning/references/research-protocol.md
@@ -1,0 +1,79 @@
+# Per-competitor research protocol
+
+Run this protocol once per competitor, in parallel threads when researching several. Each thread gets: the competitor's name, its domain, and its previous positioning snapshot (or "first run — no comparison available"). Budget roughly a dozen research calls per competitor — favor extraction quality over quantity.
+
+## Phase 0 — Site discovery (always first)
+
+Map the site's actual structure (sitemap fetch or shallow crawl, up to ~200 URLs) before extracting anything. Guessed paths 404; discovered paths don't.
+
+From the URL list, identify:
+
+- **Homepage** — always extract.
+- **Features/product page** — paths containing `/features`, `/product`, `/platform`, `/solutions`, `/why-us`, `/capabilities`. Pick the single most relevant.
+- **Pricing page** — `/pricing`, `/plans`, `/get-started`.
+- **Blog index** — `/blog`, `/resources`, `/content`, `/insights`.
+- **Case studies** — `/case-study`, `/customers`, `/stories`.
+
+Record which pages exist and which don't. Absences are positioning signals in their own right: no public pricing page suggests enterprise/sales-led motion; no blog suggests the company isn't competing on content. Note notable subdomains too (`docs.`, `api.`, `community.`) — a docs subdomain signals a developer audience regardless of what the homepage claims.
+
+If the site blocks sitemap/crawl access, fall back to extracting the homepage directly and trying the common paths above by hand.
+
+## Phase 1 — Page extraction (run simultaneously)
+
+Extract each discovered page as clean text/markdown:
+
+1. **Homepage** → hero copy, tagline, primary CTA, value propositions, top-level nav structure.
+2. **Features page** → feature categories, branded feature names, emphasis, explicit differentiation claims ("unlike X", "the only platform that…"). Skip if none found.
+3. **Pricing page** → tier names, pricing model, entry price, feature gating, target audience per tier. Skip if none found.
+
+If an extraction returns garbage, retry once; if still empty, record "page not accessible" and continue.
+
+## Phase 2 — Blog and content (run simultaneously)
+
+Three searches:
+
+1. Search within the competitor's domain for its blog index and recent posts (~10 results).
+2. Search the live web for the competitor's name plus blog/content/resources terms, windowed to the period since the last run (~10 results). Verify actual publish dates from the extracted content — search-result dates lie.
+3. Search within the competitor's domain for case studies, customer stories, and testimonials (~5 results).
+
+Some companies don't blog. Record "no active blog detected" and lean on page-based positioning instead — don't invent content themes from nothing.
+
+## Phase 3 — Deep extraction (if posts found)
+
+Extract the 2–3 most recent blog posts in full for theme analysis: what story does this company tell repeatedly, who is it aimed at, do they name competitors or position against a category, what keywords do titles and headings chase.
+
+## Output — return exactly these sections
+
+**SITE STRUCTURE**
+- Pages found / pages missing (with the implication of each absence)
+- Subdomains
+- Structure signals — what the architecture reveals about positioning
+
+**HOMEPAGE POSITIONING**
+- Tagline (exact text) · Hero message · Primary CTA (button text + implied action)
+- Value props, each verbatim
+- Navigation structure (top-level items — what they choose to emphasize)
+- Target audience signals (who the copy speaks to)
+
+**FEATURES PAGE**
+- Page URL · Key feature categories · Differentiation claims · Branded feature names
+- Missing/notable — conspicuously absent or prominently highlighted capabilities
+- (No features page → write "No public features page — [implication]")
+
+**PRICING PAGE**
+- Page URL · Model (per-seat / usage / flat / freemium / custom) · Tier names
+- Entry price if visible · Enterprise signal ("contact sales", custom tier) · Feature gating
+- (No pricing page → write "No public pricing — likely enterprise/sales-led")
+
+**BLOG & CONTENT**
+- Last 5–10 posts with titles and dates · Primary recurring themes
+- Content types (blog, case study, whitepaper, webinar) · Publishing cadence estimate
+- Audience focus (developer / executive / practitioner)
+
+**SOCIAL PROOF**
+- Customer logos/names if public · Testimonial themes (what customers praise)
+- Case study focus (industries, use cases, outcomes highlighted)
+
+**CHANGES FROM PREVIOUS SNAPSHOT**
+- Specific diffs only: "Tagline changed from '[old]' to '[new]'", "New feature category added: [name]", "Pricing model shifted from [old] to [new]", "New blog theme emerging: [topic]", "Page added/removed: [url] — [significance]"
+- First run → "First run — no comparison available"

--- a/skills/alon-goldenberg/competitor-positioning/references/snapshot-format.md
+++ b/skills/alon-goldenberg/competitor-positioning/references/snapshot-format.md
@@ -1,0 +1,60 @@
+# Positioning snapshot format
+
+Keep one file per competitor in your workspace, named for the competitor. This structured format is what makes delta detection work — every field is diffable against the next run. Update the file after every run; never overwrite the History section.
+
+```markdown
+# [Competitor Name]
+## Last Updated: [YYYY-MM-DD]
+
+## Site Structure
+- Key Pages: [URLs for features, pricing, blog, docs, etc.]
+- Missing Pages: [notable absences — e.g., "no public pricing", "no blog"]
+- Subdomains: [docs., api., community., etc.]
+
+## Homepage
+- Source: [homepage URL]
+- Tagline: [exact text]
+- Hero Message: [exact text]
+- Primary CTA: [button text]
+- Value Props: [each, verbatim]
+- Target Audience: [who the copy speaks to]
+- Navigation Structure: [top-level nav items]
+
+## Features
+- Source: [features page URL]
+- Key Categories: [list]
+- Differentiation Claims: [list, verbatim]
+- Notable Features: [branded names, flagship features]
+
+## Pricing
+- Source: [pricing page URL]
+- Model: [per-seat / usage / flat / freemium / custom]
+- Tiers: [list, with prices if visible]
+- Enterprise Signal: [yes/no, details]
+- Feature Gating: [what's locked to higher tiers]
+
+## Content Strategy
+- Sources: [blog/resource URLs analyzed]
+- Blog Cadence: [weekly / biweekly / monthly / sporadic]
+- Primary Themes: [list]
+- Content Types: [blog, case study, whitepaper, webinar, etc.]
+- Audience Focus: [developer, executive, practitioner, etc.]
+
+## Social Proof
+- Sources: [customer/case-study URLs]
+- Key Customers: [names if public]
+- Testimonial Themes: [what customers praise]
+- Case Study Focus: [industries, use cases highlighted]
+
+## History
+### [YYYY-MM-DD]
+- [change — e.g., "Tagline changed from 'X' to 'Y'"]
+- [change]
+```
+
+## Maintenance rules
+
+- **Top sections reflect current state; History is append-only.** On each run, update the current-state sections to what's live now, then add a dated History entry describing every diff you made. The History trail is how "when did they pivot to enterprise?" gets answered months later.
+- **Verbatim or nothing.** Taglines, CTAs, value props, and differentiation claims are stored as exact text. If a page was inaccessible this run, keep the prior value and note "not re-verified [date]" rather than blanking it.
+- **A run with no changes still gets a History entry** ("[date] — no changes detected") so cadence gaps are distinguishable from missed runs.
+- **Cross-link, don't merge.** If you keep separate business-signal notes on the same company (funding, hiring), reference that file from here — positioning shifts and business events explain each other, but the files serve different plays.


### PR DESCRIPTION
## What this skill does

Tracks how competitors present themselves — homepage messaging, value props, CTAs, pricing models, content themes — with per-competitor snapshots and before/after delta tracking. Produces a messaging matrix, positioning white-space map, content gap read, and honest battlecard inputs (including a mandatory "Where they win" section).

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
