### PR TITLE
add brand-mention-monitor

### DIFF
--- a/skills/alon-goldenberg/brand-mention-monitor/SKILL.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: brand-mention-monitor
+title: Brand mention monitor
+description: |
+  Use this skill when you need to know what people are saying about a brand across
+  the web and social — "monitor brand mentions", "what are people saying about
+  [brand] this week", "run a brand sweep", "social listening", "find high-risk
+  mentions", or "how does [brand] compare to [competitor] in the conversation".
+  Sweeps social platforms, news, forums, and review sites; scores every mention on
+  reach, velocity, sentiment, and risk-topic match; and produces a triage report
+  bucketed into Crisis / Watch / Engage / Log with a suggested owner and response
+  window for each mention, so the team responds before one spirals.
+category: Signals
+tags: [Marketing]
+---
+
+Run this when anyone needs eyes on the brand conversation — a routine weekly sweep, a launch-week watch, or a "something feels off" check. It produces a triage report: every mention scored on four dimensions, deduped against what previous runs already found, and bucketed into Crisis / Watch / Engage / Log with an owner and a response window.
+
+## Before the sweep — resolve, profile, confirm
+
+Do two research steps before asking the user anything:
+
+1. **Resolve brand variants.** Search the live web for the brand's alternate spellings, hashtags, handles, product names, and sub-brands that get mentioned independently. For common-word brand names, find the disambiguating terms (industry, founder, domain) so the sweep doesn't pull unrelated noise. Fold every confirmed variant into the query list silently — never ask the user to supply this.
+2. **Profile the brand.** Establish B2B vs B2C, industry, primary geography and language, and rough audience size. This picks the source profile and calibrates scoring — "high reach" means something different for a niche B2B tool than for a consumer app with millions of users.
+
+Then confirm scope in a single message: the brand as you understood it plus any competitors to track alongside, the date window (default: last 7 days), depth (quick scan vs deep sweep; default deep), and who gets flagged on a Crisis-tier hit ({{CRISIS_OWNER}} — a PR lead, legal, founder, or the marketing team by default). Skip the questions entirely when the user already provided the answers or a prior run in this workspace configured them. If the brand name is still ambiguous after research, confirm which entity is meant before running anything.
+
+## Pick the source profile
+
+The single most important configuration step. Do not scan all platforms equally — weight the channels where this brand's audience actually talks. B2B brands live on LinkedIn, G2, Hacker News, and trade press; consumer brands on TikTok, Instagram, YouTube, and Trustpilot; regulated industries on wire services, regulatory watchdogs, and journalist accounts; regional brands on local-language platforms. Read `references/source-playbook.md` for the five market profiles and the full per-platform query patterns before building the query list.
+
+## Sweep
+
+Fan out parallel searches, one stream per source group (social, news and press, review platforms, community forums), every query bounded to the confirmed date window. Run a shallow discovery pass first across all streams; extract full page or thread content only for candidates that look high-impact — that is where the scoring evidence (engagement counts, reply tone, author profile) comes from. Every pass runs three query families: broad brand queries, risk queries (lawsuit, outage, scam, recall — tuned to the industry), and opportunity queries (organic praise, purchase intent, comparison wins). If one stream fails, continue with the rest and name the gap in the report — never silently present a partial sweep as complete.
+
+## Score every mention
+
+Four dimensions, each 0–100: **reach** (how many people can see this), **velocity** (how fast it is gaining ground — the differentiator between "viral forming" and "stale"), **sentiment** (scored separately for risk and opportunity), and **risk-topic match** (legal, safety, outage, executive controversy, misinformation). Composite:
+
+```
+composite = reach x 0.30 + velocity x 0.30 + max(risk_sentiment, risk_topic) x 0.25 + opportunity x 0.15
+```
+
+Velocity has an honesty gate: hourly growth rates need two data points. On a first pass with no baseline, score only observable proxies (cross-platform pickup, press pickup of a social post, crisis-scale absolute engagement) and label the velocity `~estimated`. The full point tables, baseline rules, and the rapid re-check upgrade path are in `references/scoring-rubric.md` — read it before scoring anything.
+
+## Dedup against brand memory
+
+Keep a running file per brand in your workspace. On each run, load it, fingerprint every found mention as `{url, platform, published_date}` (URLs normalized), and split the feed: net-new, returning-with-score-shift, and already-known-unchanged (suppressed to Log). Lead the report with the split: `X net-new · Y returning (score changed) · Z suppressed`. After the run, persist the new fingerprints and scores. Windowing, carry-forward, and cadence rules are in `references/rerun-and-memory.md`.
+
+## Tier and route
+
+Assign every mention exactly one tier — teams act on tiers, not numbers.
+
+| Tier | Score | Action | Suggested owner | Window |
+|---|---|---|---|---|
+| Crisis | 80–100 | Route immediately | {{CRISIS_OWNER}} + legal + leadership | Respond < 2h |
+| Watch | 50–79 | Assign owner, monitor velocity | Marketing / comms | Respond < 24h |
+| Engage | Any score, positive + high reach | Amplify, thank, share | Marketing / social team | Act within 48h |
+| Log | < 50, no risk signals | None — searchable record | — | — |
+
+Crisis mentions surface first, each as a full decision card: excerpt, all four scores, why it was flagged, who responds, by when, and a suggested draft action. If the user wants Crisis and Watch items pushed to a team channel ({{ALERTS_CHANNEL}}), post only those tiers — never the full feed.
+
+## Write the report
+
+Follow `references/output-format.md` exactly: TL;DR up top, then the triage sections in fixed order, closing with a "What this means" section carrying one to three recommended actions, each tied to a tier and an owner. On a first run, note that a second pass in a few days establishes the velocity baseline and trend lines.
+
+## What good looks like
+
+- The best operator reads velocity before volume — a 40-minute-old post already at thousands of reposts outranks last week's big thread every time — and picks the source profile before writing a single query, because B2B risk hides in G2 review clusters while a generic sweep is busy reading consumer social noise.
+- The mediocre version is a flat list sorted by follower count: every platform weighted equally, velocity "scored" on a single snapshot with no baseline, homepages pasted as source links, and re-runs that re-report everything last week's run already surfaced.
+- Output is good when every Crisis card is actionable in 60 seconds (excerpt, exact link, reason, owner, window, draft action), the dedup summary line proves the run only surfaced what is new, and any mention can be re-found from its exact URL a month later.
+
+## Rules
+
+- MUST link every mention to the exact post/article/thread URL — never a platform homepage.
+- MUST label first-pass velocity scores `~estimated`; hourly-rate points require a prior measurement.
+- MUST bound every query to the confirmed date window and state that window in the report header.
+- MUST persist mention fingerprints after every run and carry Crisis and Watch items forward until the user marks them handled.
+- NEVER fabricate engagement counts, follower numbers, or sentiment — when a value can't be verified from the page, say so on the card.
+- NEVER publish, post, or send any response on the brand's behalf — suggested actions are drafts that require explicit human approval.
+- NEVER suppress a returning mention as a duplicate when its composite score moved 10+ points — a score shift is news.

