### PR TITLE
add market-finder

### DIFF
--- a/skills/alon-goldenberg/market-finder/SKILL.md
+++ b/skills/alon-goldenberg/market-finder/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: market-finder
+title: Market finder
+description: |
+  Use this skill when you need to enumerate every business of a given type in a
+  geography — "find all X in Y", "build a list of", "market sizing", "account
+  universe", "how many X in Y", "TAM for", "discover all", "prospect list" — or
+  when you already have a list and want it checked: "audit my list", "compare
+  against", "what am I missing", "gap analysis", "verify my business list".
+  Produces a deduplicated, source-linked market inventory with a confidence
+  score per entity; in audit mode, a three-way comparison of your list against
+  fresh discovery (matched / discovered-only / reference-only) with a coverage
+  score. Not for monitoring known competitors over time or deep-diving a single
+  company — this play is for mapping a whole market.
+category: Prospecting
+tags: [Sales]
+---
+
+# Market finder
+
+Runs when someone needs the full universe of businesses of one type in one geography — for territory planning, TAM sizing, list building, or checking an existing account list for gaps.
+
+Produces a deduplicated entity list with per-entity strength scores and mandatory source links; in audit mode, your list categorized against fresh discovery with a coverage percentage.
+
+## The play
+
+### 1. Detect the mode
+
+Two modes, and the difference is whether the user handed you a list:
+
+| Signal | Mode |
+|--------|------|
+| Spreadsheet link, CSV file, or inline list of 3+ businesses | **Audit** |
+| Explicit audit language ("audit my list", "compare against", "gap analysis") | **Audit** |
+| No reference list | **Discovery** (default) |
+
+If a list is present but intent is ambiguous, ask: "Want me to audit your list against fresh discovery, or use it as a starting point?" If audit language appears but no list does, ask for the list — never run an audit against an imagined reference.
+
+### 2. Scope the request
+
+Extract: business type (required), geography (required — except software/SaaS markets, which are not geography-bound), qualification criteria (optional: "must have a website", "10+ reviews"), and depth. If type and geography are both clear, confirm in one line and go; if not, ask one combined question — never a drip of clarifications.
+
+Two depth modes: **quick scan** (one discovery pass over all sources, enrich only the top 5, verify only the top 5) and **comprehensive** (all sources with retries, full enrichment, verify everything). Default to quick scan unless the user signals they want the complete universe.
+
+### 3. Load the vertical preset
+
+Read `references/vertical-presets.md` and match the business type against preset trigger keywords (Healthcare, SaaS/Software, Restaurants, Legal/Financial, Auto/Home Services, Custom fallback). The preset tells you which sources to search, in what priority order, what query pattern to use per metro, and whether the vertical is geographic at all. A partial match gets confirmed ("This looks like Healthcare — use healthcare sources?"); no match falls through to the Custom preset with the user's own keywords.
+
+### 4. Tile the geography
+
+Skip for SaaS. Otherwise:
+
+| Geography | Tiling |
+|-----------|--------|
+| City | Single query set |
+| Metro area | Single query set per source |
+| State | Top 5–10 metros in the state |
+| Region | States, then top metros per state |
+| Nationwide | All states, then top metros per state |
+
+Estimate the total work before starting: `metros × discovery sources × (1 + ~0.3 enrichment ratio)`. A nationwide comprehensive run is thousands of lookups — state the estimate and get an explicit go-ahead before launching anything that large. Derive a market slug (`dentists-florida`, `hvac-nationwide`) and keep a working file per slug in your workspace; save intermediate results after each phase so a long run can resume instead of restarting, and so a repeat run can load prior entities and only chase what's new (new metros, new entrants) rather than re-discovering everything.
+
+### 5. Discover
+
+For each metro in the tiling plan, run the preset's discovery queries against its sources in parallel — primary source first (maps-style listings), secondary (review directories), tertiary only when the first two return fewer than ~10 combined unique results for that metro. When a structured source is unavailable or fails, fall back to a plain web search for `"{type} in {metro}"` — partial data beats none; never abort a whole run for one empty metro.
+
+SaaS discovery is different: two parallel search passes, no geography. Pass 1 finds the players (software review directories, "best {vertical} software" roundups, launch platforms, open-source repos); pass 2 finds the money (funding databases, funding news, market-landscape pieces). Pass 2 is not optional — without it, funding and traction data will be missing or wrong.
+
+Then deduplicate in strict key order: place identifier → root domain → fuzzy name + city. Merge fields across sources into one record per entity and track `source_count` — how many independent sources found it. That count is the backbone of scoring.
+
+### 6. Enrich and verify
+
+Enrich highest-`source_count` entities first, using the preset's enrichment targets (review volume, accreditation, complaint history, funding profile). Skip entities missing the identifier the enrichment source needs.
+
+For SaaS, run a financial verification pass on top entities: search `"{company} funding raised series"` and use only sourced amounts and dates. **No source found → report "Undisclosed."** Never guess "early stage" or "bootstrapped" — an unverified funding label is worse than an honest blank.
+
+### 7. Score
+
+Strength is earned by independent corroboration, not by any single listing:
+
+Geographic verticals — **High:** 3+ sources, or 2+ sources with >50 reviews. **Medium:** 2 sources, or 1 source with >10 reviews. **Low:** 1 source, few/no reviews.
+
+SaaS — **High:** verified funding >$10M, or 3+ directory sources, or 1000+ reviews on a major software directory. **Medium:** verified funding <$10M, or 2 sources, or 100+ reviews. **Low:** 1 source, no verified funding.
+
+### 8. Audit comparison (audit mode only)
+
+Read `references/audit-mode.md` for the full parsing rules, normalization, and matching algorithm. In short: normalize every reference record to `{name, domain, city, state, phone}`, then match in three layers — exact root-domain, fuzzy name + same city at an 80% word-overlap threshold, then normalized phone. First match wins; record which layer matched. Categorize everything as `matched`, `discovered_only` (expansion candidates), or `reference_only` (coverage gaps), and compute the coverage score: `matched / reference_count × 100`. A 0% score is a valid, informative result — report it, don't retry until it looks better.
+
+### 9. Report
+
+Follow `references/output-formats.md` — discovery format, SaaS tier-grouped variant, and audit variant. Non-negotiable: **every entity carries at least one clickable source URL.** Save the report and the structured entity data to the market slug's workspace files, then offer natural follow-ups: filter, expand geography, export the discovered-only set for outreach, or investigate reference-only gaps to see who closed, moved, or rebranded.
+
+## What good looks like
+
+- The best operator scopes cost before spending it: the nationwide estimate is on the table before the first query fires, and the user chose comprehensive knowingly. The mediocre version discovers halfway through that the job is 10× bigger than anyone wanted.
+- Strength scores mean something: a High entity was independently confirmed by multiple sources, not enthusiastically listed once. If most of your list is single-source Low, say so in "What's missing" instead of dressing it up.
+- SaaS funding claims all trace to a source or read "Undisclosed". The mediocre version copies a stale directory figure and labels a Series C company "early stage".
+- In audit mode, the interpretation earns the run: "82% coverage; your gaps cluster in Orlando; three reference-only entries appear to have closed" — not just three tables.
+- Dedup held: no business appears twice under name variants, because domain matching ran before fuzzy names and suffixes ("LLC", "Associates", "DDS") were stripped before comparing.
+- A repeat run surfaces the delta — new metros, new entrants — instead of re-presenting last month's list as fresh discovery.
+
+## Rules
+
+- MUST attach at least one source URL per entity in every output. An entity nobody can verify doesn't ship.
+- MUST get explicit approval before launching a large run (nationwide or multi-state comprehensive), and before any bulk export intended for outreach.
+- MUST deduplicate in key order (place identifier → domain → fuzzy name+city) before scoring — scores on a duplicated list are fiction.
+- MUST report unverifiable funding as "Undisclosed". NEVER fabricate or infer a funding stage.
+- NEVER run audit mode without an actual reference list in hand.
+- NEVER abort an entire discovery run because one metro or one source returned nothing — log the gap and continue.
+- NEVER present a stale prior run as fresh discovery; either refresh it or label its date.

