### PR TITLE
add talent-sourcing

### DIFF
--- a/skills/alon-goldenberg/talent-sourcing/SKILL.md
+++ b/skills/alon-goldenberg/talent-sourcing/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: talent-sourcing
+title: Talent sourcing
+description: |
+  Use this skill when you need to find, source, or recruit candidates for a role —
+  "find candidates for", "source engineers in", "who can I hire for", "find me a
+  [role] in [city]", "build a candidate list", "recruiting for", "talent search",
+  "who's available for", "find potential hires" — or when a job description is
+  pasted with a sourcing request. Produces a ranked, tiered candidate report with
+  profiles, skills, availability signals, and contact signals, deduplicated against
+  every previous search for the same role. Not for salary benchmarking or job-market
+  research, and not for researching one already-known person.
+category: Research
+tags: [Leadership]
+---
+
+# Talent sourcing
+
+Runs when someone needs a candidate list for an open role — a title and location, a pasted job description, or a vague "who could we hire for this". Produces a tiered candidate report (Strong / Partial / Stretch) with per-candidate profiles, availability and contact signals, and a hiring-outlook read — with repeat candidates from earlier runs flagged instead of re-pitched as new.
+
+## The play
+
+### 1. Turn the request into a search brief
+
+Extract five fields: **role** (title or function), **location** (city, metro, region, or remote), **skills/requirements** (technologies, years, domain), **seniority** (junior → C-level), and **source preference** (specific platforms or all). If a full job description was pasted, pull the fields out of it rather than asking again. If the role itself is missing or ambiguous, ask one question — "What role, and where?" — and stop until answered.
+
+Then confirm the brief back before searching: role, location, key skills, seniority, and the platforms you intend to sweep. Searches are cheap but a wrong brief wastes the whole run; a ten-second confirmation is the highest-leverage step in the play.
+
+### 2. Fan out searches across platforms in parallel
+
+One search lane per platform, run simultaneously, never sequentially: professional-network profiles, resume boards, code-hosting profiles (technical roles only — skip this lane entirely for sales, marketing, and operations roles), and startup-talent / community sources. Query construction per platform — site-scoped operators, availability-phrase patterns, the two-query rule per lane, and the fallback ladder when a platform returns nothing — is in `references/source-playbook.md`. Read it before writing the first query.
+
+Each lane returns raw candidate leads: name if visible, profile URL, current title, location snippet, inferred skills, and any availability phrase ("open to work", "seeking", "available") with its date and source URL.
+
+### 3. Extract the top profiles — inside a budget
+
+Aim for 10–20 unique profiles across all lanes; extract full details for at most 15. If the lanes surfaced more, triage by relevance (seniority match + skill overlap + location match) *before* extracting — extraction is the expensive step, so spend it on the plausible ones, not the first ones found.
+
+From each profile pull: full name, current role and company, location, skills/stack, experience summary (years, notable employers), education, availability signals, and contact signals (email, personal site, code-hosting handle). When a profile sits behind a login wall and extraction fails, keep the search-snippet summary and note "full profile unavailable — login required" — never drop the candidate just because the page wouldn't open.
+
+### 4. Score and tier
+
+Score each candidate 1–10 on weighted signals — role match 30%, skill overlap 30%, location 20%, seniority 10%, availability 10% — and group into Tier 1 (Strong, 7–10), Tier 2 (Partial, 4–6), Tier 3 (Stretch, 1–3). The full rubric, tier definitions, and a worked scoring example are in `references/scoring-rubric.md`; read it before assigning any score, and score against the confirmed brief, not against what the search happened to return.
+
+### 5. Dedup against role memory
+
+Keep a running file per role in your workspace (one file per role slug, e.g. `talent/senior-ml-engineer-remote-us.md`). Before presenting, load it: any candidate surfaced in a prior run for this role gets marked `(previously surfaced)` — still listed, still scored, but never re-presented as a fresh find. This is what makes the second and third run on the same role useful instead of noise. After presenting, write every candidate from this run back into the file with date and score.
+
+### 6. Present the report
+
+Follow the structure in `references/report-format.md` exactly: header with platforms searched and tier counts, TL;DR, tiered candidate entries, and a closing "What this means" hiring-outlook read. Every Tier 1 candidate gets a one-sentence "Why this candidate". Missing data is written as "unknown" — a field is never guessed to make an entry look complete.
+
+### 7. Offer the next move
+
+Close with concrete options: go deeper on one candidate (full profile + contact discovery), broaden (remote, relaxed seniority, more platforms), narrow (add a required skill, tighten location), or export the list as a CSV or document. If the run found fewer than five candidates total, don't present a thin list as an answer — say so, propose the specific broadening (usually location → remote, or seniority down one notch), and ask before re-running.
+
+## What good looks like
+
+- The best operator notices **availability signals with dates** first — a candidate who posted "open to work" last month outranks a slightly better-matched candidate with no availability signal, because reply rates, not resume quality, decide whether a sourcing list converts. They also read the tier *distribution* as market data: a thin Tier 1 with a fat Tier 3 means the brief is over-constrained for this market, and they say so instead of padding Tier 1.
+- The mediocre version is a flat list of profile links: no scores, no tiers, GitHub searched for a sales role, the same candidates re-presented as new on the second run, and fields silently invented to make entries look uniform.
+- Output is good when a hiring manager can act on it in five minutes: every Tier 1 entry has a "why", an availability read with a source, and at least one contact path — and the "What this means" line tells them whether to move fast (thin supply) or be picky (deep supply).
+
+## Rules
+
+- MUST confirm role, location, skills, and seniority with the requester before searching.
+- MUST run platform lanes in parallel and cap deep extraction at 15 profiles, triaged by relevance first.
+- MUST check the role's running memory file and mark repeat candidates `(previously surfaced)`.
+- MUST attach a date and source URL to every availability claim, or state "date unknown".
+- MUST note skipped or failed platforms in the report header (e.g. "code-hosting not searched for this role type").
+- NEVER fabricate candidate details — missing fields are "unknown", and a candidate kept from a snippet is labeled as snippet-only.
+- NEVER contact, message, or email a candidate as part of this play; sourcing ends at the report, and any outreach is a separate, explicitly human-approved action.
+- NEVER drop a strong candidate because their profile is login-walled — keep the snippet entry.
+- NEVER present fewer than five candidates as a finished answer without flagging it and proposing a broader brief.