--- a/skills/alon-goldenberg/brand-mention-monitor/references/output-format.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/references/output-format.md
@@ -1,0 +1,93 @@
+# Output format — the triage report
+
+The output is a triage console, not an essay: dense, action-oriented, sorted by urgency. The tier badge is the primary label on every mention — the composite number supports it, never replaces it. Deliver the report in the conversation first; save a copy alongside the brand's memory file. If pushing to a team channel, send Crisis and Watch tiers only, never the full feed.
+
+Sections in this exact order.
+
+## 1. Header block
+
+```markdown
+# Brand mention monitor — [Brand]
+**Window:** [start] – [end]   **Generated:** [timestamp]
+**Total mentions:** [N]   **Depth:** [quick|deep]
+**Dedup:** X net-new · Y returning (score changed) · Z suppressed (already logged)
+```
+
+The window is the one confirmed at setup — state it even when it was a default. The dedup line is mandatory on every run after the first.
+
+## 2. TL;DR
+
+2–4 lines: total mentions, the tier breakdown (`X Crisis · Y Watch · Z Engage`), and the single most urgent item with its response window. A reader who stops here must still know whether anything is on fire.
+
+## 3. Sources searched
+
+A short table of every source group queried this run with mention counts — and an explicit note for any stream that failed or was skipped. This is the honesty panel: the reader must be able to see what the sweep did and did not cover.
+
+| Source | Searched | Mentions |
+|---|---|---|
+| Reddit | yes | 14 |
+| LinkedIn | yes | 6 |
+| TikTok | skipped — low signal for this profile | — |
+
+## 4. Score summary
+
+One line of aggregates: average reach, top velocity (with its arrow), top sentiment risk, top opportunity. Fast context for how hot the window was overall.
+
+## 5. Share of voice (when competitors are tracked)
+
+The brand's share of the conversation vs each tracked competitor in this window. One row per brand, user's brand first, percentages summing to ~100 with an "Other" bucket:
+
+| Brand | Share | Mentions | Trend vs last window | Sentiment (+/0/-) | Signal |
+|---|---|---|---|---|---|
+| [Brand] | 42% | 87 | ↑ +6pts | 55/30/15 | [one line on what's driving the share] |
+
+The Signal column is the analysis — one line per brand explaining what is driving its share (a launch, a complaint cluster, a viral post). Omit the section entirely when no competitors are tracked; never pad it with guesses.
+
+## 6. Crisis alert cards — respond within 2 hours
+
+Full-width treatment, before everything else in the feed. One card per Crisis mention:
+
+```markdown
+### 🔴 CRISIS — [Platform] · [Author] · [published date]
+**Scores:** composite [N] · R:[N] V:[N] S:[N] RT:[N] · [↑ accelerating|→ stable|~estimated]
+> "[Excerpt — the actual words, enough to judge tone]"
+**Why flagged:** [the specific signals: risk topic hit, velocity, reach]
+**Owner:** [who responds] · **Window:** < 2h
+**Suggested action:** [a concrete draft move — requires human approval before anything is sent]
+**Source:** [EXACT post/article URL]
+```
+
+## 7. Mention feed by tier
+
+Then Watch (respond < 24h), Engage (act within 48h), and Log, in that order, each mention sorted by composite within its tier. Compact card format:
+
+```markdown
+- **[Tier] [composite]** · [Platform] · [Author] · [date] · R:[N] V:[N] S:[N] RT:[N] [velocity arrow]
+  "[Excerpt]"
+  Owner: [owner] · Window: [window] · Action: [suggested action]
+  Source: [EXACT URL]
+```
+
+Returning mentions whose score shifted carry a `↩ returning · score changed` badge. Log entries can compress to one line each (tier, platform, excerpt fragment, URL) — they exist as a searchable record, not for reading.
+
+## 8. Mentions by platform
+
+A count-per-platform table so the reader sees where the conversation is concentrated. When mentions cluster geographically (a regional outage, a local press story), add a geographic breakdown: location, mention count, highest tier there, and the exact source links. Skip geography when it adds nothing.
+
+## 9. What this means
+
+The closing section, always present: what this window's sweep signals for the brand right now, then the top 1–3 recommended actions — each tied to a tier and an owner ("Watch item #2 → comms, draft a response today"). This is judgment, not a recap; it should read like the first paragraph of the note the marketing lead forwards.
+
+## Source URL rule (applies to every line above)
+
+Every mention links to the exact article, post, or thread URL as returned by the search — never a homepage, never a search-results page.
+
+- CORRECT: `https://reddit.com/r/SaaS/comments/abc123/title`
+- CORRECT: `https://x.com/username/status/1234567890`
+- WRONG: `https://reddit.com` · WRONG: `https://x.com`
+
+## Follow-ups to offer (only the relevant one)
+
+- First run with no prior memory → suggest re-running in a few days to establish the velocity baseline and trends.
+- Competitors framing the brand negatively in Watch/Crisis → offer a deeper competitor messaging and positioning analysis as a separate exercise.
+- Mostly positive mentions → offer to turn the strongest ones into amplification or content angles.

--- a/skills/alon-goldenberg/brand-mention-monitor/references/rerun-and-memory.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/references/rerun-and-memory.md
@@ -1,0 +1,40 @@
+# Re-runs, memory, and dedup
+
+Brand monitoring only earns its keep on the second run: memory is what turns a pile of search results into "here's what's new." Keep a running memory file per brand in your workspace (one file per brand, e.g. `brand-monitor/[brand]/memory.md`), plus a saved copy of each run's report next to it.
+
+## The memory file
+
+Holds, per known mention:
+
+- **Fingerprint:** `{url, platform, published_date}`. Normalize URLs before fingerprinting — strip query parameters and trailing slashes, lowercase the host — so the same post shared with tracking parameters doesn't read as new.
+- **Last composite score and tier**, plus the last engagement counts observed (reposts, replies, upvotes, views). These counts are the baseline that makes real velocity scoring possible on the next pass.
+- **Status for Crisis/Watch items:** open or handled.
+
+Also record run metadata at the top: last run timestamp, window covered, source profile used, competitors tracked, routing preference. Load this before asking setup questions — a returning user confirms, never re-enters.
+
+## Dedup lifecycle (runs after scoring, before tier assignment)
+
+For every mention found this run, check its fingerprint against memory:
+
+1. **Not in memory → net-new.** Full treatment: tier, card, routing.
+2. **In memory, composite moved 10+ points → returning.** Keep it in the feed at its new tier with a `↩ returning · score changed` badge. A score shift is news — usually velocity or fresh replies — and must never be suppressed as a duplicate.
+3. **In memory, score unchanged → suppressed.** Move to the Log tier; exclude from Crisis/Watch/Engage unless the user asked for full history.
+
+Open the report with the split: `X net-new · Y returning (score changed) · Z suppressed (already logged)`. After the run, write the new fingerprints, scores, and engagement counts back to memory.
+
+**Carry-forward:** Crisis and Watch items stay listed on every subsequent run — with current status and velocity arrow — until the user marks them handled. Suppression applies to noise, never to open incidents.
+
+## Date windowing by run type
+
+- **First run:** use the window the user confirmed (default: last 7 days). No baseline exists — velocity is proxy-only and labeled `~estimated`; say explicitly that trends start on the next pass.
+- **Refresh (a day or more since last run):** window from the last run's timestamp to now. Sweep for net-new mentions; re-fetch open Crisis/Watch items to update velocity.
+- **Same-day repeat (within ~2 hours):** don't re-sweep everything. Re-fetch every mention that scored Watch or higher and compare engagement to the stored counts — 20%+ growth upgrades the tier and marks `↑ accelerating`; flat or declining marks `→ stable` / `↓ declining`. Add a quick pass over the fastest sources (the profile's tier-1 social) for brand-new items.
+- **User names an explicit window** ("June 1–15", "since the launch"): use it verbatim; dedup still applies.
+
+## Cadence guidance
+
+- **Continuous monitoring:** daily or every few days.
+- **Launches and campaigns:** every 6–12 hours for the first 48 hours.
+- **Crisis mode (any open Crisis item):** every 1–2 hours until the item is handled or clearly declining.
+
+Whatever the cadence, always record the run timestamp — it is what makes the next window calculation and the "only what's new" promise possible.