--- a/skills/alon-goldenberg/market-finder/references/audit-mode.md
+++ b/skills/alon-goldenberg/market-finder/references/audit-mode.md
@@ -1,0 +1,161 @@
+# Audit mode
+
+Compares a user's existing business list against fresh discovery results, surfacing gaps in both directions. Read this when a reference list is in play.
+
+---
+
+## When audit mode triggers
+
+| Signal | Example |
+|--------|---------|
+| Spreadsheet link in the request | a shared Google Sheet or similar |
+| CSV file path | `my-practices.csv`, a downloads-folder file |
+| Inline list (3+ businesses) | pasted names/addresses, one per line |
+| Explicit audit language | "audit my list", "compare against", "what am I missing" |
+
+A list without stated intent gets one question: "Want me to audit it against fresh discovery, or just use it as a starting point?" Audit language without a list gets a request for the list — never proceed on an imagined reference.
+
+---
+
+## Reference list parsing
+
+Detect the format, extract the rows, then normalize every record to a uniform shape.
+
+**Spreadsheet:** extract the sheet as a table. Map columns by header name, case-insensitive:
+
+| Target field | Accepted column headers |
+|--------------|------------------------|
+| `name` | name, business name, practice name, company, organization |
+| `domain` | domain, website, url, web, site |
+| `city` | city, location, metro, area |
+| `state` | state, st, region |
+| `phone` | phone, telephone, tel, phone number |
+| `address` | address, street, full address |
+
+**CSV:** read the file, same column mapping.
+
+**Inline list:** parse each line — business name is the first segment before any delimiter; pull city/state, domain, or phone if present. If the format is unclear, ask once: "What columns does your list have? (e.g. name, city, phone)"
+
+**Normalized record:**
+
+```json
+{
+  "name": "Acme Dental",
+  "domain": "acmedental.com",
+  "city": "Miami",
+  "state": "FL",
+  "phone": "3051234567",
+  "raw": "original row as-is, for traceability"
+}
+```
+
+- **Domain:** strip protocol, `www.`, trailing `/`, and path segments
+- **Phone:** strip all non-digits; keep the last 10 digits (US) or the full international number
+- **Name:** trim whitespace; preserve original casing for display
+- **Missing fields:** set to `null` — matching layers skip null fields
+
+**Failure handling:** if extraction returns garbage or the CSV is malformed, ask the user to paste the data inline. If the parsed list has zero valid records, warn and offer to switch to plain discovery.
+
+---
+
+## Matching algorithm
+
+Three layers, in order. Once an entity matches at any layer, stop — don't re-match at lower layers. Track which layer produced each match; it's reported per row.
+
+### Layer 1 — domain match (primary)
+
+Compare normalized root domains.
+
+```
+reference: acmedental.com  ↔  discovered: acmedental.com   →  MATCH
+reference: acmedental.com  ↔  discovered: acme-dental.com  →  NO MATCH
+```
+
+Root domain only (not subdomains). Exact match required — no fuzzy domain matching, ever: near-miss domains are usually different businesses. Skip pairs where either side has `domain: null`.
+
+### Layer 2 — name + city fuzzy match (secondary)
+
+For entities unmatched after Layer 1, compare names within the same city.
+
+Normalization: lowercase both names; remove punctuation (`.,'-&!()[]`); remove common suffixes (`inc`, `llc`, `ltd`, `corp`, `co`, `pllc`, `pa`, `pc`, `dds`, `md`, `dmd`, `do`, `group`, `associates`, `and associates`); split into word tokens.
+
+Matching: both entities must share the same city (case-insensitive, trimmed). Word overlap = `shared_words / max(words_a, words_b)`. **Threshold: 80% overlap = match.**
+
+```
+"Acme Dental Associates" in Miami  ↔  "Acme Dental" in Miami
+  → tokens [acme, dental] vs [acme, dental]  → 100%  → MATCH
+
+"Acme Dental" in Miami  ↔  "Acme Health" in Miami
+  → tokens [acme, dental] vs [acme, health]  → 50%   → NO MATCH
+```
+
+Skip pairs where either side has `city: null`.
+
+### Layer 3 — phone match (tertiary)
+
+For still-unmatched entities, compare normalized phones (non-digits stripped, last 10 digits).
+
+```
+reference: (305) 123-4567  →  3051234567
+discovered: 305-123-4567   →  3051234567  →  MATCH
+```
+
+Skip pairs where either side has `phone: null`.
+
+---
+
+## Categorization
+
+| Category | Definition | Business meaning |
+|----------|-----------|------------------|
+| `matched` | In both reference list AND discovery | Validated — the list is accurate here |
+| `discovered_only` | Found by discovery, NOT in reference list | Expansion candidates — gaps in the user's list |
+| `reference_only` | In reference list, NOT found by discovery | Coverage gaps — may have closed, moved, rebranded, or be missed by sources |
+
+**Coverage score:** `matched / reference_count × 100`. Zero matches across all three layers is a valid result — report the 0% honestly; it usually means the list and the discovery scope describe different markets, which is itself the finding.
+
+---
+
+## Output template
+
+```markdown
+# Market Audit: [Business Type] in [Geography]
+*Audited [R] reference entries against [D] discovered businesses | [Date]*
+
+## TL;DR
+[M/R × 100]% coverage — [M] of [R] reference entries verified, [DO] new
+businesses discovered, [RO] in your list but not found by discovery.
+
+## Summary
+- **Reference list:** [R] entries
+- **Discovered:** [D] businesses
+- **Matched:** [M] ([M/R]% of reference list verified)
+- **Discovered only:** [DO] expansion candidates
+- **Reference only:** [RO] coverage gaps
+
+## Matched ([M])
+| # | Name | Location | Match Layer | Discovery Strength | Sources |
+|---|------|----------|-------------|--------------------|---------|
+
+## Discovered Only ([DO]) — Expansion Candidates
+| # | Name | Location | Domain | Rating | Strength | Sources |
+|---|------|----------|--------|--------|----------|---------|
+
+## Reference Only ([RO]) — Coverage Gaps
+| # | Name | Location | Domain | Phone | Possible Reason |
+|---|------|----------|--------|-------|-----------------|
+
+## What This Means
+[1–3 sentences of interpretation — the coverage percentage in plain terms,
+geographic clusters in discovered_only, notable reference_only entries.]
+```
+
+Save the report plus a structured data file (all three categories, with match layer per entity) under the market slug in your workspace — the structured file is what downstream exports and follow-up investigations read.
+
+---
+
+## Follow-ups to offer
+
+- **Export discovered-only for outreach** — a CSV of expansion candidates. Confirm before generating anything intended for bulk outreach.
+- **Investigate reference-only gaps** — targeted searches per entity to determine closed vs. moved vs. rebranded vs. simply unlisted.
+- **Re-run against a different geography** — same list, broader or narrower area.

