### PR TITLE
add meeting-prep

### DIFF
--- a/skills/alon-goldenberg/meeting-prep/SKILL.md
+++ b/skills/alon-goldenberg/meeting-prep/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: meeting-prep
+title: Meeting prep
+description: |
+  Use this skill when a meeting is coming up and you need to know who is in the
+  room before you walk in. Produces a meeting briefing: each attendee's role,
+  background, and recent public activity with conversation hooks, a
+  cross-attendee relationship map, company context, specific talking points,
+  watch-outs, and — for sales, partnership, and investor meetings — value
+  positioning grounded in research. Triggers: "prepare me for my meeting",
+  "who am I meeting with", "research this person", "meeting prep", "brief me
+  on this person", "I have a meeting with this company", "get me ready for my
+  call", "what should I know about them", "background on someone before our
+  meeting", "attendee research".
+category: Sales
+tags: [Sales]
+---
+
+# Meeting prep
+
+Runs before any meeting where you'd benefit from knowing the people across the table better than they expect. Produces one briefing per meeting: who the attendees are, what they've been saying publicly, how they connect to each other, what's happening at their company, and exactly what to bring up — never a generic dossier.
+
+## The play
+
+### 1. Pin down the meeting
+
+Extract from the request (or ask): attendee names, company, meeting date, and any context the user volunteers ("they're evaluating us", "board intro"). If a calendar is connected, offer to pull today's meetings so the user can pick one; if not, skip silently. If only a name is given, proceed and infer the company from research.
+
+Then establish the **meeting type**, because it gates the whole briefing shape:
+
+| Signal in the request | Type |
+|---|---|
+| "prospect", "demo", "sales call" | Sales / discovery |
+| "interview", "candidate" | Interview |
+| "board", "investor" | Board / investor |
+| "partner", "integration" | Partnership |
+| "check-in", "sync", "1:1" with a colleague | Internal |
+| No signal | **Ask — don't guess** |
+
+The type decides whether the Value Positioning section is produced: yes for sales/discovery, partnership, and board/investor; no for interview, internal, and general external. That's worth one clarifying question when there's no signal.
+
+### 2. Load what you already know
+
+Keep a running file per person and per company in your workspace (e.g. `people/alex-kim.md`, `companies/widgetco.md`). Before searching:
+
+- Person file updated **within 24 hours** → offer to reuse it: "I have a fresh profile on this person — use it, or refresh?" (Meeting prep is per-meeting, not per-day — never refuse a second prep in one day.)
+- Person file **under 30 days old** → load it as known context and research only what's new since. Pass the known facts into the research so it doesn't re-report them.
+- **Over 30 days old** or missing → full refresh.
+
+Follow cross-references between files: if an attendee's file links to a company or competitor you've researched before, load that too — prior meeting notes and tracked-competitor intel are the highest-value content a briefing can carry.
+
+### 3. Research each attendee, in parallel
+
+One research thread per attendee, run concurrently. Read `references/attendee-research.md` for the full query fan-out (two groups of searches), name-disambiguation rules, page-extraction limits, and the exact profile format each thread must return. For a single attendee, just run the searches directly — no fan-out overhead. If any thread fails or comes back empty, rerun its searches yourself; never leave a gap in the briefing.
+
+While threads run, have them flag overlaps for the relationship map: shared past employers, schools, boards, communities. "My attendee worked at that company 2019–2022 — did yours overlap?" is the question that produces relationship maps worth reading.
+
+### 4. Gap check — no "Role Unknown"
+
+Every attendee needs at least a confirmed title and company before you write anything. For anyone thin (fewer than 3 meaningful results):
+
+1. Search the people indices of social platforms for "[Name] [Company]" — the most reliable way to find someone.
+2. Restrict a web search for the bare name to linkedin.com.
+3. If you have their email, search "[first] [last] [email-domain]" — the email domain disambiguates common names far better than the name alone.
+4. Try name variations: first + last only, full name + title if known.
+
+If still nothing, say so honestly in the briefing: "Limited public presence — could not confirm role. Consider asking for their LinkedIn URL." Never speculate. Collect each attendee's LinkedIn URL along the way — readers want the link.
+
+### 5. Company context
+
+Lighter than a full company deep-dive — only what's useful in this conversation. Run in parallel: company news from the last two weeks; product launches and announcements; the about page on their own domain; funding history; and a search pairing their company with yours, which catches prior partnerships, shared investors, or competitive overlap. Fewer than 3 news results → retry without the date window.
+
+Two craft points: wrap multi-word company names in quotes (or anchor to their domain) so "Acme Supply" doesn't drown in noise; and validate **event dates, not article dates** — a snippet saying "last year" or "back in Q3" is background context, never "recent news". If a company file already exists in your workspace, load it and run only the fresh-news search.
+
+### 6. Value positioning (sales, partnership, board/investor only)
+
+Read `references/value-positioning.md`. Cross-reference what you learned about their company against your own sales context — differentiators, integrations, case studies, tracked competitors — to produce value mappings, integration hooks, and a positioning paragraph calibrated to this specific meeting. Skip entirely for interview, internal, and general meetings.
+
+### 7. Deep-read the top sources
+
+Pick the 3–5 most informative URLs across everything found and extract the full pages. Priority order: the attendee's own posts, articles, or talks; recent company announcements relevant to the meeting; interviews or profiles of the attendee; the company team page if a title is still unconfirmed; and, when positioning is active, pages revealing their stack or challenges. Multiple attendees → person URLs beat company URLs.
+
+### 8. Write the briefing
+
+Follow `references/briefing-format.md` — section order, per-type adaptations, and sourcing rules. Lead with the Quick Take; most readers stop there.
+
+### 9. Save and offer to share
+
+Update the per-person and per-company files with structured facts (role, background, interests, communication style) and cross-references both ways, so the next prep starts warm. Save the briefing itself. Then offer to place it wherever the user works — a doc, a channel — keeping source links intact. Offer; don't push it anywhere without a yes.
+
+## What good looks like
+
+- The best operators mine **continuity first**: open items and preferences from prior meetings, then the attendee's own words — a direct quote from a post or talk is worth ten biography lines as a conversation hook.
+- The mediocre version: generic talking points ("ask about their priorities"), a guessed title, year-old news presented as recent, and positioning advice that could apply to any company on earth.
+- You know it's good when the Quick Take alone would carry the meeting; every talking point names something specific ("ask about the migration they announced last month"); every external claim carries a source URL; and gaps are stated plainly instead of papered over.
+
+## Rules
+
+- MUST source every factual claim about an external person or company with a URL. Claims drawn from your own sales-context notes are attributed to those notes.
+- NEVER speculate about a person's role or background — write "no public information found" and suggest asking for their profile link.
+- NEVER present an old event as recent news; check the event date, not the article date.
+- MUST skip the Value Positioning section for interview, internal, and general external meetings.
+- NEVER write a generic value mapping — every mapping pairs a specific researched finding with a specific capability of yours, or it's cut.
+- NEVER distribute the briefing or any researched data outside the user's own workspace and tools without explicit approval.

