### PR TITLE
add seo-intel

### DIFF
--- a/skills/alon-goldenberg/seo-intel/SKILL.md
+++ b/skills/alon-goldenberg/seo-intel/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: seo-intel
+title: SEO intel
+description: |
+  Use this skill when you need SEO answers grounded in live data instead of a tool's
+  guessed metrics: keyword research, rank checks, a technical site audit, content gap
+  analysis against competitors, reverse-engineering a competitor's on-page strategy, or
+  an AI-visibility audit of how often AI assistants mention and cite your brand.
+  Produces an evidence-backed report per play — every keyword, gap, finding, and score
+  traceable to a real search result or extracted page. Covers "what should we rank
+  for", "why did rankings move", "SEO audit", "technical SEO", "keyword difficulty",
+  "topic clusters", "content gap", "competitor keywords", "SERP analysis", "AI
+  visibility", "AI citation audit", "AEO", "GEO", and "do AI Overviews mention us".
+category: SEO
+tags: [Marketing]
+---
+
+# SEO intel
+
+Runs whenever an SEO question needs a live-data answer: what to rank for, what is technically broken, what competitors cover that you don't, whether AI assistants cite you. Produces one report per play, with every claim tied to an observed search result or extracted page.
+
+## Ground rules
+
+- **Only observed evidence.** Every difficulty score, gap, and finding must trace to a real search result or a page you actually extracted. Never quote search volume, domain authority, or traffic numbers you did not measure — if a metric is unavailable, say "not measurable" instead of inventing it.
+- **Source URL on every row.** Every keyword opportunity, content gap, and AI citation in a report carries the URL that proves it.
+- **Partial data is reported as partial.** If a platform was unreachable or a crawl came back incomplete, score from what returned and state the coverage gap. Never backfill.
+
+## Route the request
+
+| The user wants | Play | Read first |
+|---|---|---|
+| Keywords to target, topic clusters, difficulty | Keyword research | `references/serp-and-keywords.md` |
+| Current positions, ranking movement | Rank check | `references/serp-and-keywords.md` |
+| Technical/on-page health, "SEO audit" | Site audit | `references/site-audit-checks.md` |
+| Topics competitors cover that they don't | Content gap | `references/content-gaps.md` |
+| A competitor's on-page playbook at scale | Competitor reverse-engineering | `references/content-gaps.md` |
+| Brand presence in AI answers, AEO/GEO | AI visibility | `references/ai-visibility.md` |
+
+If the request is generic ("help me with SEO"), ask which of these they need — don't guess. After finishing one play, suggest the natural next one (audit → keyword research → content gap → rank check), carrying forward the domains, keyword lists, and crawl data already gathered instead of re-collecting.
+
+## Running memory and delta modes
+
+Keep a running file per domain (and per brand, for AI visibility) in your workspace: audit findings, rank snapshots, gap lists, AI-citation snapshots — dated, structured, append-only. On every run, load the prior snapshot first and pick a mode:
+
+- **Full mode** — first run, or the last run is more than 14 days old. Report the whole landscape as a baseline.
+- **Delta mode** — a snapshot exists from the last 14 days. Diff against it and lead with what changed: new gaps, resolved findings, position movers, citations gained or lost. Unchanged items go to an appendix, not the summary.
+- **Same-day repeat** — a report from today already exists. Ask before re-running; don't silently burn a second pass on identical data.
+
+Delta framing is the discipline that keeps repeat reports readable: the executive summary carries only NEW and WORSENED items, resolved items are noted as wins, and everything else stays in the breakdown sections.
+
+## The plays
+
+**Keyword research.** Expand the user's topic into 15–25 seed variations (modifiers, long-tail questions, commercial variants, adjacent concepts), sweep the live results page for each, and score what you actually see: who ranks, how deep their content is, which result-page features appear. Classify intent and AI-surface type from the result-page composition — not intuition — then cluster into pillars and rank by `(relevance x intent value) / difficulty` into Quick Wins, Growth Targets, and Moonshots. Rubrics, formulas, and the report format are in `references/serp-and-keywords.md`.
+
+**Rank check.** Normalize each keyword, search it, and match the target domain against the top 20 organic results by root domain — recording the first (highest) match. Snapshot every run; on re-runs compute deltas and classify moves (major / notable / stable / new entry / drop-out). For unranked keywords, still record which result-page features appeared and who holds the top spots. Query normalization, domain-matching, feature taxonomy, and delta thresholds are in `references/serp-and-keywords.md`.
+
+**Site audit.** Map the site (sitemap included, so orphans surface), sample pages representatively — homepage, primary landing pages, a cross-section per section, paginated pages, a few sitemap-only orphans — and extract each page's head metadata and body content, escalating to JS rendering when extraction comes back empty. Run the seven check categories (meta tags, headings, schema, internal links, content quality, technical foundations, observational Core Web Vitals), tag each finding with a severity and a confidence tier, dedup against the prior audit, and grade overall health A–F. The full rule set with thresholds lives in `references/site-audit-checks.md` — run the checks from that page, not from memory.
+
+**Content gap.** Map your site and 1–3 competitor sites in parallel, extract every page's topics, and build a coverage matrix: topic clusters as rows, domains as columns. A gap is a topic where a competitor has pages and you have none — or your coverage is under 30% of their depth. Then validate each gap against live search results before recommending it: a competitor page that doesn't rank is a much weaker signal than one in the top 10. Score by `(rank strength x relevance) / effort` and bucket into Quick Wins, Strategic Bets, Nice-to-Have. Full logic in `references/content-gaps.md`.
+
+**Competitor reverse-engineering.** Crawl a competitor's site at scale and read their strategy out of the on-page elements: keyword themes from titles/H1s/H2s, hub-and-spoke structures from body-only internal anchors, title formulas, publishing velocity, meta-description CTAs. The filtering rules that keep this honest (boilerplate H2 and anchor stripping, exact-URL hub matching) are in `references/content-gaps.md`.
+
+**AI visibility.** Build 20–40 queries a buyer would actually ask an AI assistant, run each against the AI platforms you can reach (asked as natural questions, not keyword strings), and analyze each answer for brand mentions, domain citations, sentiment, and competitor presence — with a false-positive guard for common-word brand names. Compute visibility score, share of AI voice, and citation rate; the competitor-visible-you-absent queries are the priority list. Then recommend fixes from the measured GEO methods (citations, statistics, quotations lead) and check that AI crawlers aren't blocked in robots.txt — if bots can't crawl, nothing else matters. Detection rules, scoring formulas, per-platform profiles, and the GEO playbook are in `references/ai-visibility.md`.
+
+## What good looks like
+
+- The best operator reads the results page before scoring anything: difficulty comes from who actually ranks and how deep their content is; intent comes from what kind of pages Google chose to show; a gap only counts after the competitor's page was seen ranking. The evidence chain never breaks.
+- The best operator notices structure others miss: an AI Overview on a keyword changes the content recommendation; a competitor's hub page changes the effort estimate; a "brand mention" that's really a common English noun gets caught by the proximity check.
+- The mediocre version quotes difficulty scores and search volumes from nowhere, treats every competitor page as a gap without checking whether it ranks, re-reports the same 40 audit findings every run with no delta, and counts navigation links as internal-linking strategy.
+- Output is good when a stranger can verify any row of the report by opening its source URL, when a repeat run's summary contains only what changed, and when every recommendation names the specific page or query it came from.
+
+## Rules
+
+- MUST tie every reported keyword, gap, finding, and citation to a source URL or extracted page.
+- MUST load the prior snapshot before a repeat run and lead the report with deltas, not a re-baseline.
+- MUST state coverage honestly: pages that failed extraction, platforms that were unreachable, gaps that went unvalidated — all named in the report.
+- MUST ask before re-running a play already run the same day for the same target.
+- NEVER fabricate or estimate metrics you did not measure — no invented search volumes, authority scores, or traffic figures.
+- NEVER score from a stale snapshot as if it were fresh — data older than the run's window is background, not evidence.
+- NEVER let one failed extraction or unreachable platform abort a run — skip, note it, and complete the rest.