--- a/skills/alon-goldenberg/market-finder/references/output-formats.md
+++ b/skills/alon-goldenberg/market-finder/references/output-formats.md
@@ -1,0 +1,73 @@
+# Output formats
+
+Three output shapes: discovery (geographic verticals), the SaaS variant, and — for audit mode — the template in the audit reference. Every entity row in every format carries at least one clickable source URL (map listing, review page, website, registry profile, software-directory page, or code repository). An entity without a verifiable source doesn't ship.
+
+---
+
+## Discovery output (geographic verticals)
+
+```markdown
+# Market Finder: [Business Type] in [Geography]
+*Found [N] businesses | [Date] | Strength: [H] High, [M] Medium, [L] Low*
+
+## Summary
+- **Total discovered:** [N] unique businesses across [M] metros
+- **Geographic breakdown:** [top 5 metros by count]
+- **Source coverage:** [each source used, with entity counts]
+
+## Top Results (High Strength)
+| # | Name | Location | Rating | Reviews | Strength | Sources |
+|---|------|----------|--------|---------|----------|---------|
+| 1 | Acme Dental | Miami, FL | 4.8 | 312 | *** High | Maps, Yelp, BBB |
+
+## All Results by Geography
+### [Metro 1] ([n] businesses)
+[table]
+### [Metro 2] ([n] businesses)
+[table]
+
+## What's Missing
+[Data gaps, honestly: metros with low coverage, entities without websites,
+sources that failed or returned thin results, anything skipped in quick scan.]
+```
+
+Strength displays as `*** High`, `** Medium`, `* Low`. The "What's Missing" section is mandatory — a market inventory that hides its own blind spots gets trusted for decisions it can't support.
+
+---
+
+## SaaS variant
+
+Same header and summary; replace "All Results by Geography" with tier grouping. The tiers are a positioning statement, not a size ranking — a small pure-play outranks a giant with a feature.
+
+```markdown
+## Players by Tier
+
+### Pure-Play (dedicated to this vertical)
+| # | Name | Domain | Funding | Key Metric | Strength | Sources |
+|---|------|--------|---------|------------|----------|---------|
+
+### Adjacent (feature overlap from larger platforms)
+| # | Name | Domain | Funding | Key Metric | Strength | Sources |
+|---|------|--------|---------|------------|----------|---------|
+
+### Open Source
+| # | Name | Repo | Stars | Key Metric | Strength | Sources |
+|---|------|------|-------|------------|----------|---------|
+```
+
+Funding column rules: sourced amount + date, or the word "Undisclosed". No inferred stages, no directory figures that failed verification. "Key Metric" is whatever best evidences traction for that entity (review count, notable customers, stars, seats) — with its source.
+
+---
+
+## Delivery conventions
+
+- **Full output** goes to the user and to the market slug's workspace files (rendered output + structured entity data), so the next run can diff instead of rediscover.
+- **Summaries for chat channels:** total count plus the top 10 entities only — never paste hundreds of rows into a channel.
+- **CSV export:** offer, don't assume; generate from the structured entity file, and confirm before producing anything destined for bulk outreach.
+
+## Follow-ups to offer (discovery mode)
+
+- **"Tell me more about #N"** — full detail for one entity from the structured data
+- **"Filter by [criteria]"** — re-filter existing results, no new discovery
+- **"Expand to [new geography]"** — add metros, run discovery only for the new tiles, merge and re-dedup
+- **"Audit against my existing list"** — switch to audit mode using this run's results as the discovery side