--- a/skills/alon-goldenberg/talent-sourcing/references/report-format.md
+++ b/skills/alon-goldenberg/talent-sourcing/references/report-format.md
@@ -1,0 +1,69 @@
+# Report format and role memory
+
+The output contract for every sourcing run, plus the per-role memory that keeps repeat runs honest.
+
+## Report structure
+
+```
+## Candidate Report: [Role] in [Location]
+Searched: [platforms actually swept — name skips and failures here, e.g.
+"code-hosting not searched for this role type", "resume boards skipped after repeated errors"]
+Found: [N] candidates | Tier 1: [N] | Tier 2: [N] | Tier 3: [N]
+
+**TL;DR:** [2–3 sentences: the strongest candidates by name, and any notable
+pattern — e.g. "supply is thin outside two metros", "half of Tier 1 shows fresh
+availability signals".]
+
+---
+
+### Tier 1 — Strong Match
+
+#### 1. [Name] — [Score]/10
+- **Current role:** [Title] at [Company]
+- **Location:** [Location]
+- **Skills:** [Skill1], [Skill2], [Skill3]
+- **Experience:** [X years; notable employers]
+- **Availability:** [signal phrase] — [date or "date unknown"] — [source URL]
+- **Profile:** [URL]
+- **Contact signals:** [email / personal site / code-hosting handle]
+- **Why this candidate:** [one sentence — required for every Tier 1 entry]
+
+[…remaining Tier 1, then "### Tier 2 — Partial Match" with the gap named per
+entry, then "### Tier 3 — Stretch", max 5 entries…]
+
+---
+
+### What This Means
+[1–2 sentences of hiring outlook: supply/demand read from the tier distribution,
+a speed recommendation ("move fast — only 3 strong matches and 2 show active
+availability"), and the standout sourcing channel for this role.]
+```
+
+## Formatting and honesty rules
+
+- **Omit fields with no data rather than padding them** — except availability, which is always present as either a sourced signal or "no availability signal found".
+- **"Unknown" is a valid value.** Never infer an email pattern, guess years of experience, or upgrade an undated availability snippet to "recent".
+- **Snippet-only candidates** carry the line "full profile unavailable — login required; scored from snippet" so the reader knows the confidence level.
+- **Every availability claim carries its source URL and date** (or "date unknown"). This is the field hiring managers act on first; it is also the easiest to accidentally fabricate.
+- Tier 2 entries name their gap in one clause ("adjacent stack — Django not FastAPI"). A gap the reader can evaluate is useful; an unexplained middling score is not.
+- The report is a research artifact: it never includes drafted outreach, and no candidate is contacted as part of producing it.
+
+## Role memory — dedup across runs
+
+Keep one running file per role in your workspace, named by role slug (e.g. `talent/senior-ml-engineer-remote-us.md`), plus a small index listing all roles searched with last-run dates.
+
+**On every run, before presenting:**
+
+1. Load the role's file (match by role + location; a materially changed brief — new location, different seniority — is a new slug, not an append).
+2. Dedup candidates by profile URL first, then by name + current company.
+3. Any candidate already in the file is marked `(previously surfaced — first seen [date])` in the report. They keep their tier and score but are never counted or narrated as a new find. If their situation visibly changed (new title, fresh availability signal), say what changed — that delta is the news.
+
+**After presenting, write back:**
+
+- Every candidate from this run: name, profile URL, score, tier, availability signal + date, first-seen date, last-seen date.
+- A run header: date, brief as confirmed, platforms swept, tier counts.
+- Update the index row for this role.
+
+**Refresh runs.** When re-running an unchanged brief, the deliverable is the *diff*: lead with "New since [last run date]: N candidates", list the new ones in full, and compress previously-surfaced candidates to one line each unless something changed. A refresh that re-presents last week's list at full length is the signature failure of the mediocre version.
+
+**Same-day repeat** (parameters tweaked minutes later): treat as a continuation — dedup against the earlier run silently, don't stamp "(previously surfaced)" on candidates from an hour ago, and overwrite the day's run header rather than appending a second one.