--- a/skills/alon-goldenberg/meeting-prep/references/attendee-research.md
+++ b/skills/alon-goldenberg/meeting-prep/references/attendee-research.md
@@ -1,0 +1,70 @@
+# Attendee research: query fan-out and profile format
+
+How to research one attendee. Run one of these per attendee, in parallel across attendees. Before starting, pass in any **known facts** from the person's running file so the research reports only what's new.
+
+## Searches — Group 1 (run simultaneously)
+
+1. **"[Name] [Company]"** — broad web search, ~10 results. The primary query: role, title, background, company association.
+2. **People search for "[Name] [Company]"** — if your research tool can search the people indices of social platforms directly, use it; it is the most reliable way to find someone's LinkedIn profile and social presence.
+3. **"[Name]" restricted to linkedin.com** — the fallback for query 2. If both return results, prefer query 2 (richer people-index data).
+4. **"[Name] [Company] interview OR podcast OR talk OR keynote"** — where they share their actual thinking.
+
+**Email-enhanced variant:** if you have the attendee's email (from a calendar invite), replace query 3 with **"[first] [last] [email-domain]" restricted to linkedin.com**. The email domain confirms the company and disambiguates common names far better than name alone.
+
+**Retry rule:** fewer than 3 total results from Group 1 → drop any date filters and try name variations: "[First] [Last]", "[Full Name] [Company]", "[Full Name] [Title if known]".
+
+## Searches — Group 2 (after Group 1 returns)
+
+5. **"[Name]" restricted to x.com, past month** — recent opinions, announcements, what they care about right now.
+6. **"[Name] [Company]" restricted to github.com, medium.com, substack.com** — technical and thought-leadership content they authored.
+7. **"[Name] conference OR speaker OR panel OR published"** — appearances and published work.
+
+Keep scope tight: roughly 7 searches and at most 2 page extractions per attendee. Running in two groups also keeps you under rate limits when several attendee threads run at once.
+
+## Extraction (max 2 per attendee)
+
+- If a LinkedIn profile URL surfaced, extract the page (render it if your tool supports it). Profile photos are not extractable — don't try.
+- If a recent interview or talk surfaced, extract the top result.
+
+## Name disambiguation
+
+If the primary query returns multiple different people with the same name, filter by the company. Still ambiguous → stop and present the top candidates with their titles and companies for the user to pick. Never silently research the wrong person.
+
+## Cross-attendee overlap flags
+
+When a thread discovers a workplace, school, board, or community for its attendee, check it against the other attendees' findings — "my attendee worked at that company 2019–2022, did yours overlap?" These overlaps feed the briefing's Relationship Map; hunting for them actively beats comparing results after the fact.
+
+## Return format (exact)
+
+```
+PROFILE:
+Name: [Full name]
+Title: [Current title]
+Company: [Company name]
+LinkedIn: [Profile URL if found]
+Time in role: [Duration if found]
+Location: [If found]
+
+CAREER:
+- [Previous role] at [Company] ([years])
+
+EDUCATION:
+- [Degree, Institution] (if found)
+
+RECENT ACTIVITY:
+- [What they've posted, shared, or spoken about — with dates]
+- [Direct quotes when available — these are gold for conversation hooks]
+
+INTERESTS & OPINIONS:
+- [Topics they care about based on posts/talks/articles]
+- [Positions they've taken publicly]
+
+CONNECTIONS:
+- [Notable past employers — flag any overlap with other attendees]
+- [Organizations, boards, or communities they're part of]
+
+SOURCES:
+- [URL] — [what it contained]
+```
+
+Anything already in the known facts stays out of RECENT ACTIVITY — the profile carries the full picture; the research reports the delta.