--- a/skills/alon-goldenberg/market-finder/references/vertical-presets.md
+++ b/skills/alon-goldenberg/market-finder/references/vertical-presets.md
@@ -1,0 +1,128 @@
+# Vertical presets
+
+Each preset defines the trigger keywords that select it, the discovery sources in priority order, the enrichment targets, and the query pattern. Match the user's business type against trigger keywords; a clear match loads the preset, a partial match gets confirmed with the user, no match falls through to Custom.
+
+Source tiers matter: run primary and secondary for every metro; add the tertiary source only when primary + secondary return fewer than ~10 combined unique results for that metro. When a structured source is unavailable, substitute a plain web search for the same query — don't skip the metro.
+
+---
+
+## Healthcare
+
+**Trigger keywords:** doctor, dentist, dermatologist, ophthalmologist, optometrist, chiropractor, therapist, psychiatrist, pediatrician, clinic, medical, healthcare, hospital, pharmacy, urgent care, physical therapy, orthodontist, surgeon, physician, practice, practitioner
+
+**Discovery sources:**
+
+| Source | Tier | Purpose |
+|--------|------|---------|
+| Map/local listings (e.g. Google Maps) | Primary | Geo-targeted discovery — best coverage of physical practices |
+| Review directories (e.g. Yelp) | Secondary | Catches practices missing from map listings |
+| Accreditation registries (e.g. BBB) | Tertiary | Credibility and complaint data |
+
+**Enrichment:** review volume and sentiment from map listings; accreditation status and complaint history from registry profiles.
+
+**Query pattern:** `"{specialty} {type}" in {metro}` — e.g. `ophthalmologist in Miami FL`, `dentist in Tampa FL`.
+
+**Geo-tiling:** yes — tile by metro areas within the target state/region.
+
+**Disambiguation note:** "practice" alone is ambiguous (medical / dental / legal) — ask before assuming.
+
+---
+
+## SaaS / Software
+
+**Trigger keywords:** SaaS, software, app, platform, tool, cloud, B2B, startup, project management, CRM, ERP, analytics, automation, API, fintech, martech, edtech, healthtech, devtools, developer tools, productivity software
+
+**Discovery:** no map sources. Two search passes, run in parallel:
+
+**Pass 1 — product discovery** (find the players):
+- `{vertical}` restricted to major software review directories (e.g. `site:g2.com`, `site:capterra.com`)
+- `best {vertical} software {current year}` — roundups and comparison articles
+- `{vertical}` on launch platforms (e.g. `site:producthunt.com`)
+- `{vertical} open source github` — the open-source contingent
+
+**Pass 2 — financial & traction discovery** (funding, market context):
+- `{vertical}` restricted to funding databases (e.g. `site:crunchbase.com`)
+- `{vertical} startup funding raised` — news-focused search
+- `{vertical} market landscape players` — analyst and landscape pieces
+
+Pass 2 is critical: without it, funding and traction data will be missing or wrong, and the tier grouping in the report collapses.
+
+**Enrichment:** structured product data, ratings, and pricing tier from software directories; funding rounds, valuation, and team size from funding databases.
+
+**Geo-tiling:** no — software markets are not geography-bound. If the user names a region, interpret it as "headquartered in" and add it as a search qualifier, not a tiling plan.
+
+**Dedup key:** root domain (there is no place identifier).
+
+**Verification:** every funding figure needs its own source check before it appears in output — search `"{company} funding raised series"`, use only sourced amounts and dates, otherwise report "Undisclosed".
+
+---
+
+## Restaurants / Food
+
+**Trigger keywords:** restaurant, cafe, coffee, bakery, bar, pub, brewery, pizza, sushi, taco, brunch, diner, bistro, food, catering, food truck, ice cream, juice, steakhouse, seafood, burger, ramen, pho, thai, italian, mexican, chinese, indian, mediterranean, vegan, vegetarian
+
+**Discovery sources:**
+
+| Source | Tier | Purpose |
+|--------|------|---------|
+| Map/local listings | Primary | Geo-targeted discovery |
+| Review directories | Secondary | Especially strong for food and drink |
+
+**Enrichment:** review volume and rating from map listings.
+
+**Query pattern:** `"{cuisine} restaurant" in {metro}`.
+
+**Geo-tiling:** yes — metros, or neighborhoods for dense large-city runs.
+
+---
+
+## Legal / Financial
+
+**Trigger keywords:** lawyer, attorney, law firm, legal, accountant, accounting, CPA, financial advisor, wealth management, insurance, tax, bankruptcy, immigration, personal injury, real estate attorney, family law, criminal defense, corporate law, patent, IP, intellectual property
+
+**Discovery sources:**
+
+| Source | Tier | Purpose |
+|--------|------|---------|
+| Map/local listings | Primary | Geo-targeted discovery |
+| Accreditation registries | Secondary | Accreditation and complaint history |
+
+**Enrichment:** accreditation status, years in business, complaint history from registry profiles.
+
+**Query pattern:** `"{practice area} {type}" in {metro}` — e.g. `immigration attorney in Austin TX`.
+
+**Geo-tiling:** yes — metros within the target state/region.
+
+---
+
+## Auto / Home Services
+
+**Trigger keywords:** mechanic, auto repair, body shop, car wash, oil change, tire, plumber, plumbing, electrician, HVAC, roofing, landscaping, pest control, cleaning, maid service, handyman, locksmith, moving, storage, painting, flooring, contractor, renovation, remodeling, garage door, appliance repair
+
+**Discovery sources:**
+
+| Source | Tier | Purpose |
+|--------|------|---------|
+| Map/local listings | Primary | Geo-targeted discovery |
+| Review directories | Secondary | Strong for home services |
+| Accreditation registries | Tertiary | Complaint history — matters more in this vertical than most |
+
+**Enrichment:** review volume and sentiment; complaint history and years in business from registry profiles.
+
+**Query pattern:** `"{service}" in {metro}`.
+
+**Geo-tiling:** yes — by metro.
+
+---
+
+## Custom (fallback)
+
+Used when no other preset matches.
+
+**Discovery sources:** map/local listings (primary), review directories (secondary).
+
+**Enrichment:** review volume and rating.
+
+**Query pattern:** the user's own keywords per metro.
+
+**Geo-tiling:** yes, unless the query is clearly non-geographic — in which case borrow the SaaS shape: two search passes, dedup by domain, no tiling.


### PR DESCRIPTION
## What this skill does

Market enumeration: every business of a type in a geography (or the SaaS landscape, geography-free), via vertical source presets, geographic tiling with an upfront cost estimate and approval gate, strict dedup key order, and corroboration-based strength scoring. Audit mode three-way-compares an existing list against fresh discovery with a coverage score.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
