### PR TITLE
add company-deep-dive

### DIFF
--- a/skills/alon-goldenberg/company-deep-dive/SKILL.md
+++ b/skills/alon-goldenberg/company-deep-dive/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: company-deep-dive
+title: Company deep dive
+description: |
+  Use this skill when the ask is about one specific company: "tell me about
+  [company]", "research [company]", "what does [company] do", "who is
+  [company]", "look up [company]", "company deep dive", "due diligence on
+  [company]", "background on [company]", "dig into [company]", "analyze
+  [company]" — or when evaluating a company as a sales target, partner, or
+  investment. Research the live web instead of answering from memory: funding,
+  leadership changes, and product launches move faster than any knowledge base,
+  so run it even for well-known companies. Produces a sourced 360-degree
+  report covering funding, leadership, product and technology, market position,
+  news, and strategic outlook — with a date and URL on every claim.
+category: Research
+tags: [Sales]
+---
+
+Runs when someone needs real, current intelligence on one specific company — not a vibe from stale general knowledge.
+
+Produces a 360-degree company report: quick assessment up top, then funding, leadership, product, market position, and news, closed by a strategic outlook — every factual claim carrying a date and a source URL.
+
+## Scope the run
+
+Three decisions before any research:
+
+1. **Which company, exactly.** If the name is unambiguous ("research Stripe"), run two quick web searches — `"[Company] official site"` and `"[Company] company overview"` — to lock the legal name and primary domain, and confirm in one line: "Researching **[Company]** ([domain])". If the name collides ("research Mercury" — bank? auto brand?), ask one clarifying question with the top candidates. If no company was named, ask which one.
+2. **Full or quick.** Default to the full deep dive. If the ask says "quick overview", "brief", or "summary", run quick mode: search-snippet research only, skip the deep-extraction step, produce a shorter report.
+3. **First run or refresh.** Keep a running file per company in your workspace (format in `references/company-memory.md`). If a file for this company exists, load it and run in **refresh mode**: tell the reader "I have prior research on [Company] from [date] — refreshing with what's new", pass the known facts into every research thread so they hunt only for new signals, and lead the report with a "What's new since [date]" section. No file → full mode across all dimensions.
+
+## The play
+
+### 1. Research five dimensions in parallel
+
+Fan out one research thread per dimension — run them concurrently, not sequentially; a deep dive is five narrow investigations, not one broad search:
+
+| Dimension | Hunting for |
+|---|---|
+| **Funding & financials** | Rounds, total raised, valuation, revenue signals, investors, IPO chatter |
+| **Product & technology** | Core products, launches, tech-stack signals, engineering blog, open source |
+| **Leadership & team** | Founders, C-suite, key hires and departures, headcount, culture signals, executive interviews |
+| **News & events** | Press coverage, partnerships, acquisitions, awards, conferences, social chatter |
+| **Market position** | Competitors, market share, analyst coverage, customer reviews, case studies |
+
+The per-dimension query patterns — including which queries to date-filter, which to run against the company's own domain, and which review and analyst sources to target — are in `references/dimension-queries.md`. Read it before fanning out.
+
+Two searches run outside the fan-out, first, to frame everything: an "about" search restricted to the company's own domain, and a search for the company's profile on the major business registries (Wikipedia, Crunchbase, Pitchbook). These give founding date, HQ, headcount, and mission — the skeleton the dimensional findings hang on.
+
+Every finding comes back as a structured signal — description, article date, event date, source URL, source type — not prose. The distinction between when a page was published and when the event actually happened is where most research goes wrong; the dating rules, source-quality hierarchy, and the drop rules for stale or unverifiable signals are in `references/signal-dating.md`. Read it before recording the first signal.
+
+If a research thread fails or comes back empty, rerun its queries directly — never leave a dimension blank without trying twice.
+
+### 2. Extract the pages that matter
+
+From all findings, pick the **5–8 most informative URLs** and extract each full page (in parallel). Prioritize, in order: funding announcements with specific amounts; official product or feature pages; executive interviews, podcasts, or conference talks; in-depth analyst or journalist profiles; the company's own about/team page. Full pages yield the numbers, direct quotes, and context that snippets flatten.
+
+Quick mode skips this step entirely and reports from snippets.
+
+### 3. Synthesize the report
+
+Assemble the 360-degree report — exact section order, per-section content rules, and the refresh-mode variant are in `references/report-format.md`. The non-negotiables:
+
+- Lead with a 2–3 sentence **Quick Assessment** — what the company is, where it stands, the one thing that matters most right now. Most readers stop there; make it earn the stop.
+- Every claim dated and sourced. A dimension with nothing found says "no public data found" — never speculation dressed as findings.
+- Confirmed facts and inferred signals are labeled differently.
+- Direct executive quotes (from interviews, earnings calls, talks) beat paraphrase wherever found.
+
+### 4. Update memory and offer next steps
+
+Write the full report to your workspace, and update (or create) the company's running memory file: structured key facts plus dated signal entries, so the next run dedups against it instead of re-reporting old news. Format and dedup rules in `references/company-memory.md`.
+
+Then offer the natural follow-ups: go deeper on one dimension, compare side-by-side with another company, set the company up for ongoing tracking over time, or research the specific people ahead of a meeting.
+
+## What this is not
+
+- **Not multi-company monitoring.** This goes deep on ONE company; tracking a set of competitors over time is a different, recurring motion.
+- **Not people research.** It profiles companies, not the individuals attending your next meeting.
+- **Not investment advice.** It is intelligence gathering from public sources — say so if asked.
+- **Not live monitoring.** The report is point-in-time; rerun it (in refresh mode) when currency matters.
+
+## What good looks like
+
+- The best operators check the **event date, not the article date**, before calling anything new — a syndicated recap published this week about a funding round from last year is the single most common way a "fresh" report embarrasses its author.
+- The second tell: single-sourcing a big claim from an aggregator. Funding amounts, M&A, and leadership changes get corroborated against a primary or wire source before they appear — every time.
+- The mediocre version is a Wikipedia-shaped summary: undated claims, no URLs, "recent developments" that are neither, dimensions padded with speculation where the search came up empty, and a refresh that re-reports everything already known instead of only what changed.
+- Good output test: a reader can click through any claim to its source, the Quick Assessment could stand alone as a briefing, and a refresh run reads like a changelog — short, dated, only genuinely new or updated signals.
+
+## Rules
+
+- MUST research the live web — never answer about a specific company purely from prior general knowledge, however famous the company.
+- MUST attach a date and source URL to every factual claim in the report.
+- MUST corroborate funding, M&A, and leadership-change claims sourced from derivative or aggregator sites against a primary or major source before reporting them (see `references/signal-dating.md`).
+- MUST write "no public data found" for an empty dimension — NEVER fill the gap with speculation.
+- MUST dedup against the company's memory file in refresh mode and surface only NEW or UPDATED signals.
+- NEVER include a signal whose event date cannot be established — dropped means dropped, not footnoted as "background".
+- NEVER present an estimate or inference with the same confidence as a confirmed fact — label which is which.