--- a/skills/alon-goldenberg/brand-mention-monitor/references/scoring-rubric.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/references/scoring-rubric.md
@@ -1,0 +1,87 @@
+# Scoring rubric — four dimensions, composite, tiers
+
+Score every mention 0–100 on each dimension, then compute the composite. Points come from evidence visible on the page (follower counts, reply counts, repost counts, domain, language) — never from guesses. When a value can't be verified, leave the points off and note it on the card.
+
+## Reach / visibility (0–100) — how many people can see this?
+
+| Signal | Points |
+|---|---|
+| 500K+ followers / major publication | +35 |
+| 100K–500K followers | +25 |
+| 10K–100K followers | +15 |
+| 1K–10K followers | +8 |
+| Under 1K followers | +3 |
+| Thread with 100+ replies/comments | +20 |
+| Post going viral (100+ reposts in under an hour) | +25 |
+| High-authority domain (major wire or tech press) | +25 |
+| Reddit front page / 1K+ upvotes | +25 |
+
+## Velocity (0–100) — the differentiator
+
+How fast is this gaining ground? Velocity separates "viral forming" from "stale," and it is the dimension most often faked. The honesty gate:
+
+- **Hourly-rate rows require a baseline** — a prior engagement count and the current count. A single snapshot cannot yield a rate.
+- **Re-run with prior data:** use the full table.
+- **First-pass sweep (no baseline):** skip the hourly-rate rows; score only observable proxies. Label the velocity `~estimated` on the card so the reader knows it is inferred, not measured.
+
+| Signal | Points | Needs baseline? |
+|---|---|---|
+| Engagement climbing 50%+/hour vs baseline | +40 | Yes |
+| Engagement climbing 20–50%/hour | +25 | Yes |
+| Engagement climbing 5–20%/hour | +10 | Yes |
+| Flat engagement | +0 | Yes |
+| Cross-platform pickup (same mention on 2+ platforms) | +20 | No |
+| Press picking up a social post | +25 | No |
+| Crisis-scale absolute engagement (thousands of reposts within the hour) | +40 | No — observable in one sweep |
+
+**Rapid re-check upgrade:** when re-running within 2 hours of a prior run, re-fetch every mention that scored Watch or higher and compare engagement. Grown 20%+ → upgrade the tier and mark `↑ accelerating`. Otherwise mark `→ stable` or `↓ declining`. Every card carries one of these three arrows once a baseline exists.
+
+## Sentiment (0–100 risk score; 0–100 opportunity score — scored separately)
+
+| Negative signals (risk) | Points |
+|---|---|
+| Explicit negative sentiment | +20 |
+| Complaint plus product/service failure language | +20 |
+| Sarcasm ("great job [brand]…") | +15 |
+| All-caps, exclamation marks, profanity | +10 |
+| Replies amplifying the negative tone | +15 |
+
+| Positive signals (opportunity) | Points |
+|---|---|
+| Organic, unprompted praise | +20 |
+| Purchase intent or recommendation | +20 |
+| User-generated content the brand could share | +15 |
+| Journalist / analyst positive mention | +20 |
+
+## Risk-topic match (0–100) — does this hit a flagged category?
+
+Default dictionary below; add the industry-specific topics from the brand profile and any the user names.
+
+| Topic category | Points |
+|---|---|
+| Legal / regulatory / lawsuit / class action | +40 |
+| Safety / health / injury / recall | +40 |
+| Executive misconduct or controversy | +35 |
+| Product outage or critical failure | +30 |
+| False claim / misinformation about the brand | +25 |
+| Pricing / billing complaint (if spreading) | +20 |
+| Competitor comparison framing the brand negatively | +15 |
+
+## Composite
+
+```
+composite = (reach x 0.30) + (velocity x 0.30) + (max(risk_sentiment, risk_topic) x 0.25) + (opportunity x 0.15)
+```
+
+Risk takes the stronger of the two risk reads — a legally dangerous mention with mild wording still scores as dangerous.
+
+## Tier thresholds
+
+| Tier | Rule |
+|---|---|
+| Crisis | composite 80–100 |
+| Watch | composite 50–79 |
+| Engage | any composite, sentiment strongly positive and reach high — opportunity worth acting on |
+| Log | composite under 50 with no risk signals |
+
+Engage is not a consolation tier: it exists so high-reach praise gets amplified within 48 hours instead of rotting in a log. A mention can be Engage even with a modest composite when opportunity and reach are both strong.

