### PR TITLE
add launch-monitor

### DIFF
--- a/skills/alon-goldenberg/launch-monitor/SKILL.md
+++ b/skills/alon-goldenberg/launch-monitor/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: launch-monitor
+title: Launch monitor
+description: |
+  Use this skill when a product launch is live and you need to know what press, social,
+  and developer communities are saying — and what to do about it. Produces a response
+  war room report: a triaged signal feed with urgency levels and action badges, a
+  mischaracterization tracker with copy-ready corrections, a competitor response panel,
+  and a sentiment velocity read. Reach for it when someone says "monitor this launch",
+  "track the launch", "what's being said about the launch", "what's the reaction to the
+  announcement", "flag any mischaracterizations", "check press coverage for the launch",
+  "post-launch coverage", or "how are competitors responding to our launch". Not for
+  steady-state brand monitoring outside a launch window.
+category: Signals
+tags: [Marketing]
+---
+
+Applies from the moment a launch is public until the coverage wave dies — typically two to four weeks. Produces a triaged response war room report where every signal carries an urgency level, an action badge, and an exact source link, so the team knows what to respond to, correct, amplify, or escalate — in that order.
+
+Replace before enabling: `{{ALERTS_CHANNEL}}` — where act-now items get flagged to the team; `{{COMMS_OWNER}}` — who receives escalations (comms, legal, or leadership).
+
+## Before the first sweep
+
+Do two research steps before asking the user anything:
+
+1. **Resolve alternate names silently.** Search the live web for the product's codenames, former names, version names, API/SDK/repo names, and model identifiers — they are often different from the marketing name, and coverage splits across all of them. Fold every confirmed variant into your query list without showing the user this step. Query patterns are in `references/sources.md`.
+2. **Confirm the launch date from evidence.** Search for when the product actually launched. Present what you found for confirmation; if announcement date and general availability differ, surface both and ask which window matters.
+
+Then confirm in a single message: launch date, lookback window (default: launch to now), depth (quick scan vs deep sweep — default deep), and competitors to prioritize or exclude (default: on, identified automatically). If the user says "just run it", take every default. If the product name is ambiguous after research, disambiguate before spending a single search on the wrong product.
+
+**Profile the product before querying.** Answer five questions from the announcement and a quick search: What category is it? What ecosystem does it live in? Who is the audience? What are the key launch claims? And — most important — what would a mischaracterization look like: wrong category, wrong price, wrong capability, wrong comparison? This profile decides which communities you sweep, and you cannot flag a mischaracterization without knowing what "correct" looks like.
+
+## The sweep
+
+Run parallel searches across four fronts — press, community, social, competitors — highest-reach sources first, because that is where a wrong claim does the most damage before you catch it. The full tiered source list, per-platform query patterns, and consumer-launch additions are in `references/sources.md`; read it before the first sweep of any launch.
+
+Alongside the discovery queries, run the **mischaracterization hunt** every pass: targeted queries built from the context profile — the wrong claim you fear, the price, the wrong category, the capability it does not have, the wrong competitor comparison. Wrong information rarely surfaces in a generic sweep; you find it by searching for the specific error.
+
+Use shallow, fast searches for discovery; extract the full page only for signals that survive triage and need exact quotes or reach estimates.
+
+## Triage
+
+Every signal gets four labels: an urgency level (act now / monitor / good signal / noise), an action badge (RESPOND, CORRECT, AMPLIFY, ESCALATE, WATCH, IGNORE), a signal type, and the **exact URL** of the article, thread, or post — never a homepage, never fabricated. The full rubric — urgency definitions, badge semantics, reach heuristics, and the materiality threshold that filters noise — is in `references/triage.md`; apply it to every signal, every run.
+
+For each piece of coverage that gets something wrong, extract the six-field mischaracterization record (claim, source and reach, what's wrong, correct version, spread risk, suggested one-sentence correction) per the same reference — including a secondary search to see whether other outlets are already citing the wrong claim. Spread status (SPREADING / CONTAINED / CORRECTED) decides urgency more than the original outlet's size does.
+
+## Sentiment velocity
+
+Break the window into intervals — hourly for the first 24 hours, daily after — and count positive, negative, and neutral signals per interval. Identify the inflection point (when did sentiment peak or flip?) and flag any velocity spike, positive or negative: a sudden surge in mentions is itself a signal even before you read a single post.
+
+## Memory and re-runs
+
+Keep a running file per launch in your workspace. On every run, load it and dedup before writing output: fingerprint each signal as `{url, signal_type, published_date}` with URLs normalized (strip query params and trailing slashes). Already-known and unchanged → suppress from the main feed (appendix only, on request). Returning with changed urgency → keep in the feed, marked as returning. Lead the report with the honesty line: `X net-new · Y returning (urgency changed) · Z suppressed`. After the run, append the new fingerprints and carry forward every unresolved mischaracterization and open action item — a wrong claim is not done until its status is CORRECTED.
+
+Re-run cadence: every 1–2 hours for the first 6 hours post-launch, every 3–4 hours until hour 24, then once or twice daily until momentum dies. On a re-run, sweep only since the last run timestamp and surface only what is new.
+
+## The report
+
+One format, every run: TL;DR first (sentiment read, act-now count, single most urgent item), the war room body in fixed section order, "What this means" last (trajectory read plus the one action to take now). The full section-by-section format spec — card fields, mischaracterization tracker layout, competitor panel, source index, and tone rules — is in `references/report-format.md`; follow it exactly.
+
+After the report is delivered, flag act-now items to `{{ALERTS_CHANNEL}}` and route ESCALATE items to `{{COMMS_OWNER}}` — only after the user approves what gets posted. Suggested responses and corrections are always drafts for a human to send, never sent by you.
+
+## What good looks like
+
+- The best operator hunts for what's *wrong*, not what's *said*: the mischaracterization queries built from the context profile find the "it's just an X reskin" thread hours before it hits press, and the spread-risk search shows whether it is one Reddit comment or three outlets already citing each other.
+- The mediocre version is a clipping service: a flat list of links, no urgency, no suggested action, homepage URLs, positive and negative mixed together — the user still has to do all the thinking. Or worse: a re-run that re-reports Tuesday's signals as if they were news.
+- Output is good when the user can act in sixty seconds: the TL;DR names the single most urgent item, every act-now card carries a specific suggested action ("reply in the HN thread with the pricing page link", not "consider responding"), every correction is copy-ready, and every source link lands on the exact thread.
+
+## Rules
+
+- MUST include the exact article/thread/post URL for every signal, as returned by search. NEVER a homepage. NEVER a fabricated or reconstructed URL.
+- MUST run the mischaracterization hunt on every pass, not just the first.
+- MUST dedup against the launch's running file before output and lead with the net-new/returning/suppressed counts.
+- MUST keep suggested responses and corrections as drafts — NEVER post, reply, comment, or send anything publicly or to a channel without explicit human approval.
+- NEVER report a claim as spreading, or attach a reach number, without evidence found in the sweep — say "unverified" when it is.
+- NEVER treat accurate neutral coverage as a problem to fix; flag it, don't prioritize it.
+- NEVER count syndicated wire copy as multiple signals.

--- a/skills/alon-goldenberg/launch-monitor/references/report-format.md
+++ b/skills/alon-goldenberg/launch-monitor/references/report-format.md
@@ -1,0 +1,97 @@
+# Response war room — report format spec
+
+One report shape, every run. Markdown, section order fixed. Tone: operational, terse, plain-language — a war room board, not a market-research essay. Name the outlet, the claim, the competitor; never "some coverage suggests".
+
+Save each run as `launch-monitor-[YYYY-MM-DD].md` in the launch's workspace folder, next to the running memory file.
+
+---
+
+## Section order
+
+### 0. Header block
+
+```markdown
+# Launch Monitor — [Product Name]
+**Launch date:** [DATE]
+**Monitored window:** [DATE RANGE]
+**Generated:** [TIMESTAMP]
+**Total signals:** [N]
+**Dedup:** [X] net-new · [Y] returning (urgency changed) · [Z] suppressed
+```
+
+The dedup line is mandatory on every run after the first — it is the honesty line that tells the reader how much of this report is actually new.
+
+### 1. TL;DR — always first
+
+Two to three sentences: overall sentiment read (positive / mixed / negative / trending which way), count of act-now items, and the single most urgent signal or mischaracterization by name. Example: "Sentiment is mixed-to-negative in the first 48 hours, with 5 act-now items. The dominant risk is the '[wrong-framing]' claim spreading across HN and press. Three mischaracterizations are active, two spreading."
+
+### 2. Attention summary
+
+One bold line for scanners: **"[N] things need your attention right now —"** followed by the 2–3 most urgent items in plain language. Be specific: the outlet, the claim, the competitor move — not categories.
+
+### 3. Coverage stats
+
+One compact line or mini-table: All signals · Act now · Monitor · Good · Mischaracterizations · Competitor moves · Overall sentiment.
+
+### 4. Sentiment velocity
+
+A small table, intervals as rows (hourly for the first 24h, daily after):
+
+```markdown
+| Interval | Positive | Negative | Neutral | Top signal |
+|---|---|---|---|---|
+| Launch–6h | 4 | 1 | 2 | [headline] |
+```
+
+Below the table, two lines of reading: the inflection point (when sentiment peaked or flipped) and any velocity spike, with the likely cause.
+
+### 5. Signal feed — the war room
+
+Grouped by urgency, 🔴 first, then 🟡, then 🟢. Within a group, highest reach first. Per signal, this exact card shape:
+
+```markdown
+- **[RESPOND]** · [Signal type] · [Headline — what happened, in one line]
+  Context: [One sentence — why it matters]
+  Source: [outlet/platform] · [reach estimate] · [time since launch] · [exact URL]
+  Action: [The specific suggested action — what to say, where to post it]
+```
+
+Rules: the URL is the exact article/thread/post URL (see the triage reference); the Action line on 🔴 cards must be executable in sixty seconds; 🟢 cards may compress Context and Action into one line. Returning signals whose urgency changed carry a `↩ returning · urgency changed` marker after the headline. Suppressed known signals do not appear here — appendix only, and only if the user asked for full history.
+
+### 6. Mischaracterization tracker
+
+Only render if mischaracterizations were found. One row per wrong claim, claim on the left, correction on the right:
+
+```markdown
+| The claim | Source · reach | Status | The correction | Suggested response |
+|---|---|---|---|---|
+| "[Exact wrong claim]" | [Outlet · author · ~reach] ([URL]) | SPREADING | [Accurate version] | "[One-sentence, copy-ready correction]" |
+```
+
+The suggested response is written to be pasted verbatim — quote it so the boundary is unambiguous. Carry unresolved rows forward from previous runs; a row leaves the tracker only at CORRECTED.
+
+### 7. Competitor responses
+
+Only render if competitor monitoring is enabled. One entry per competitor — including the silent ones:
+
+```markdown
+- **[Competitor]** — [what they did: published comparison, posted, counter-announced, stayed silent] ([URL if any])
+  Urgency: [read] · Suggested counter-move: [specific move]
+```
+
+### 8. Source index
+
+Flat list for auditability — every signal in the report, one line each: `[URL] · [source] · [date] · [urgency] · [action]`.
+
+### 9. What this means — always last
+
+Two to three sentences synthesizing what the signal pattern implies for the launch trajectory, ending with the single most important action for the team to take right now. This is the section an exec reads if they read nothing else — write it like a recommendation, not a summary.
+
+---
+
+## Tone and honesty rules
+
+- Every number in the report was counted from found signals; every reach figure is sourced or marked as an estimate.
+- Quotes are verbatim from the source, never paraphrased inside quotation marks.
+- Empty sections are omitted, not filled — "no mischaracterizations found" is one line in the stats, not an empty table.
+- No hedging filler ("it seems", "arguably") on act-now items — the card either earns 🔴 with evidence or it moves to 🟡.

--- a/skills/alon-goldenberg/launch-monitor/references/sources.md
+++ b/skills/alon-goldenberg/launch-monitor/references/sources.md
@@ -1,0 +1,137 @@
+# Source tiers and query patterns
+
+Launch monitoring needs speed and precision. Run tiers in this order: highest-reach first, then community, then niche — a wrong claim in a high-reach outlet spreads to secondary coverage within hours, so that is where the first minutes of any run go. Within a tier, run all queries in parallel.
+
+All patterns below use `site:` operators, which work in any web search tool. Substitute the product's confirmed name variants (from alternate-name resolution) into every `"[product name]"` slot — run the high-signal queries once per variant when variants differ materially.
+
+---
+
+## Tier 1 — High-reach press (run first)
+
+Widest reach, highest chance of a mischaracterization spreading to secondary coverage. Check within the first pass of any run.
+
+- `"[product name]" site:techcrunch.com`
+- `"[product name]" site:theverge.com`
+- `"[product name]" site:wired.com`
+- `"[product name]" site:arstechnica.com`
+- `"[product name]" site:venturebeat.com`
+- `"[product name]" site:siliconangle.com`
+- `"[product name]" site:theregister.com`
+- `"[product name]" site:zdnet.com`
+- `"[product name]" site:bloomberg.com`
+- `"[product name]" site:reuters.com`
+- `"[product name]" "[company name]" announcement OR launch OR release`
+
+**Category-specific press** — add based on the context profile:
+
+- Developer tools / APIs: `site:infoq.com`, `site:sdtimes.com`, `site:thenewstack.io`
+- AI/ML: `site:theinformation.com`, plus the major AI newsletters
+- Enterprise SaaS: `site:cio.com`, `site:computerworld.com`
+- Consumer: `site:mashable.com`, `site:engadget.com`
+
+---
+
+## Tier 2 — Community & developer forums (parallel with Tier 1)
+
+Community threads move faster than press and contain the most honest reactions — including the mischaracterizations that later spread *to* press.
+
+### Hacker News
+- `"[product name]" site:news.ycombinator.com`
+- Also search HN's own search index (hn.algolia.com) with a last-24h date filter
+- Signal: threads with 50+ comments are high-priority; read the top comments specifically for wrong claims — an upvoted wrong claim is the seed of tomorrow's press error
+
+### Reddit — broad + subreddit-specific (run all, not just one)
+- `"[product name]" site:reddit.com` — broad sweep
+- `"[product name]" site:reddit.com/r/[category subreddit]` — from the context profile
+- `"[product name]" site:reddit.com/r/[company name]` — brand subreddit if it exists
+- `"[product name]" site:reddit.com/r/technology`, plus the profile-relevant subs (`r/programming`, `r/MachineLearning`, `r/SaaS`, `r/webdev`, `r/devops`, `r/artificial`, …)
+- Signal: sort by "new" for real-time reaction, "top" for highest-reach threads; "I'm disappointed" and "this is actually X not Y" threads are the priority reads
+
+### Dev communities (if the audience is technical)
+- `"[product name]" site:dev.to`
+- `"[product name]" site:hashnode.com`
+- `"[product name]" site:medium.com`
+- `"[product name]" site:stackoverflow.com`
+- `"[product name]" site:github.com` — issues, discussions, reactions on the repo if public
+- `"[product name]" discord` — find the official or community server; early feedback lands there before it surfaces publicly
+
+---
+
+## Tier 3 — Social (real-time volume and influencer signal)
+
+Sweep every pass, not just the first run — social moves faster than everything else.
+
+### X / Twitter
+- `"[product name]" site:x.com`
+- `"[product name]" launch OR announced OR "just released" site:x.com`
+- `"[product name]" wrong OR broken OR disappointed site:x.com` — complaint hunt
+- `"[product name]" "actually" OR "turns out" OR correcting site:x.com` — correction chains
+- Check quote-posts of the official launch post — reactions and mischaracterizations concentrate there
+- Signal: threads with 100+ likes within 24h; journalist corrections; influencer takes
+
+### LinkedIn
+- `"[product name]" site:linkedin.com`
+- `"[product name]" launched OR "my take" site:linkedin.com`
+- Signal: founder/exec posts, practitioner commentary, buyer takes — for B2B products LinkedIn often carries higher-quality signal than X
+
+### YouTube
+- `"[product name]" review OR "hands on" OR reaction site:youtube.com`
+- `"[product name]" "first impressions" OR unboxing site:youtube.com`
+- `"[product name]" problems OR issues OR "doesn't work" site:youtube.com`
+- Signal: view count within 48h and comment themes; large tech channels shape mainstream perception faster than most press
+
+### Instagram / TikTok / Facebook / Threads
+These platforms block most direct search — if your web-research tool has a social-focused search mode, use it here; otherwise pair `site:` queries with platform-name keyword queries:
+- `"[product name]" site:tiktok.com`, or social-mode query `"[product name]" review OR reaction`
+- `"[product name]" site:instagram.com`, or social-mode query `"[product name]" instagram`
+- `"[product name]" site:facebook.com` / `site:threads.net`
+- Signal: viral reaction videos in the first 48h can reach audiences larger than any press outlet; comment sections surface raw consumer sentiment fast
+
+---
+
+## Tier 4 — Competitor monitoring (if enabled)
+
+- `[competitor] "[product name]" OR "[category keyword]"` — are they writing about the launch?
+- `[competitor] "compared to" OR "vs" OR "alternative"` — positioning content
+- `[competitor] site:x.com` — real-time reactions from their accounts
+- Check each competitor's blog and changelog for counter-announcements within 48h of launch
+- `"[competitor] vs [product name]"` — comparison content published since launch date
+- Silence is also a data point — record "no visible response" per competitor rather than omitting them
+
+---
+
+## Tier 5 — Mischaracterization-specific queries (every pass)
+
+Build these from the context profile's "what would a mischaracterization look like":
+
+- **Pricing:** `"[product name]" pricing OR price OR "costs $"` — compare against actual pricing
+- **Category confusion:** `"[product name]" "[wrong category]"` — e.g. an API being called a "no-code tool"
+- **Capability inflation:** `"[product name]" "[feature it doesn't have]"`
+- **Capability deflation:** `"[product name]" "only" OR "just" OR "limited to"`
+- **Wrong comparisons:** `"[product name]" vs "[wrong competitor]"`
+- **Attribution errors:** `"[product name]" "[wrong company name]"`
+- **Spread check:** re-run any confirmed wrong claim as its own query — `"[product name]" "[wrong claim]"` and `"[product name]" site:reddit.com "[wrong claim]"` — to see who else is citing it
+
+---
+
+## Tier 6 — Consumer & app-specific sources
+
+Add for consumer launches (apps, hardware, consumer software); skip for pure B2B/developer tools.
+
+- **App stores:** `"[product name]" site:apps.apple.com` / `site:play.google.com` — check the recent-reviews tab directly; 1-star reviews after an update flag regressions before press notices, and platform-specific issues surface here first
+- **Podcasts:** `"[product name]" podcast OR episode site:open.spotify.com OR site:podcasts.apple.com` — major tech podcasts shape consumer narrative
+- **Product Hunt:** `"[product name]" site:producthunt.com` — launch-day comments and "alternatives to" pages
+- **Ecosystem forums:** Apple → `site:forums.macrumors.com`, `site:9to5mac.com`, `site:appleinsider.com`; Android → `site:androidpolice.com`, `site:9to5google.com`; gaming → `site:resetera.com`, `r/gaming`
+
+---
+
+## Alternate name resolution — query patterns
+
+Run before asking the user anything; fold every confirmed variant into the query lists above.
+
+- `"[product name]" codename OR "internal name" OR "project name"`
+- `"[product name]" "formerly known as" OR "previously called" OR rebranded`
+- `"[company name]" "[product category]" names OR versions`
+- Hardware: search both the marketing name and the internal model identifier
+- AI products: check API name, model name, and consumer-facing name separately — they are often different
+- Software: check the GitHub repo name, package name, and SDK name

--- a/skills/alon-goldenberg/launch-monitor/references/triage.md
+++ b/skills/alon-goldenberg/launch-monitor/references/triage.md
@@ -1,0 +1,89 @@
+# Triage rubric — urgency, action badges, mischaracterization records
+
+Apply to every signal, every run. A signal without all four labels (urgency, action, type, exact URL) is not done being triaged.
+
+---
+
+## Urgency levels
+
+- 🔴 **Act now** — a mischaracterization going viral, high-reach negative coverage, a competitor counter-announcement, or a crisis-shaped signal. The team should see it today.
+- 🟡 **Monitor** — an emerging negative theme, mid-reach inaccurate coverage, competitor positioning content. Track for escalation; no action yet.
+- 🟢 **Good signal** — accurate positive coverage, organic enthusiasm, adoption signals. Candidates for amplification.
+- ⬜ **Noise** — irrelevant mentions, same-name products, spam. Filtered by the materiality threshold below; never shown in the main feed.
+
+Urgency is a function of **reach × wrongness × velocity**, not tone alone. A scathing post with 12 views is Monitor at most; a politely wrong claim in a high-reach outlet is Act now.
+
+### Reach heuristics (when platforms don't publish numbers)
+
+- Hacker News: 50+ comments = high priority; front page = treat as press-tier reach
+- X: 100+ likes within 24h = meaningful; quote-posted by a journalist or known account = escalate a level
+- Reddit: top-of-subreddit in a large sub, or 100+ upvotes = meaningful; comment depth signals real engagement over drive-by voting
+- YouTube/TikTok: view velocity in the first 48h matters more than the absolute count
+- Press: use the outlet's typical audience as a proxy; secondary pickup (another outlet citing the piece) is worth more than raw readership
+- State reach as an estimate ("~50K readers", "front page of HN") and mark it unverified when you could not confirm it
+
+---
+
+## Action badges
+
+- `RESPOND` — needs a direct public response: a reply in the thread, a comment, press outreach
+- `CORRECT` — needs a correction or clarification: a DM, a comment, a note to the journalist
+- `AMPLIFY` — worth sharing, reposting, or building on
+- `ESCALATE` — belongs with comms, legal, or leadership — not with whoever is watching the feed
+- `WATCH` — no action yet; track for escalation and name what would trigger it
+- `IGNORE` — filtered noise (record it in the appendix, not the feed)
+
+Every RESPOND/CORRECT badge must come with a *specific* suggested action — the actual sentence to post and where to post it. "Consider responding" is not an action. All suggested actions are drafts for a human to approve and send.
+
+## Signal types
+
+Press coverage · Community discussion · Social mention · Competitor move · Mischaracterization · Churn signal · Influencer take · Developer reaction · Analyst comment
+
+---
+
+## Source URL — required for every signal
+
+Every signal carries the **exact URL** of the specific article, thread, or post, exactly as the search tool returned it.
+
+Correct:
+- `https://techcrunch.com/2026/06/11/example-product-launch`
+- `https://news.ycombinator.com/item?id=12345678`
+- `https://reddit.com/r/MachineLearning/comments/abc123/thread_title`
+- `https://x.com/[username]/status/[POST_ID]`
+
+Wrong — never use: `https://techcrunch.com`, `https://news.ycombinator.com`, `https://reddit.com`, `https://x.com`. A homepage link is useless to the reader, and a fabricated deep link is worse than no link — if you don't have the exact URL, say so on the card.
+
+---
+
+## Mischaracterization record — six fields, all required
+
+For every piece of coverage that gets something wrong:
+
+1. **The claim** — exactly what was said, quoted
+2. **The source** — outlet, author, reach estimate, date
+3. **What's wrong** — the specific inaccuracy, not a vibe
+4. **The correct version** — the accurate statement, checkable against the announcement
+5. **Spread risk** — search for secondary coverage citing the wrong claim before assigning this; "is being picked up" requires found evidence
+6. **Suggested response** — a one-sentence, copy-ready correction
+
+### Status badges
+
+- `SPREADING` — found in 2+ independent sources, or being cited/quoted onward
+- `CONTAINED` — single source, no secondary pickup found
+- `CORRECTED` — the source amended it, or the correction is visibly winning in the thread
+
+Status drives urgency more than the original outlet's size: a small blog's wrong claim that three other places are citing outranks a big outlet's wrong claim nobody repeated. A mischaracterization stays on the tracker across re-runs until its status is CORRECTED — carry it forward even when no new coverage mentions it.
+
+---
+
+## Materiality threshold
+
+Skip entirely (don't triage, don't count):
+- Clearly a different product with the same name (the context profile is the filter)
+- Automated bots or spam accounts
+- Duplicate coverage with no new information — syndicated wire copy counts once, at the original
+- Single-digit reach with no amplification potential
+
+Flag but don't prioritize:
+- Neutral coverage that accurately describes the product
+- Positive signals that need no action


### PR DESCRIPTION
## What this skill does

Launch-window response war room: tiered press/community/social/competitor sweeps, a targeted mischaracterization hunt with copy-ready corrections and spread tracking (SPREADING/CONTAINED/CORRECTED), sentiment velocity, and urgency-triaged signal cards with exact source URLs. All responses stay drafts until a human approves.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