--- a/skills/alon-goldenberg/talent-sourcing/references/scoring-rubric.md
+++ b/skills/alon-goldenberg/talent-sourcing/references/scoring-rubric.md
@@ -1,0 +1,47 @@
+# Scoring rubric — weights, tiers, extraction budget
+
+Score every candidate against the **confirmed brief**, not against whatever the search returned. The same profile can be a 9 for one brief and a 4 for another.
+
+## Weighted score (1–10)
+
+| Signal | Weight | What earns full marks |
+|---|---|---|
+| Role / title match | 30% | Current or most recent title is the target role or its direct feeder (e.g. "Staff Engineer" for a "Senior Engineer" brief) |
+| Skill overlap | 30% | All must-have skills evidenced on the profile — listed AND backed by role history or work samples, not keyword-listed only |
+| Location match | 20% | In the target metro, or explicitly remote-open for a remote brief |
+| Seniority match | 10% | Years and scope line up with the brief's level — one notch either side scores partial |
+| Availability signals | 10% | A dated "open to work"/"seeking" phrase, a job change in the last few months, or active job-search behavior — with source URL |
+
+Scoring discipline:
+
+- Score each dimension 0–10, multiply by weight, sum. Don't eyeball a single holistic number — the dimension scores are what make the ranking defensible when the hiring manager pushes back.
+- **Evidence over keywords.** A skill listed in a profile's skill section with no supporting role or project scores half; a skill demonstrated in role descriptions or public work scores full.
+- **Snippet-only candidates** (login-walled profiles) are scored on what the snippet shows; unknown dimensions score the midpoint (5), never zero and never full — and the entry says "scored from snippet".
+- **Overqualified is a real score, not a bonus.** A VP applying to a senior-IC brief scores partial on seniority match — flag it, don't inflate it.
+
+## Tiers
+
+| Tier | Score | Meaning |
+|---|---|---|
+| **Tier 1 — Strong match** | 7–10 | All required signals present. Every entry gets a one-sentence "Why this candidate". |
+| **Tier 2 — Partial match** | 4–6 | Most signals present, 1–2 gaps — name the gap explicitly in the entry (e.g. "no availability signal", "adjacent stack"). |
+| **Tier 3 — Stretch** | 1–3 | Worth reviewing only if Tiers 1–2 are thin. Cap at 5 entries; a long Tier 3 is noise. |
+
+Read the distribution as market data: a healthy brief yields roughly 3–6 Tier 1, 5–10 Tier 2. Near-empty Tier 1 with a heavy Tier 3 means the brief is over-constrained for this market — say that in "What this means" rather than quietly promoting 6s to Tier 1.
+
+## Extraction budget
+
+Deep-extract **at most 15 profiles** per run. When the lanes surface more than 15 unique candidates, triage before extracting using the three cheap dimensions visible in snippets — seniority match + skill overlap + location match — and extract the top 15 by that pre-score. Everyone else stays in the report as a snippet-level Tier 2/3 entry. Never extract in discovery order; the first results found are not the best results found.
+
+## Worked example
+
+Brief: **Senior ML Engineer, remote US, must-have PyTorch + production model serving, nice-to-have Kubernetes.**
+
+Candidate A — "Staff ML Engineer" at a known AI company, profile shows PyTorch projects and a serving-infrastructure role, based in Austin, posted "open to new roles" two weeks ago (dated, with URL):
+role 9 × .30 + skills 9 × .30 + location 10 × .20 + seniority 8 × .10 + availability 10 × .10 = **9.2 → Tier 1.** Why: exact stack with production evidence plus a fresh, dated availability signal.
+
+Candidate B — "Data Scientist" listing PyTorch among 14 skills, no serving experience visible, NYC, no availability signal:
+role 5 × .30 + skills 4 × .30 + location 10 × .20 + seniority 5 × .10 + availability 0 × .10 = **5.2 → Tier 2.** Gap to name: no production-serving evidence; PyTorch is keyword-only.
+
+Candidate C — login-walled profile, snippet shows "ML Engineer • PyTorch • Kubernetes", location not visible:
+role 8 × .30 + skills 7 × .30 + location 5 × .20 (unknown → midpoint) + seniority 5 × .10 + availability 5 × .10 = **6.5 → Tier 2**, marked "scored from snippet — full profile unavailable, login required". Kept, not dropped.