--- a/skills/alon-goldenberg/meeting-prep/references/briefing-format.md
+++ b/skills/alon-goldenberg/meeting-prep/references/briefing-format.md
@@ -1,0 +1,79 @@
+# Briefing format
+
+The output structure for every meeting-prep run. Section order matters — the Quick Take carries readers who read nothing else.
+
+## Structure
+
+```
+# Meeting Prep: [Company Name]
+*[Meeting date/time if known] | Prepared [date]*
+
+## Quick Take
+[2–3 sentences: who you're meeting, why it matters, and the one thing to
+know going in. The "read nothing else" paragraph.]
+
+## Attendees
+
+### [Name] — [Title]
+**Background:** [Current role, time in position, career trajectory highlights]
+**Recent activity:** [What they've been posting, speaking about, or working
+  on. Direct quotes from posts/talks when available.]
+**Conversation hooks:** [2–3 specific things to reference — shared
+  connections, their recent project, a post they wrote, a talk they gave]
+**Notes from prior meetings:** [From your running person file — what was
+  discussed, their preferences, open items. "No prior meetings on file"
+  if none.]
+
+[Repeat per attendee]
+
+## Relationship Map
+[Cross-attendee connections — shared employers, mutual connections,
+  overlapping interests, organizational dynamics. Skip if single attendee.]
+
+## Company Context
+- **What they do:** [One line]
+- **Size / stage:** [Employees, funding stage, HQ]
+- **Recent news:** [Top 2–3 items, dated, with source]
+- **Relevant to your meeting:** [How the company context connects to the
+  discussion — a launch you might discuss, funding that signals growth,
+  a leadership change shifting priorities]
+
+## Value Positioning
+*[Only for sales/discovery, partnership, and board/investor meetings.
+  Omit entirely otherwise. Subsection specs in the value-positioning
+  reference: Value Mapping, Integration Hooks, Recommended Positioning,
+  Reference Customers.]*
+
+## Talking Points
+[3–5 specific, actionable conversation starters grounded in the research.
+  Never "ask about their priorities" — instead: "Ask about the migration
+  from [old tool] to [new tool] they announced last month." When value
+  positioning is active, weave 1–2 positioning angles in naturally — don't
+  make every talking point a pitch.]
+
+## Watch Out For
+[1–3 things to be aware of — sensitive topics (layoffs, bad press),
+  awkward overlaps, information gaps you couldn't fill.]
+
+## Sources
+[Numbered list of key URLs cited above]
+```
+
+## Per-type adaptations
+
+| Meeting type | Emphasis | Extra section | Value Positioning |
+|---|---|---|---|
+| Sales / discovery | Buyer authority, pain signals, competitive stack | "Qualification signals" | **Yes** — full section |
+| Partnership | Mutual-benefit signals, integration opportunities | "Alignment opportunities" | **Yes** — lead with integration hooks |
+| Board / investor | Financial context, market position, portfolio overlap | "Key metrics to reference" | **Yes** — lead with recommended positioning |
+| Interview | Work-history depth, cultural signals | "Assessment angles" | No |
+| Internal | Person's recent work; skip company research | Lighter format, no company section | No |
+| General external | Balanced | Standard format | No |
+
+## Writing rules
+
+- Every factual claim about an external company or person carries a source URL. Claims from your own sales-context notes are attributed to those notes.
+- Lead with the Quick Take — most readers stop there.
+- Talking points are specific to THIS meeting; if a talking point would fit any meeting, it's filler — cut it.
+- "No public information found" beats speculation, always.
+- If the running person file holds prior meeting notes, surface open items and continuity points prominently — this is the highest-value content in the entire briefing.