--- a/skills/alon-goldenberg/company-deep-dive/references/company-memory.md
+++ b/skills/alon-goldenberg/company-deep-dive/references/company-memory.md
@@ -1,0 +1,53 @@
+# Company memory and differential analysis
+
+Keep one running file per researched company in your workspace (e.g. `memory/companies/[company-slug].md`), plus the full timestamped report per run (e.g. `memory/reports/company-deep-dive-[company-slug]-[YYYY-MM-DD].md`). The memory file is what makes the second run on a company worth more than the first: it turns a repeat deep dive into a changelog.
+
+## Company profile format
+
+Structured key facts up top, dated signal entries below — newest first:
+
+```markdown
+# Target Corp
+
+## Overview
+- Industry: Enterprise SaaS | Founded: 2015 | HQ: Austin, TX | ~500 employees
+- Domain: targetcorp.com
+- Last researched: [date of most recent run]
+
+## Financials
+- Last funding: Series B ($30M, Sep 2025) | Revenue: est. $40M ARR (inferred)
+
+## Leadership
+- CEO: [name] | Notable: [key hires/departures with dates]
+
+## Products
+- [core products, one line each]
+
+## Signals
+### [YYYY-MM-DD]
+- [signal] — [source URL]
+### [YYYY-MM-DD]
+- [signal] — [source URL]
+```
+
+Keep cross-references to related entities you also track — key people, competitors in the same space — so adjacent research can load the connected context.
+
+## Dedup lifecycle
+
+Memory is loaded at two points in every run:
+
+1. **Before research:** load the company's file and pass its known facts to every dimension thread, so threads hunt only for what is not already known.
+2. **Before writing the report:** final dedup pass — compare every finding against memory. Only signals classified NEW or UPDATED (per the freshness rules in the signal-dating reference) make it into the report.
+
+## What "new" means
+
+- "Raised a Series C" is **noise** if it is already in memory.
+- "Just hired a new CTO" is a **new** signal worth surfacing.
+- "Raised a Series C" with a detail memory lacks (amount, lead investor) is an **update** — surface only the new detail.
+
+## After each run
+
+- Append the run's NEW/UPDATED signals to the profile's Signals section (dated).
+- Update the structured key facts where they changed (headcount, last funding, leadership).
+- Save the complete report — the full text, not a summary — to the reports location.
+- When the reader corrects a fact ("that ARR figure is wrong"), fix the memory file immediately and confirm the correction — memory errors compound across every future run.