--- a/skills/alon-goldenberg/talent-sourcing/references/source-playbook.md
+++ b/skills/alon-goldenberg/talent-sourcing/references/source-playbook.md
@@ -1,0 +1,71 @@
+# Source playbook — platforms, query patterns, fallbacks
+
+How to sweep each candidate source: which platforms to use for which roles, how to construct queries, and what to do when a lane comes back empty.
+
+## Platform selection
+
+| Lane | Search where | Use for | Skip when |
+|---|---|---|---|
+| Professional network | Public professional-network profiles (e.g. `site:linkedin.com/in`) | Every role | Never — always run |
+| Resume boards | Public resume/job-board pages (e.g. `site:indeed.com resume`) | Every role, strongest for mid-level and high-volume roles | Rarely useful for C-level |
+| Code hosting | Developer profiles (e.g. `site:github.com`) | Engineering, data, DevOps, ML — any role where public code is a work sample | **Skip entirely for non-technical roles** (sales, marketing, ops, finance) and note the skip in the report header |
+| Startup talent + communities | Startup-hiring platforms (e.g. `site:wellfound.com`) and open professional communities | Startup-profile roles, "open to work" discovery | Enterprise-only briefs |
+
+Run all applicable lanes **in parallel** — one lane per search thread. Sequential sweeps double the runtime and tempt you to stop after the first lane looks "good enough".
+
+## Query construction
+
+Two queries per lane, always: one **site-scoped** (precision) and one **open-web** (recall). Fill from the confirmed brief.
+
+**Professional network**
+
+```
+site:linkedin.com/in "[Role]" "[Location]" [Skill1] [Skill2]
+"[Role]" "[Location]" linkedin profile [Skill1] [Skill2]
+```
+
+**Resume boards**
+
+```
+site:indeed.com resume "[Role]" "[Location]" [Skill1]
+"[Role]" resume "[Location]" [Skill1] [Skill2]
+```
+
+**Code hosting** (technical roles only)
+
+```
+site:github.com "[Role]" "[Location]" [Skill1]
+github [Skill1] [Skill2] developer "[Location]" "open to work"
+```
+
+**Startup talent + communities**
+
+```
+site:wellfound.com "[Role]" "[Location]" [Skill1]
+"[Role]" "[Location]" ("open to work" OR "seeking opportunities") [Skill1]
+```
+
+Construction rules:
+
+- Quote multi-word phrases (role titles, city names); leave single-word skills unquoted so stemming helps recall.
+- 2–3 skills per query maximum. Stuffing five skills into one query returns only resume-keyword spam; run a second query with the other skills instead.
+- For remote roles, replace the location term with `remote` plus the country/region constraint (`remote US`), and add the seniority word (`senior`, `staff`, `director`) to the role phrase — remote pools are too large to search without it.
+- Availability phrases worth searching explicitly: `"open to work"`, `"seeking opportunities"`, `"available for"`, `"looking for my next"`. A hit on one of these is a first-class signal — record the phrase, the date if visible, and the URL.
+- ~15 results for the primary lane (professional network), ~10 for the others. More than that per lane produces dedup work, not candidates.
+
+## Structured search tools
+
+If your stack includes a structured people-search or profile-extraction tool for any of these platforms, prefer it over open-web queries for that lane — feed it the role title, location, and skill keywords from the brief. Validate its output on the first run (does it return real, current profiles?) before trusting it for the whole sweep. Open-web search remains the fallback for any platform with no working structured tool.
+
+## Fallback ladder
+
+When a lane fails, degrade in this order — never silently return an empty lane:
+
+1. **Zero results** → simplify: drop the least-important skill, then drop the location qualifier. Two simplification rounds max.
+2. **Search errors** on a platform → retry once with a simplified query; if it still fails, skip the platform and state so in the report header.
+3. **Profile behind a login wall** at extraction time → keep the search-snippet entry (name/title/location/skills as visible in the snippet), mark it "full profile unavailable — login required". Snippet-only candidates are scored like any other, on what is known.
+4. **All lanes thin (<5 candidates total)** → this is a brief problem, not a search problem. Report the shortfall and propose one concrete broadening — location → remote first, seniority down one notch second — and wait for approval before re-running.
+
+## Source-quality tiers
+
+When the same person surfaces on multiple platforms, keep one entry and cite the richest source. Trust order for conflicting facts: the person's own current profile page > resume-board listing > community mention > search snippet. An availability signal is only as good as its date — an undated "open to work" from an unknown-age snippet is recorded as "date unknown", never assumed fresh.


### PR DESCRIPTION
## What this skill does

Candidate sourcing for an open role: confirmed search brief, parallel platform lanes with a 15-profile extraction budget triaged by relevance, a weighted 1–10 scoring rubric into Strong/Partial/Stretch tiers, dated availability signals with source URLs, and per-role memory so repeat runs flag previously-surfaced candidates instead of re-pitching them.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/alon-goldenberg/` only
- [x] `node tools/validate.mjs` passes locally (with author.md from #100 present)
- [ ] First contribution: `author.md` rides with #100 per CONTRIBUTING — this PR will fail the validator's author.md check until #100 merges
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

Origin: distilled from Nimbleway's open-source (MIT) agent-skills library, which I work on — rewritten tool-agnostic in this library's format, keeping the judgment and dropping all product plumbing. One of nine sibling submissions; author profile is in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