--- a/skills/alon-goldenberg/seo-intel/references/ai-visibility.md
+++ b/skills/alon-goldenberg/seo-intel/references/ai-visibility.md
@@ -1,0 +1,81 @@
+# AI visibility audit
+
+How to measure whether AI assistants mention and cite a brand, score it against competitors, and fix the gaps. Covers query design, detection rules, scoring, per-platform ranking factors, and the GEO optimization playbook.
+
+## Query set
+
+Test 20–40 queries. Sources, in order of preference: the user's own list; the brand's known industry keywords plus recent keyword-research output; or auto-discovery ("best {category}", "{category} comparison", "{category} reviews", "{brand} {category}") confirmed with the user. Phrase each query as a natural question a buyer would ask an assistant — "What is the best web scraping API?", not the keyword string "web scraping api". Keyword-style phrasing only belongs on search-box surfaces (Google AI Mode / AI Overviews).
+
+## Platforms
+
+Query every AI answer surface you can reach — typically some subset of ChatGPT, Perplexity, Google AI Overviews / AI Mode, Gemini, and Grok — capturing for each query the full answer text and the cited-source list with URLs. Also run a plain Google search per query to record whether it triggers an AI Overview (a distinct surface from AI Mode). Platform rules:
+
+- A platform that errors gets one retry, then is excluded **for that query** with the gap noted. Never fabricate an answer for an unreachable platform, and never abort the run over one platform.
+- A query with no AI answer is data, not an error — record "no AI answer present"; those queries are early positioning opportunities.
+- Compute all scores only from platforms that actually returned data, and say which were missing.
+
+## Detection rules (per query x platform)
+
+Extract: brand mention (in the answer text), domain citation (in the source list), position of first mention / ordinal position among sources, sentiment of the mention sentence (positive / neutral / negative / unknown — judge only the sentence containing the mention, default to unknown), competitor mentions, competitor domain citations, and a 1–2 sentence excerpt as evidence.
+
+- **Brand mention:** case-insensitive match on the brand name and common variants.
+- **False-positive guard for common-word brands** (e.g. a brand named "Nimble", "Notion", "Craft"): count a mention only if (a) the name appears within 5 words of a domain-relevant term, or (b) the brand's domain is also cited in the sources. A bare occurrence of the common word is generic usage — record `brand_mention: false` with a note.
+- **Domain citation:** normalize cited URLs to root domain (strip protocol, `www.`, path) before comparing against brand and competitor domains.
+- Citations placed earlier in the answer are stronger signals than late ones — record position when the platform exposes it.
+
+## Scoring
+
+- **Visibility score** = % of queries where the brand has at least one mention or citation on any platform.
+- **Share of AI voice** = brand signals (mentions + citations) / all signals including competitors' x 100. If nobody — brand or competitor — appears anywhere, set it to 0 and report "the space may not yet trigger AI answers"; never divide by zero.
+- **Citation rate** = domain citations / brand mentions. High mentions with low citations means the brand is discussed but not linked — a specific, fixable optimization target.
+- **Per-platform breakdown:** queries with an AI answer, mention count, citation count, coverage rate.
+- **Competitor gap list:** queries where a competitor appears and the brand doesn't — the highest-priority targets, each with the platform and the competitor's citation as evidence.
+
+## Delta tracking
+
+Keep a per-brand snapshot of every run (per query, per platform: answer present, mention, citation, sources). On re-runs, lead with: citations gained, citations lost, competitor movements, queries newly triggering (or losing) AI Overviews, and score deltas. First run = full baseline, no delta section.
+
+## Per-platform ranking factors
+
+Directional profiles from published research (Princeton GEO study, arXiv:2311.09735; SE Ranking's 400K-page study; ZipTie) — treat as priors to test, not gospel:
+
+- **ChatGPT:** content-answer fit dominates (~55% of citation likelihood); domain authority matters far less (~12%) than in classic SEO; fresh content is heavily favored; lists, tables, and "X is..." definitional openings get cited over prose.
+- **Perplexity:** FAQ schema is disproportionately rewarded; public PDFs get priority; publishing velocity beats keyword targeting; it prefers citing content that itself cites sources; sources appearing in the answer's first paragraph carry the most visibility value.
+- **Google AI Overviews / AI Mode:** E-E-A-T signals dominate; passage-level optimization beats page-level (the AI extracts passages); featured-snippet winners are ~2x more likely to be cited; pages ranking organically in the top 5 supply ~80% of AI Overview citations — traditional rank is still the entry ticket.
+- **Gemini:** mirrors Google AI patterns and the knowledge graph; structured-data work pays on both at once.
+- **Grok:** real-time and social signals weigh heaviest; strongest recency bias of any platform; least studied — directional only.
+- **Claude (not directly queryable):** extremely selective; factual density with specific numbers is the strongest signal; uses Brave Search for grounding, so estimate visibility via Brave rankings and confirm its crawler isn't blocked.
+
+## GEO optimization playbook
+
+Nine methods ranked by measured visibility boost (Princeton GEO study):
+
+| Method | Boost |
+|---|---|
+| Cite authoritative sources | +40% |
+| Add statistics / specific numbers | +37% |
+| Add attributed expert quotes | +30% |
+| Authoritative tone (no hedging) | +25% |
+| Easy-to-understand language | +20% |
+| Appropriate technical terms | +18% |
+| Vocabulary diversity | +15% |
+| Fluency / readability | +15–30% |
+| Keyword stuffing | **−10% — actively hurts** |
+
+Best combinations: fluency + statistics (highest overall); citations + authoritative tone (B2B); easy language + statistics (consumer). Apply the 3–4 most relevant methods per page, not all nine.
+
+**Content block sizing** — different surfaces extract at different granularities, and each block must stand alone without surrounding context:
+
+- AI-answer citations (GEO): 134–167-word self-contained passages
+- Featured snippets / PAA (AEO): 40–55-word direct answers
+- Voice: under 30 words, one clear sentence
+
+**Optimizing an existing page:** identify its target query → check which platforms currently cite it → score it against the nine methods → add the top-three methods first (citations, statistics, quotes) → restructure into surface-sized blocks → re-query after changes to measure movement.
+
+## AI crawler access — check first
+
+If AI bots can't crawl the site, no content optimization matters. Fetch `robots.txt` and check for: `GPTBot`, `ChatGPT-User`, `ClaudeBot` / `anthropic-ai`, `PerplexityBot`, `GoogleOther`, `Googlebot`. Report which are allowed vs blocked; recommend allowing all unless there is a documented reason. Also check for `/llms.txt` at the site root (llmstxt.org) — low priority, forward-looking.
+
+## Report shape
+
+TL;DR (visibility %, share of voice vs top competitor, delta line, top findings) → per-platform breakdown with top queries where the brand appears → query-level matrix (query x platform: cited / mentioned / absent) → competitor comparison table (visibility, share of voice, citation rate per brand) → optimization opportunities in three buckets: **high priority** (competitor visible, brand absent — with the specific competitor citation), **quick wins** (mentioned but not cited — earn the link), **coverage gaps** (no AI answer triggered yet — early positioning) → a GEO recommendation per high-priority gap naming the methods to apply → strategic interpretation.

--- a/skills/alon-goldenberg/seo-intel/references/content-gaps.md
+++ b/skills/alon-goldenberg/seo-intel/references/content-gaps.md
@@ -1,0 +1,89 @@
+# Content gaps and competitor pages
+
+Rules for the two competitor-facing plays: content gap analysis (what they cover that you don't, validated against live rankings) and on-page reverse-engineering (their SEO playbook read out of their pages).
+
+## Content gap analysis
+
+### Scope and crawl
+
+Compare the user's domain against 1–3 competitors. If the user can't name competitors, discover them: search "[Company] competitors", "[Company] vs", "[Company] alternatives" in parallel, propose a shortlist, confirm. Agree crawl depth up front (~50 pages per domain for a quick pass, ~200 standard, ~500 deep) and whether to scope to a section (`/blog`, `/resources`). Map all domains in parallel from their sitemaps and link graphs; if mapping fails for a domain, fall back to a `site:{domain}` search and build the page list from those results. Always keep the homepage even when scoped to a path.
+
+### Per-page extraction
+
+For every page: URL, title, meta description, H1, H2 outline, primary topic (one noun phrase), secondary topics, inferred target keywords (from title + H1 + first paragraph), word count, content type (blog post / product / landing / docs / resource / pricing / about / other), and publish date if visible.
+
+### Topic modeling and the coverage matrix
+
+1. Extract noun phrases from each page's H1, H2 outline, and primary topic.
+2. Normalize: lowercase, strip punctuation, stem ("Content Marketing Strategies" → "content marketing strategy").
+3. Cluster pages sharing a normalized primary topic or 2+ overlapping secondary topics; label each cluster with its most common noun phrase.
+4. Build the matrix — rows are topic clusters, columns are domains, cells hold page count, average word count, and whether a hub page exists (a landing/resource page with 3+ internal links to other pages in the cluster).
+
+### What counts as a gap
+
+- **Missing:** any competitor has ≥ 1 page on the topic and the user has 0.
+- **Thin:** the user's average word count on the topic is under 30% of the best competitor's.
+
+Record per gap: type, which competitors cover it, their page count and best average word count, whether they have a hub, the single best representative competitor URL, and the user's own coverage numbers.
+
+### SERP validation — the honesty step
+
+A competitor page that doesn't rank is a weak reason to write anything. Derive 2–3 representative queries per gap from the topic's H1s and keywords, then validate in two passes to control cost:
+
+- **Pass 1 (all gaps):** a light sweep to check whether the competitor's domain appears in organic results.
+- **Pass 2 (confirmed gaps only):** a deeper pass capturing AI Overview presence, Featured Snippets, and People Also Ask questions.
+
+| Competitor rank | Classification |
+|---|---|
+| Top 10 | CONFIRMED — high-value gap |
+| 11–20 | MODERATE — they rank, not dominantly |
+| Not in top 20 | LOW PRIORITY — they publish but don't rank |
+| Query returned too little data | UNVALIDATED — say so in the report |
+
+If validation covered under 50% of gaps, state it in the TL;DR ("validated N of M gaps — unvalidated gaps scored conservatively") so the tiers aren't misleading.
+
+### Gap scoring
+
+```
+score = (competitor_rank_strength x topic_relevance) / estimated_effort
+```
+
+Rank strength: CONFIRMED=3, MODERATE=2, LOW_PRIORITY=1, UNVALIDATED=1. Relevance: alignment with the user's themes and goals, High=3 / Medium=2 / Low=1. Effort: from the competitor's average word count (< 1,500 words = 1; 1,500–3,000 = 2; 3,000+ = 3), +1 if they have a hub page the user would need to match.
+
+Tiers: **Quick Wins** (low effort + CONFIRMED/MODERATE), **Strategic Bets** (high effort + CONFIRMED), **Nice-to-Have** (the rest). Sort by score within tiers.
+
+### Delta mode and report
+
+On re-runs, diff against the prior gap snapshot: **NEW** gaps lead the summary, **CLOSED** gaps are called out as wins, UNCHANGED gaps stay in the body. Report shape: TL;DR (gap count, quick-win count, biggest gap, SERP-confirmed count, delta line) → tier tables (gap topic, type, competitor coverage, their best rank, features on that results page, suggested content angle) → full coverage matrix → results-page landscape with PAA questions found → "What this means" with 30/60/90-day priorities. Every gap row carries the verified competitor URL.
+
+## Competitor on-page reverse-engineering
+
+Crawl each competitor domain at the agreed depth, classify pages into sections by path (`/product`, `/pricing`, `/blog`, `/docs`, `/customers`, `/about`), and extract per page: title, H1, meta description, H2 outline (max 10), H3–H6 outline (max 20), body-only internal anchor texts (max 50), image alt texts (max 30), word count, publish date if visible.
+
+**Body-only anchors — the rule that keeps hub detection honest:** collect internal anchors only between the H1 and the first footer marker ("Related Posts", "Subscribe", "Newsletter", a second horizontal rule). Nav, header, and footer links are boilerplate that poisons hub-and-spoke analysis.
+
+### Theme clustering
+
+Collect all titles, H1s, and H2s; normalize; and **filter boilerplate H2s before clustering** — drop generic section headers that appear across unrelated posts: conclusion, summary, introduction, overview, table of contents, FAQ(s), related posts/articles, what's next, next steps, about the author, references, sources, further reading, TL;DR, get started, try it free, contact us, share this post. Then group pages sharing 2+ overlapping content words in title + H1 + filtered H2s, aiming for 5–15 labeled themes per domain, each with its 3–5 most-repeated keyword phrases.
+
+### Hub detection (three steps, in order)
+
+1. Body-only anchor extraction (above).
+2. Strip navigation boilerplate: any anchor text appearing on more than 80% of pages ("Features", "Pricing", "Blog") is chrome, not strategy.
+3. A page is a hub if its URL appears in the body anchors of 3+ other pages in the same theme, using **exact URL equality** after normalization (strip trailing slash, fragments, tracking params). Never substring-match — `/blog` "matching" every `/blog/*` page is the classic false positive.
+
+### Pattern extraction — seven element categories
+
+- **Titles:** top 20 keywords, length distribution, truncation rate (% over 60 chars), dominant formula (`X | Brand`, `X: Y`, `How to X`, `N Best X`, question titles).
+- **H1s:** H1-title alignment rate, dominant tone (benefit / feature / question / how-to / listicle), top keywords.
+- **Meta descriptions:** coverage rate, average length, CTA formulas ("Learn more", "Get started", "Try free"), keyword inclusion rate.
+- **Blog topics:** theme map scoped to the blog, posting velocity (posts/month from publish dates or dated URL paths), content-type mix (how-to / listicle / comparison / case study / thought leadership).
+- **Heading hierarchy:** average H2s per page, H3s per H2, common H2 patterns per content type.
+- **Anchor text:** keyword-rich vs generic ratio ("click here"), top 10 most-linked-to pages, detected hub/spoke structures.
+- **Image alt text:** coverage rate, top keyword signals, stuffing flags (alt over 125 chars or 5+ comma-separated keywords).
+
+When 2+ domains (or the user's own site) are analyzed, build a comparison matrix across these dimensions and highlight where the user lags and which themes only one competitor targets.
+
+### Delta signals on re-runs
+
+Surface only meaningful changes, with before/after numbers: a **new theme emerging** (3+ new pages under a previously absent theme), a **theme abandoned** (5+ pages, no additions since last snapshot), a **title-pattern shift** (dominant formula changed across 10+ pages), an **anchor-strategy shift** (keyword-rich ratio moved > 10 points), **blog velocity** changing by > 30%, a **new site section** with 5+ pages. If nothing meaningful changed, say exactly that. Fewer than ~10 pages extracted for a domain → skip theme clustering and report raw element analysis only, noting the limited sample.

--- a/skills/alon-goldenberg/seo-intel/references/serp-and-keywords.md
+++ b/skills/alon-goldenberg/seo-intel/references/serp-and-keywords.md
@@ -1,0 +1,103 @@
+# SERP research and keyword scoring
+
+Query construction and results-page parsing rules shared by the keyword-research and rank-check plays, plus the difficulty, intent, and opportunity rubrics.
+
+## Query normalization
+
+Before searching any keyword:
+
+1. Lowercase the whole query; trim and collapse whitespace.
+2. Preserve intentional quotes (the user asking for `"project management"` means exact phrase) — but never add quotes to unquoted keywords.
+3. Strip characters that break searches: `[ ] { }`. Keep hyphens, ampersands, and periods — they matter in brand names and domains.
+4. Set country and language explicitly per run ("UK rankings" means UK geo-targeting with English results; "German rankings" means German geo and language). Never rely on defaults when the user named a market.
+
+If a search returns fewer than 3 organic results, broaden once — drop modifiers, shorten to core terms — then skip the keyword and note "insufficient SERP data" rather than forcing a result.
+
+## Domain matching (rank checks)
+
+For each keyword, capture the top 20 organic results, then:
+
+1. Normalize each result URL: strip protocol, `www.`, trailing slash; reduce to the root domain (`blog.example.com` → `example.com`).
+2. The target "ranks" if any organic result's root domain matches. Record the **first** (highest) matching position — a match at #3 and #7 records 3.
+3. No match in the top 20 → `position: null`. Still record which result-page features appeared and when the check ran — knowing what the results page looks like is useful even when you're absent, and it proves the query ran.
+
+## Results-page feature taxonomy
+
+Scan each results page and record which features are present (as evidence, and because they change strategy): AI Overview, Featured Snippet, People Also Ask, Knowledge Panel, Image Pack, Video Pack, News Pack, Shopping Pack, Local Pack, Site Links. Harvest for free while you're there: People Also Ask questions (long-tail content ideas) and related searches (keyword expansion). Feature detection is worth a deeper pass only on the ~5 highest-priority keywords per run — position checks alone don't need it.
+
+## Rank deltas
+
+`delta = previous_position - current_position` (positive = moved up). Classify each keyword:
+
+| Condition | Classification |
+|---|---|
+| abs(delta) ≥ 5 | Major move |
+| abs(delta) 2–4 | Notable shift |
+| abs(delta) ≤ 1 | Stable |
+| Was null, now ranked | New entry |
+| Was ranked, now null | Drop-out |
+| Both null | Not ranked |
+
+Summarize: counts in positions 1–3 / 4–10 / 11–20 / unranked vs the prior run; improved / declined / stable totals; average movement. First-run convention: label baseline entries "BASELINE", never "NEW" — "NEW" is reserved for keywords entering the top 20 in delta mode. For unranked keywords, list the top 3 domains holding those positions so the user sees who owns the ground. Maintain a canonical keyword list per domain that new keywords merge into (union, never replace) so future runs auto-load the tracked set.
+
+## Keyword research: seed expansion
+
+Expand the user's topic into 15–25 variations across five strategies:
+
+1. **Core terms** — the exact seeds.
+2. **Modifiers** — "best", "how to", "vs", "alternatives", "tools", "guide", "template", "for [audience]".
+3. **Long-tail questions** — "how to X", "what is X", "why X", "X for [use case]".
+4. **Commercial variants** — "X pricing", "X reviews", "X comparison".
+5. **Adjacent concepts** — what the same audience also searches.
+
+Group into 3–5 thematic clusters before searching, then sweep the live results for every seed, collecting top URLs, dominant content types (listicles, tools, comparison pages, videos), and which domains recur across keywords. Extract the top 3–5 ranking pages per priority cluster (word count, heading outline, topic coverage) and map each recurring competitor's site structure — a competitor with deep topical coverage is harder to displace, and that feeds difficulty.
+
+## Difficulty rubric
+
+Score Low / Medium / High / Very High from observable evidence only — every score must trace to results-page data:
+
+| Difficulty | Criteria |
+|---|---|
+| Low | Niche/small domains in the top 5, thin content (< 1,500 words avg), few features, content-type match |
+| Medium | Mixed authority, moderate depth, some features |
+| High | Authority domains dominate top 5, deep content (3,000+ words avg), multiple features |
+| Very High | Major brands own the top 10, rich features, deep topical coverage, content-type mismatch |
+
+Content-type alignment is the underrated input: if every top result is an interactive tool and the user plans a blog post, difficulty rises regardless of who ranks.
+
+## Intent and AI-surface classification
+
+Classify from what the results page actually shows, not from the keyword's wording:
+
+| Intent | Evidence |
+|---|---|
+| Informational | How-to guides, blog posts, encyclopedic content dominate |
+| Navigational | Brand results; official site owns #1 |
+| Commercial | Comparison pages, "best of" lists, review sites |
+| Transactional | Product/pricing pages, buy CTAs, shopping results |
+
+Mixed intent is real — note primary and secondary. Also classify which AI surface the keyword triggers, because it changes the content recommendation:
+
+| Surface | Signal | Content strategy |
+|---|---|---|
+| GEO (AI Overview / assistant answers) | AI Overview present; question or comparison query | Self-contained 134–167-word passages, statistic- and citation-rich |
+| AEO (Featured Snippet / PAA) | Snippet or PAA box present | Direct 40–55-word answer blocks; FAQ schema |
+| Traditional only | No AI features | Standard SEO: title, meta, depth, links |
+
+## Clustering and opportunity scoring
+
+Group all keywords (seeds + PAA discoveries + long-tails) into 3–7 clusters, each with a pillar keyword, supporting long-tails, and a recommended content approach (pillar page + supporting posts, comparison hub, tool). Then rank:
+
+```
+Opportunity = (Relevance x Intent Value) / Difficulty
+```
+
+Relevance: High=3 / Medium=2 / Low=1 against the user's stated goal. Intent value: Transactional=4, Commercial=3, Informational=2, Navigational=1. Difficulty: Low=1 → Very High=4.
+
+Bucket into three tiers: **Quick Wins** (low/medium difficulty + high relevance + commercial/transactional intent — fastest path to traffic), **Growth Targets** (medium/high difficulty + high intent value — worth quality content), **Moonshots** (very high difficulty, exceptional intent value — long-term plays).
+
+## Report shapes
+
+**Keyword research:** TL;DR (opportunity count, cluster count, top opportunity, dominant content type) → Quick Wins and Growth Targets tables (keyword, intent, difficulty, content type, top competitor, source URL) → topic clusters with per-cluster content strategy → results-page landscape (features observed, dominant domains, PAA questions found) → competitor strength table → "What this means" in 2–4 strategic sentences.
+
+**Rank check:** TL;DR → position summary table with change-vs-last column → biggest movers (gains, drops, new entries, drop-outs) → top competitors per unranked keyword → full rankings table (keyword, position, delta, URL, features) → feature-presence table with deltas → interpretation: are features squeezing organic clicks, which clusters are strongest, which dropped pages need an audit.

--- a/skills/alon-goldenberg/seo-intel/references/site-audit-checks.md
+++ b/skills/alon-goldenberg/seo-intel/references/site-audit-checks.md
@@ -1,0 +1,147 @@
+# Site audit checks
+
+The complete rule set for the site audit play: what to extract, the seven check categories with severities, confidence tiers, escalation rules, dedup, and the health grade.
+
+## Scope and sampling
+
+Ask two things up front: how thorough (Quick ~50 pages / Standard ~200 / Deep ~500) and whether the site is a JS-heavy single-page app (determines whether to start with rendered extraction). Discover URLs via the sitemap plus a crawl of the link graph — discovering from both is what surfaces orphan pages.
+
+When the site has more URLs than the scan size, sample representatively:
+
+- **Always include:** the homepage, `/robots.txt`, `/sitemap.xml`
+- **Depth 1:** every page one click from the homepage
+- **Depth 2:** a proportional cross-section per site section (`/blog/`, `/products/`, `/docs/`…)
+- **Paginated:** at least one page-2/page-3 URL per section
+- **Orphans:** a few URLs present in the sitemap but absent from the link graph
+
+## Per-page extraction
+
+Capture for every sampled page: `title`, `meta_description`, `canonical` (and whether it is self-referential), `og_title`, `og_description`, `twitter_card`, all `h1` values, the H2–H6 outline, JSON-LD `@type` values, internal and external link counts, count of images missing alt text, body word count, content-to-HTML ratio, hreflang presence, `<html lang>` value, and the HTTP status code.
+
+**Render escalation:** start with plain extraction for static sites. If a page (or, after the first batch, more than 30% of pages) returns an empty or near-empty head, re-extract with JS rendering; if that still fails, use your heaviest rendering option. Only after the heaviest tier fails do you record a page as "extraction failed" — and failed pages are excluded from checks, never guessed at.
+
+## The seven categories
+
+### 1. Meta tags
+
+| Rule | Condition | Severity |
+|---|---|---|
+| Missing title | title null/empty | Critical |
+| Duplicate title | same title on 2+ pages | High |
+| Title too short / too long | < 30 chars / > 60 chars | Medium |
+| Missing meta description | null/empty | Medium |
+| Duplicate meta description | same on 3+ pages | High |
+| Description too short / too long | < 70 chars / > 160 chars | Low |
+| Missing canonical | null/empty | Medium |
+| Non-self-referential canonical | canonical points elsewhere | Medium |
+| Missing OG tags / Twitter card | og_title or og_description null / twitter_card null | Low |
+
+Fixes: unique title per page, primary keyword near the start, 30–60 chars; unique 70–160-char descriptions (shared descriptions signal thin content); self-referential canonicals to prevent duplicate-content issues.
+
+### 2. Heading structure
+
+| Rule | Condition | Severity |
+|---|---|---|
+| Missing H1 | no H1 | Critical |
+| Multiple H1s | 2+ H1s | High |
+| Hierarchy gap | H3 without preceding H2, etc. | Medium |
+| Empty heading | whitespace-only heading | Low |
+| Duplicate H1 | same H1 on 2+ pages (excluding homepage) | Medium |
+
+### 3. Schema markup (JSON-LD)
+
+| Rule | Condition | Severity |
+|---|---|---|
+| No JSON-LD on a content page | none present and word count > 300 | High |
+| Missing required fields | Article without headline+datePublished; Product without name+offers; Organization without name+url | Medium |
+| Deprecated @type | outdated schema.org types | Low |
+| No Organization/WebSite schema on homepage | absent | Medium |
+
+### 4. Internal links
+
+| Rule | Condition | Severity |
+|---|---|---|
+| Orphan page | in sitemap, 0 inlinks from crawled pages | Critical |
+| Broken internal link | linked URL returns 4xx/5xx | High |
+| Redirect chain | resolves through 3+ redirects | High |
+| Excessive links | > 100 internal links on one page | Medium |
+| Deep page | > 4 clicks from homepage | Medium |
+| No internal links | 0 internal links on a content page | High |
+
+Fixes: link orphans from relevant hub pages; point links at final destinations; keep important pages within 3 clicks.
+
+### 5. Content quality
+
+| Rule | Condition | Severity |
+|---|---|---|
+| Thin content | < 300 words on an indexable page | High |
+| Very thin content | < 100 words on an indexable page | Critical |
+| Duplicate content | 4-gram shingle Jaccard similarity > 0.9 between two pages | High |
+| Images missing alt text | any on a content page | Medium |
+| Low content-to-HTML ratio | < 0.10 | Low |
+
+Duplicate detection: compute 4-gram shingle sets from body text per page pair; above 100 pages, compare within site sections only to stay tractable.
+
+### 6. Technical foundations
+
+| Rule | Condition | Severity |
+|---|---|---|
+| robots.txt missing | 404 or empty | Critical |
+| robots.txt blocks important paths | blanket `Disallow: /` or high-value paths blocked | Critical |
+| Sitemap missing | none at `/sitemap.xml` or in robots.txt | Critical |
+| Sitemap stale | all `<lastmod>` older than 90 days | Medium |
+| HTTPS not enforced | HTTP doesn't 301 to HTTPS | Critical |
+| Mixed content | HTTPS page loads HTTP resources | High |
+| URL hygiene | underscores, uppercase, or session IDs (`?sid=`…) in paths | Medium |
+| Missing lang attribute | no `<html lang>` | Low |
+| AI bots blocked | robots.txt disallows GPTBot, ClaudeBot, PerplexityBot, or ChatGPT-User | Medium |
+| No llms.txt | no `/llms.txt` at root | Low |
+
+The last two connect the audit to AI visibility: each blocked AI crawler is a visibility channel closed. Recommend allowing AI bots unless there is a documented reason not to; `/llms.txt` (see llmstxt.org) is low priority but forward-looking.
+
+### 7. Core Web Vitals (observational)
+
+These are inferred from HTML patterns, not measured with a performance lab — always Hypothesis-confidence:
+
+| Rule | Condition | Severity |
+|---|---|---|
+| Large images without lazy loading | likely-heavy images with no `loading="lazy"` | Medium |
+| Render-blocking resources | stylesheets/scripts in `<head>` without async/defer | Medium |
+| Excessive DOM depth | nesting beyond ~32 levels | Low |
+| No viewport meta tag | missing | Medium |
+
+## Confidence tiers
+
+Tag every finding with how it was detected, and show the tag in the report (`[C] Missing title tag on /about`):
+
+| Tier | Meaning |
+|---|---|
+| `[C]` Confirmed | Deterministically measured (parsed from the actual HTML head, fetched robots.txt) |
+| `[L]` Likely | Strong signal from content analysis (link counts from extracted text are approximate — nav boilerplate inflates them) |
+| `[H]` Hypothesis | Inferred, needs manual verification (all CWV checks; HTTPS enforcement inferred from URLs) |
+
+Meta tags, headings, and schema parsed from raw HTML are Confirmed. Internal-link counts from extracted text are Likely. CWV is always Hypothesis.
+
+## Severity escalation
+
+- **Widespread duplication:** the same rule firing on > 10% of audited pages bumps its severity one level (Low→Medium, Medium→High, High→Critical).
+- **No homepage bonus:** homepage findings keep their base severity — the rule severity already encodes impact.
+- **Combined impact:** a page with 3+ distinct Critical/High findings is flagged as a "high-priority fix page" in Quick Wins.
+
+## Dedup against the prior audit
+
+When a prior findings file exists for the domain, signature each finding as `page_url|rule_id` and classify: **Unchanged** (same signature, same severity), **Worsened** (same signature, higher severity), **New** (no prior match), **Resolved** (prior signature gone). New and Worsened go in the summary and severity tables; Unchanged only in category breakdowns; Resolved counted as wins in the summary ("3 issues resolved since last audit").
+
+## Health grade
+
+| Grade | Criteria |
+|---|---|
+| A | 0 Critical, ≤ 2 High |
+| B | 0 Critical, 3–5 High |
+| C | 1–2 Critical, or 6–10 High |
+| D | 3–5 Critical, or > 10 High |
+| F | > 5 Critical |
+
+## Report shape
+
+Header (domain, date, pages audited / discovered, render tier used) → TL;DR (grade, top 3 critical issues, biggest quick win, delta line if a prior audit exists) → severity tables (Critical / High / Medium / Low; columns: page, issue, category, recommendation) → per-category breakdown with pass rates → site structure overview → Quick Wins (each under ~2 hours of work) → "What this means" (where to start, expected impact). Every finding row names its page URL and confidence tier.


### PR DESCRIPTION
## What this skill does

Six SEO plays grounded in live data instead of guessed metrics: keyword research, rank checks, technical site audits, content gap analysis, competitor reverse-engineering, and AI-visibility (AEO/GEO) audits. Every keyword, finding, and citation traces to an observed search result or extracted page; repeat runs lead with deltas from per-domain memory.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