--- a/skills/alon-goldenberg/company-deep-dive/references/dimension-queries.md
+++ b/skills/alon-goldenberg/company-deep-dive/references/dimension-queries.md
@@ -1,0 +1,77 @@
+# Dimension query patterns
+
+One block per research dimension. Each thread runs its queries in parallel, keeps scope tight (roughly 4–5 searches per dimension), and returns findings as structured signals in this exact shape — one per signal, no commentary:
+
+```
+SIGNAL: [one-line description]
+ARTICLE_DATE: [YYYY-MM-DD or ~YYYY-MM]
+EVENT_DATE: [YYYY-MM-DD or ~YYYY-MM]
+URL: [source url]
+SOURCE_TYPE: [PRIMARY | MAJOR | DERIVATIVE]
+TYPE: [one of the dimension's signal types below]
+```
+
+Dating and source-type rules live in the signal-dating reference — apply them to every signal.
+
+**Shared conventions across all dimensions:**
+
+- `[start-date]` = the freshness window. Full mode: 12–18 months back for news-type queries. Refresh mode: the date of the last report.
+- Date-filter only the queries marked *(dated)* — evergreen facts (investors, competitors, tech stack) live on old pages, and a date filter hides them.
+- If the first two queries of a dimension return fewer than 3 results combined, rerun them without the date filter before concluding the dimension is thin.
+- In refresh mode, each thread receives the known facts from company memory and skips re-reporting them — it hunts only for what is new or changed.
+
+## Funding & financials
+
+Signal types: `funding | revenue | valuation | investor | ipo`
+
+1. `[Company] funding OR Series OR raised` — news sources *(dated)*
+2. `[Company] revenue OR valuation OR ARR`
+3. `[Company] investors OR venture capital`
+4. `[Company] Crunchbase OR Pitchbook funding`
+
+## Product & technology
+
+Signal types: `product | feature | tech-stack | open-source | engineering`
+
+1. `product OR features OR platform` — restricted to the company's own domain
+2. `[Company] product launch OR new feature OR release` — news sources *(dated)*
+3. `[Company] tech stack OR engineering OR architecture`
+4. `[Company] open source OR GitHub`
+5. `blog engineering OR tech` — restricted to the company's own domain
+
+## Leadership & team
+
+Signal types: `leadership | hire | departure | culture | team-size | executive-quote`
+
+1. `[Company] CEO OR founder OR leadership`
+2. `[Company] hired OR appointment OR CTO OR VP` — news sources *(dated)*
+3. `[Company] employees OR team size OR culture OR glassdoor`
+4. `[Company] CEO OR founder interview OR podcast OR keynote` — the richest source of direct quotes; mine these for the report
+5. `[Company]` — restricted to LinkedIn
+
+## News & events
+
+Signal types: `news | partnership | acquisition | award | event | social`
+
+1. `[Company] news` — news sources *(dated)*
+2. `[Company] partnership OR acquisition OR expansion` — news sources *(dated)*
+3. `[Company] conference OR award OR recognition` *(dated)*
+4. `[Company]` — restricted to X/Twitter, last week only (social chatter is only useful fresh)
+5. `[Company] announcement OR press release` — news sources *(dated)*
+
+## Market position
+
+Signal types: `competitor | market-share | review | analyst | customer`
+
+1. `[Company] competitors OR alternatives OR vs`
+2. `[Company] market share OR market position OR industry leader`
+3. `[Company] reviews` — restricted to review sites (G2, Capterra, TrustRadius)
+4. `[Company] analyst report OR Gartner OR Forrester`
+5. `[Company] customers OR case study OR testimonial`
+
+## Framing searches (run before the fan-out)
+
+Not a dimension — two searches that give every thread its skeleton:
+
+1. `about` — restricted to the company's own domain (mission, founding, self-description)
+2. `[Company] Wikipedia OR Crunchbase OR Pitchbook` (founding year, HQ, headcount, category)