--- a/skills/alon-goldenberg/brand-mention-monitor/references/source-playbook.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/references/source-playbook.md
@@ -1,0 +1,92 @@
+# Source playbook — profiles and query patterns
+
+Source selection must match where the brand's audience actually talks. Pick one profile from the brand research step, run its primary sources every pass, add secondaries on deep sweeps, and skip the deprioritized ones unless the user asks. Run social first (fastest to surface new mentions), then news, then review platforms. Bound every query to the run's date window.
+
+Queries below are written as web search strings. If your search tool has a social-focused mode, use it for the social queries — it surfaces posts and threads better than plain web search. Use shallow results for discovery; extract the full page or thread only on high-signal hits, since engagement counts and reply tone live in the full content.
+
+## The five market profiles
+
+### B2B enterprise software / SaaS
+- **Primary (every pass):** LinkedIn, G2, Capterra, Hacker News, category subreddits (r/sysadmin, r/devops, r/[category]), trade press (InfoQ, TechCrunch, ZDNet, The Register), Glassdoor (employee signal)
+- **Secondary:** Reddit broad, X/Twitter (exec accounts, analysts), Medium/Substack
+- **Deprioritize:** TikTok, Instagram, Facebook — low signal for B2B buyers
+
+### Consumer brand / e-commerce
+- **Primary (every pass):** TikTok, Instagram, X/Twitter, Reddit, YouTube, Facebook, Trustpilot, Google Play / App Store
+- **Secondary:** news press, blogs, Pinterest
+- **Deprioritize:** Hacker News, LinkedIn, trade press — low signal for consumer sentiment
+
+### Regulated industry (finance, healthcare, pharma, insurance)
+- **Primary:** wire and sector press (Reuters, AP, Bloomberg, sector-specific), regulatory watchdog sites, journalist accounts on X, LinkedIn exec commentary, formal review platforms (BBB, consumer-protection agency complaint databases)
+- **Secondary:** Reddit, X broad, forums
+- **Deprioritize:** TikTok, Instagram — press and regulatory risk outranks user-generated content here
+
+### Regional / non-English brand
+- **Primary:** local-language news, regional forums and social platforms (Weibo for China, VK for Russia, Naver for Korea, and equivalents), local-language X/Instagram
+- **Secondary:** English-language global platforms only where relevant
+- **Note:** set your search tool's locale/country parameters so local-language results surface
+
+### Startup / developer tool
+- **Primary:** Hacker News, Reddit (r/programming, r/webdev, r/[category]), GitHub discussions, Dev.to, X (developer influencers), Product Hunt
+- **Secondary:** LinkedIn, Medium, TechCrunch
+
+## Tier 1 — Social (run first, every pass)
+
+### Reddit
+- `"[brand]" site:reddit.com` — broad sweep
+- `"[brand]" site:reddit.com/r/[category]` — category subreddit; also the brand's own subreddit if one exists
+- `"[brand]" complaint OR issue OR problem site:reddit.com` — risk
+- `"[brand]" recommend OR love OR "switched to" OR best site:reddit.com` — opportunity
+- `"[brand]" vs OR alternative OR "compared to" site:reddit.com` — competitive
+- Signal: sort by new for recency, top for reach; threads with 100+ comments are high priority.
+
+### X / Twitter
+- `"[brand]" site:x.com` — broad; `"#[brand]" site:x.com` — hashtag sweep
+- `"[brand]" angry OR disappointed OR broken OR "doesn't work" OR worst site:x.com` — risk
+- `"[brand]" love OR amazing OR "highly recommend" site:x.com` — opportunity
+- `"[brand]" complaint OR refund OR scam site:x.com` — escalation risk
+- Signal: verified accounts, 10K+ follower accounts, threads with 50+ replies.
+
+### LinkedIn
+- `"[brand]" site:linkedin.com`
+- `"[brand]" review OR feedback OR experience OR "working with" site:linkedin.com`
+- `"[brand]" CEO OR founder OR team site:linkedin.com` — exec commentary
+- Signal: practitioner posts carry weight with B2B buyers; exec commentary shapes enterprise perception.
+
+### Instagram / TikTok / Facebook / Threads
+- Social-mode searches: `"[brand]" instagram`, `#[brand] instagram review OR unboxing OR haul`
+- `"[brand]" tiktok`, `#[brand] tiktok review OR reaction OR honest`, `"[brand]" tiktok made me buy`
+- `"[brand]" facebook group`, `"[brand]" facebook review`
+- `"[brand]" site:threads.net`
+- Signal: viral reaction content moves faster than press — a high-view negative TikTok is urgent; "TikTok made me buy it" is high opportunity; Facebook groups skew consumer/SMB and older demographics.
+
+### YouTube
+- `"[brand]" review OR "honest review" OR "is it worth it" site:youtube.com`
+- `"[brand]" "don't buy" OR problems OR "I returned" site:youtube.com` — risk
+- `"[brand]" unboxing OR "first impressions" site:youtube.com`
+- Signal: view count and like ratio; a negative review with 100K+ views is high risk.
+
+## Tier 2 — News and press
+
+- `"[brand]" news` — broad sweep
+- `"[brand]" site:techcrunch.com OR site:theverge.com OR site:wired.com`
+- `"[brand]" site:businessinsider.com OR site:forbes.com OR site:bloomberg.com`
+- `"[brand]" site:reuters.com OR site:apnews.com`
+- Add category-specific press from the brand profile.
+- Hacker News: `"[brand]" site:news.ycombinator.com` (or search hn.algolia.com); threads with 50+ comments reach a highly influential technical audience.
+- Blogs and newsletters: `"[brand]" site:medium.com`, `"[brand]" site:substack.com`, `"[brand]" blog review OR "my experience"` — long-form opinion shapes search results over time.
+
+## Tier 3 — Review platforms
+
+- G2: `"[brand]" site:g2.com reviews` — new 1–3 star reviews and a score drop are risk; watch trending themes in the cons.
+- Trustpilot: `"[brand]" site:trustpilot.com` — a cluster of negatives in a short window is the signal, not any single review.
+- Capterra/GetApp: `"[brand]" site:capterra.com`, `site:getapp.com`
+- App stores: `"[brand]" site:apps.apple.com`, `site:play.google.com` — version-specific complaints and rating drops after an update.
+- Product Hunt: `"[brand]" site:producthunt.com` — launch-day reactions, "alternatives to" pages, maker response tone.
+
+## Tier 4 — Opportunity-specific (run these deliberately)
+
+- **Purchase intent:** `"[brand]" "thinking of buying" OR "should I get" OR "is [brand] worth it"` — an unanswered purchase-intent question deserves a helpful reply, not a sales pitch.
+- **Organic advocacy / UGC:** `"[brand]" "I love" OR "obsessed with" OR "game changer"`, `"[brand]" "just got" OR "finally tried"` — amplify or reach out for partnership.
+- **Press opportunities:** `"[brand]" "for comment" OR "reached out" OR spokesperson`, `"[brand]" journalist OR "writing a story"` — a journalist looking for a quote gets flagged immediately.
+- **Comparison wins:** `"[brand]" vs "[competitor]" site:reddit.com OR site:x.com`, `"switched from [competitor] to [brand]"` — positive comparisons are amplification material; negative ones go to Watch.


### PR DESCRIPTION
## What this skill does

Brand-conversation sweep across social, news, forums, and review sites with market-fit source profiles. Scores every mention on reach, velocity, sentiment, and risk-topic match (with an honesty gate on velocity), dedups against brand memory, and buckets into Crisis / Watch / Engage / Log with owner and response window per mention.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