--- a/skills/alon-goldenberg/meeting-prep/references/value-positioning.md
+++ b/skills/alon-goldenberg/meeting-prep/references/value-positioning.md
@@ -1,0 +1,41 @@
+# Value positioning research
+
+Runs only for sales/discovery, partnership, and board/investor meetings. Cross-references what you learned about the attendee's company with your own sales context to find concrete positioning angles — never generic pitch advice.
+
+## Your sales context
+
+Keep a small sales-context note in your workspace (or pull the equivalent from your CRM/enablement docs) with:
+
+- **Key differentiators** — what actually makes your product different
+- **Integration partners** — tools your product connects with
+- **Case studies** — named or anonymized customers, their industry/size, and the outcome metric
+- **Common objections** — with your standard responses
+- **Tracked competitors** — who you displace
+
+If none of this exists yet, the play still works — pain-to-solution mapping and tech-stack discovery run on web research alone; the section is thinner but useful. Tell the user once, at the end: adding sales context makes the next briefing's positioning sharper.
+
+## Searches (run simultaneously, 3–5 depending on available context)
+
+1. **"[Their company]" tech stack OR tools OR platform OR uses** → what they run; match hits against your integration partners.
+2. **"[Their company]" paired with your company name or domain** → existing relationship, mentions, shared investors, competitive overlap. Skip if already run during company research.
+3. **"[Their company]" challenges OR pain points OR struggling OR migrating** → pain signals to map against your value props.
+4. *(If you track competitors)* **"[Their company]" [Competitor A] OR [Competitor B]** → competitor usage; critical for displacement positioning.
+5. *(If you have case studies in their industry)* **[Your company] [their industry] case study OR customer story** → published proof to reference.
+
+From the results, extract four things: tools they use (integration hooks), pain signals (value mapping), competitor usage (displacement angle), and industry matches to your case studies (social proof).
+
+## Output subsections
+
+**Value Mapping.** Match their specific needs to your capabilities. Every line is grounded in a researched finding, formatted: "They [specific finding, with source] → your product [specific capability]". A mapping with no finding behind it doesn't ship.
+
+**Integration Hooks.** Only integrations confirmed on BOTH sides — their stack (from research) and your integration list. No overlap found → say so honestly rather than stretching.
+
+**Recommended Positioning.** 2–3 sentences framing the pitch for this specific company and person: their stage, recent news, the attendee's role and priorities, any displacement opportunity. The "elevator pitch calibrated to this meeting" paragraph.
+
+**Reference Customers.** Case studies matching their industry, size, or use case, with the outcome metric. No genuine match → omit the subsection; a forced weak match reads worse than nothing.
+
+## Grounding rules
+
+- Never write "highlight your product's strengths"-grade advice. If a claim isn't traceable to a specific finding about their company plus a specific capability of yours, cut it.
+- Displacement angles require an actual signal that they use the competitor — a guess is not an angle.
+- The attendee's seniority shapes the framing: an economic buyer hears outcomes and reference customers; a hands-on evaluator hears integration hooks and workflow specifics.


### PR DESCRIPTION
## What this skill does

Pre-meeting attendee intelligence: parallel research per attendee with name disambiguation, a cross-attendee relationship map, company context, meeting-type-gated value positioning, and a briefing whose Quick Take alone could carry the meeting. Per-person/per-company memory with a 24h/30d freshness ladder.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