--- a/skills/alon-goldenberg/company-deep-dive/references/report-format.md
+++ b/skills/alon-goldenberg/company-deep-dive/references/report-format.md
@@ -1,0 +1,68 @@
+# 360-degree report format
+
+The report structure, section by section, in order. Sections are mandatory; an empty one says "No public data found" rather than disappearing or filling with speculation.
+
+```
+# [Company Name] — Deep Dive
+*As of [today's date]*
+
+## Quick Assessment
+[2–3 sentence verdict: what this company is, where they stand, and the one
+thing that matters most right now. The "if you read nothing else" paragraph.]
+
+## Company Overview
+- Founded: [year] | HQ: [location] | Employees: [estimate]
+- Domain: [domain] | Industry: [industry]
+- Mission/focus: [one line]
+
+## Funding & Financials
+[Latest round, total raised, key investors, valuation signals, revenue
+indicators. Every claim dated and sourced.]
+
+## Leadership & Team
+[Founders, C-suite, notable hires and departures. Executive perspectives on
+company direction — direct quotes when available from interviews or talks.]
+
+## Product & Technology
+[Core products, launches, tech-stack signals, engineering culture, open-source
+work. What they're building and how.]
+
+## Market Position
+[Key competitors, differentiation, market-share signals, analyst perspectives,
+customer sentiment from reviews (G2 / Capterra / Reddit).]
+
+## Recent News & Events
+[Chronological, most recent first. Each entry dated with source.]
+
+## Strategic Outlook
+[Synthesis across all dimensions: where the company is heading, key risks,
+growth signals, strategic bets. This is insight, not summary.]
+
+## Sources
+[Numbered list of every URL cited in the report]
+```
+
+## Writing rules
+
+- **Every factual claim carries a date and a source URL** (cite by number into the Sources list).
+- **Lead with the Quick Assessment** — most readers stop there. It should carry an actual verdict, not a restated overview.
+- **Confirmed vs inferred:** label the difference explicitly. "Raised $30M Series B (announced [date], [source])" is confirmed; "revenue likely in the $30–50M range based on headcount and pricing" is inferred — say so.
+- **Executive quotes add credibility.** When an interview, earnings call, or conference talk yields a direct quote about direction, use the quote, attributed and dated.
+- **Strategic Outlook is the analysis section** — connect the dimensions (e.g., a funding round plus a hiring spree in one function plus a product pivot = a readable strategic bet). It must not repeat facts already stated above; it interprets them.
+- **News entries are strictly reverse-chronological** by event date.
+
+## Refresh-mode variant
+
+When prior research exists, prepend one section before Company Overview:
+
+```
+## What's New Since [last report date]
+[Only NEW and UPDATED signals, dated, one bullet each, most significant first.
+If nothing material changed, say exactly that in one line.]
+```
+
+The rest of the report follows in full, updated where signals changed. The "What's New" section is the payoff of keeping memory — a reader who saw the last report reads only this section.
+
+## Quick-mode variant
+
+Same skeleton, but built from search snippets only (no full-page extraction): shorter sections, no executive quotes unless a snippet contained one, and the Strategic Outlook trimmed to 2–3 sentences. Still fully dated and sourced — quick mode shortens the report, never the honesty.

--- a/skills/alon-goldenberg/company-deep-dive/references/signal-dating.md
+++ b/skills/alon-goldenberg/company-deep-dive/references/signal-dating.md
@@ -1,0 +1,64 @@
+# Signal dating, source hierarchy, and verification
+
+High-quality intelligence requires distinguishing between when a **page was published** and when the **underlying event occurred**. Syndicated and republished content carries a different publication date than the original; secondary coverage (regulatory filings, recap articles, industry roundups) reports on events weeks or months after they happened. Treating article dates as event dates is how a report calls a year-old funding round "news".
+
+## Article date vs event date
+
+Every signal carries two dates:
+
+| | What it is |
+|---|---|
+| **Article date** | When the page was published |
+| **Event date** | When the underlying event actually happened |
+
+A signal is "new" only if its **event date** falls within the freshness window.
+
+## Event-date extraction rules
+
+Determine the event date from the content itself, in this order:
+
+1. **Explicit past reference** — "launched in Q3", "appointed last October" → the event date is in the past, regardless of the article date.
+2. **Temporal language** — "last quarter", "months ago", "earlier this year" → resolve relative to the article date.
+3. **Present-tense announcement** — "today announces", "is launching" → event date ≈ article date.
+4. **Dateline** — "NEW YORK, March 15 —" → event date = the dateline date.
+5. **Still ambiguous** → extract the source page and check the on-page date.
+
+Date filters on search queries reduce noise, but they filter by article date — always validate the event date from content. For news queries, consider a parallel undated query to surface the original source alongside the fresh coverage.
+
+## Source-type hierarchy
+
+When the same event appears in multiple sources, prefer the one closest to the event:
+
+1. **PRIMARY** — the company's own domain, official press release, regulatory filing
+2. **Wire service** — AP, Reuters, Bloomberg (record as MAJOR)
+3. **MAJOR** — original reporting with bylines at a major outlet
+4. **DERIVATIVE** — syndicated copies, aggregator sites, recap articles, anything that attributes its information to another source
+
+If the only source for a signal is derivative, corroborate against a primary or major source before reporting it.
+
+## Freshness classification
+
+After determining the event date, classify each signal:
+
+| Classification | Meaning | Action |
+|---|---|---|
+| **NEW** | Event date within the freshness window, not in company memory | Include in report |
+| **UPDATED** | Known event with genuinely new information (amount, lead investor, a named exec) | Include as an update |
+| **STALE** | Old event covered by a fresh article | **DROP — do not include** |
+| **UNCERTAIN** | Event date undeterminable from the snippet | Extract the page to verify; still uncertain → **DROP** |
+
+**Hard rule:** only NEW and UPDATED signals may appear in reports. STALE and UNCERTAIN signals are dropped entirely — not downgraded, not footnoted, not kept as "background context". If a signal can't be verified as genuinely current, it doesn't exist as far as the report is concerned.
+
+## Verification budget
+
+Not every signal deserves a full-page extraction. Budget verification by impact:
+
+| Priority | Signal types | Verification |
+|---|---|---|
+| **P1** (high impact) | Funding, M&A, leadership changes | Always extract the page AND corroborate |
+| **P2** (medium impact) | Product launches, partnerships, major hires | Extract if the date is UNCERTAIN or the source is DERIVATIVE |
+| **P3** (low impact) | Blog posts, minor hires, event appearances | Trust a plausible date; drop if obviously stale |
+
+## P1 corroboration (mandatory)
+
+Any P1 signal sourced from a derivative or aggregator site **must** be corroborated before it appears in a report. This is a hard gate, not a suggestion. Run a fresh search on `[Company] [event summary]`, and accept the signal only when a PRIMARY or MAJOR source confirms it. If corroboration fails, the signal is UNCERTAIN — drop it.


### PR DESCRIPTION
## What this skill does

A 360-degree single-company research play: five research dimensions in parallel (funding, product, leadership, news, market position), full-page extraction of the most informative sources, event-date-vs-article-date validation with primary-source corroboration for big claims, and a running per-company memory so refreshes report only what changed.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
