### PR TITLE
add audience-icp-filter

### DIFF
--- a/skills/erwann-lefevre/audience-icp-filter/SKILL.md
+++ b/skills/erwann-lefevre/audience-icp-filter/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: audience-icp-filter
+title: Audience ICP filter
+description: |
+  Use this skill when a list of people already exists and someone needs to know who on it is worth
+  contacting — event or webinar attendees, registrants, a prospecting export, a CRM segment, a
+  newsletter or community list. Produces every lead sorted into ICP match, needs review, or no
+  match, with a reason attached to each, the team's own colleagues and competitors stripped out,
+  and nobody silently dropped. Trigger phrasings: "filter this list against my ICP", "who here
+  matches our ICP", "clean up this lead list", "qualify my signups", "segment this audience",
+  "who should we follow up with after the webinar", "did we import junk", "remove the bad leads".
+category: Prospecting
+tags: [Sales, RevOps]
+---
+
+Applies to a list that already exists and needs sorting before anyone contacts it. Produces four labelled buckets, a reason per lead, and reconciled counts.
+
+## Every imported list is mostly noise
+
+Colleagues are in it. Competitors are watching. A third of the job titles are unreadable, half the companies are stale, and somewhere in there are the twelve people actually worth a message. The default response — skim it, sort by gut, start sequencing — leaks in the direction that hurts most: someone's own coworker gets a cold pitch.
+
+This skill starts from an existing list. Importing or scraping is a different job with different prerequisites; folding it in makes both slower.
+
+## Check the data before asking about the ICP
+
+The instinct is to ask what the ICP is first. Do the opposite: measure what the list actually contains, then ask only about criteria the data can support.
+
+There is no point offering geography filtering on a list where the location field is empty. It doesn't filter anything — it routes everyone into review and calls that a result. The same applies to industry, and to exclusion when there's no company and no email to match on.
+
+Run the coverage check, read which criteria are blocked, and say so before the conversation about the ICP starts. If enrichment is needed, quote what it will cost and get an explicit yes before spending anything. If the team declines, proceed — but name the criteria you dropped and say that exclusion is now best-effort. Filtering on a criterion the data can't support and presenting the result as clean is the worst available outcome, because it looks like work. The field-by-field thresholds and the ICP question set are in `references/coverage-and-icp.md`.
+
+## Two passes, and neither is optional
+
+**Pass 1 is deterministic.** `scripts/build.py` pattern-matches seniority and function across the title and, when the title is silent, the bio; applies exclusions uniformly across every identity field; and refuses to emit a result whose bucket counts don't reconcile against the input. Nobody gets lost, and the same list classifies the same way twice. Never hand-sort a list — it's unauditable and it's exactly how colleagues leak through.
+
+**Pass 2 is semantic, and it is the agent's job.** Patterns can't read meaning. `Chief Happiness Officer` and `Chief Medical Officer` both resolve as C-level and neither is a buyer. A competitor nobody thought to list sits quietly in the match bucket. `Founder @ Stealth Mode` lands in review when it's obviously in ICP.
+
+The point of the skill is that nobody hand-sorts a list. Handing back a fifty-lead review bucket is not a result — it's the original problem with extra steps. Work the queue down; leave only the genuinely ambiguous handful for a human.
+
+## Review the queue, not the list
+
+The expensive mistake is re-reading everything in pass 2. On a 250-lead list, lead-by-lead review took eight minutes and changed almost nothing, because most classifications were never in doubt.
+
+Pass 1 returns a bounded queue instead: the ambiguous, the matches inferred from a bio rather than a title, the matches whose company reads like an agency or a freelancer, and the leads dropped on a soft geography or industry miss. Each carries a flag saying why it's there. On a clean list that's fifteen to twenty-five leads, and it's the whole of pass 2's work. Anything outside the queue was confident enough to trust.
+
+A large review bucket is a signal, not a workload. It usually means the list was never enriched, or the ICP is under-specified — most often that nobody answered whether founders qualify regardless of stated function. Diagnose the cause and say it rather than moving forty leads by hand. `references/pass-two-review.md` covers the flags and the false-positive patterns.
+
+## Exclusion leaks in three specific ways
+
+Matching on company name alone fails, every time, on real data:
+
+**Empty company and empty email.** The only clue is the bio — "Client Partner @ Acme". Filtering on the company field lets them straight through.
+
+**Job-changers.** The company field says one employer and the email domain says another. Either field alone gives the wrong answer; a hit on *either* has to exclude.
+
+**Collapsed spellings.** `@AcmeLabs` and `acme-labs` contain none of the string "Acme Labs". A punctuation-stripped comparison catches them — but only above about five characters, or short tokens start firing inside unrelated words.
+
+Always seed the exclusion list with the team's own company and domain. It's the most common leak and by far the most embarrassing. And when extending exclusions in pass 2, remember that a competitor's name inside someone's *bio* is usually a tool they use, not their employer — check it's the employer or the domain before dropping them. Full doctrine in `references/exclusion-doctrine.md`.
+
+## What good looks like
+
+The tell of a good operator: they look at the field fill rates before they look at the list. They know that "filter by geography" on a list with 12% location coverage is not a filter, and they'd rather deliver three honest criteria than six decorative ones.
+
+The mediocre version sorts by job title alone, produces a tidy match list, and quietly includes two colleagues and a competitor — because the colleague's company field was blank and the competitor was spelled with a hyphen. It looks cleaner than the good version. That's the trap: on this task, output that looks tidy is usually output that dropped the hard cases.
+
+Good output reconciles. Every lead is in exactly one bucket, every bucket decision carries a reason, and the totals add back to the input count. If somebody asks "what happened to the other 40?", the answer is in the file, not in a shrug. And the review bucket that comes back to the user is small enough to decide in two minutes.
+
+## Rules
+
+- MUST measure field coverage before asking what the ICP is, and drop criteria the data can't support.
+- MUST get explicit approval, with a quoted cost, before spending anything on enrichment.
+- MUST run both passes — deterministic classification, then semantic review of the queue.
+- MUST match exclusions across company, both email fields, bio and company URL, with a punctuation-stripped comparison for longer terms.
+- MUST seed exclusions with the team's own company and domain.
+- MUST reconcile: every lead in exactly one bucket, with a reason, totalling the input.
+- NEVER classify a list by hand.
+- NEVER exclude someone on a competitor name found only in their bio without confirming it's their employer.
+- NEVER drop ambiguous leads to keep the output tidy — route them to review.
+- NEVER hand back the full review bucket as the deliverable.

--- a/skills/erwann-lefevre/audience-icp-filter/SKILL.md
+++ b/skills/erwann-lefevre/audience-icp-filter/SKILL.md
@@ -41,7 +41,7 @@ The point of the skill is that nobody hand-sorts a list. Handing back a fifty-le
 
 The expensive mistake is re-reading everything in pass 2. On a 250-lead list, lead-by-lead review took eight minutes and changed almost nothing, because most classifications were never in doubt.
 
-Pass 1 returns a bounded queue instead: the ambiguous, the matches inferred from a bio rather than a title, the matches whose company reads like an agency or a freelancer, and the leads dropped on a soft geography or industry miss. Each carries a flag saying why it's there. On a clean list that's fifteen to twenty-five leads, and it's the whole of pass 2's work. Anything outside the queue was confident enough to trust.
+Pass 1 returns a bounded queue instead: the ambiguous, the matches inferred from a bio rather than a title, the matches whose company reads like an agency or a freelancer, the leads dropped on a soft geography or industry miss, and the leads dropped on a seniority or function read out of free text rather than off the title. Each carries a flag saying why it's there. On a clean list that's fifteen to twenty-five leads, and it's the whole of pass 2's work. Anything outside the queue was confident enough to trust.
 
 A large review bucket is a signal, not a workload. It usually means the list was never enriched, or the ICP is under-specified — most often that nobody answered whether founders qualify regardless of stated function. Diagnose the cause and say it rather than moving forty leads by hand. `references/pass-two-review.md` covers the flags and the false-positive patterns.
 
@@ -73,6 +73,7 @@ Good output reconciles. Every lead is in exactly one bucket, every bucket decisi
 - MUST match exclusions across company, both email fields, bio and company URL, with a punctuation-stripped comparison for longer terms.
 - MUST seed exclusions with the team's own company and domain.
 - MUST reconcile: every lead in exactly one bucket, with a reason, totalling the input.
+- MUST queue any lead that left the ICP on a signal inferred from free text — a wrong drop is invisible by construction, so no lead may be discarded on an inference without a second look.
 - NEVER classify a list by hand.
 - NEVER exclude someone on a competitor name found only in their bio without confirming it's their employer.
 - NEVER drop ambiguous leads to keep the output tidy — route them to review.

--- a/skills/erwann-lefevre/audience-icp-filter/references/classification-taxonomy.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/classification-taxonomy.md
@@ -38,6 +38,14 @@ A `Managing Director` whose bio reads *"Développement commercial"* matches on t
 
 Every bio-inferred match is flagged as such in its reason and enters the pass-2 queue, because inference from free text is exactly where a pattern is most likely to be confidently wrong.
 
+## Case is part of the pattern
+
+Detection runs against the original string, not a lowercased one, and **a pattern written with an uppercase letter is matched case-sensitively.**
+
+This exists because short acronyms are indistinguishable from ordinary words once case is discarded. Matched case-insensitively, `IT` matches the English pronoun — so a bio reading "making it happen" scores as a technology function, and if the ICP doesn't include that function the lead is dropped. Three patterns rely on this: `IT`, `R&D`, and `EI` in the agency list.
+
+The practical rule when extending the taxonomy: write a pattern in lowercase unless the capitals carry meaning. `\bproduct\b` should match "Product", "product" and "PRODUCT" alike; `\bIT\b` should match only the acronym.
+
 ## Multilingual titles
 
 The taxonomy carries French alongside English — `Fondatrice`, `Responsable`, `Directeur`, `Commercial`, `Vente` — because a list drawn from a European market is routinely half non-English, and a taxonomy that only reads English routes all of it to review.

--- a/skills/erwann-lefevre/audience-icp-filter/references/classification-taxonomy.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/classification-taxonomy.md
@@ -1,0 +1,51 @@
+# Seniority and function classification
+
+The tiers pass 1 applies. The full regex patterns live in `title-taxonomy.json`, which `build.py` loads — you don't need to read it. Consult it only to extend the taxonomy or when someone disputes a classification.
+
+## Seniority — first match wins
+
+Evaluated top-down, which is why `Chief Executive Officer` resolves as founder/C-level rather than matching "executive" further down.
+
+| Tier | Matches |
+|---|---|
+| `founder_c` | Founder, Co-Founder, Fondateur/Fondatrice, CEO/CTO/CMO/CRO/COO/CFO, Chief … Officer, President, Owner, Managing Partner, Managing Director |
+| `vp_head` | VP, SVP, EVP, Vice President, Head of, Director, Directeur/Directrice, General Manager, Country Manager |
+| `manager_lead` | Manager, Lead, Responsable, Supervisor, Principal, Founder's Office |
+| `ic` | Account Executive, SDR, BDR, Specialist, Coordinator, Analyst, Consultant, Engineer, Intern, Junior |
+
+Ordering is load-bearing. A flat set of patterns would classify `VP of Engineering` and `Engineer` identically.
+
+## Function — all matches collected
+
+Unlike seniority, functions accumulate. `General Manager of Sales and Marketing` carries both `sales` and `growth_marketing`, and satisfies an ICP containing either.
+
+| Key | Matches |
+|---|---|
+| `sales` | Sales, Vente, Commercial, Account Executive, SDR/BDR, Business Development, New Business, Pre-Sales |
+| `growth_marketing` | Growth, Marketing, MarTech, Demand Gen, Acquisition, Brand, Content, SEO, Paid |
+| `revops` | RevOps, Revenue Operations/Systems/Strategy, Sales Ops, GTM, Go-to-market, CRM, Automation, Enablement |
+| `partnerships` | Partnerships, Alliances, Channel, Affiliate |
+| `product_tech` | Product, Engineering, Software, Technology, Data, Security, Platform, Architect |
+| `other` | HR, Recruiting, Finance, Legal, Customer Success, Support, Coaching, Editorial |
+
+Collecting rather than picking matters for cross-functional titles, which are common at the size of company most ICPs target. Forcing a single function on a `Head of Growth & Partnerships` throws away half the signal.
+
+## Title first, bio as fallback
+
+Detection runs on the job title. When the title carries no seniority signal, or no function signal, pass 1 falls back to the bio.
+
+A `Managing Director` whose bio reads *"Développement commercial"* matches on that bio. This is worth more than it sounds: on a real 150-lead list, reading the bio cut the review bucket by roughly 60%.
+
+Every bio-inferred match is flagged as such in its reason and enters the pass-2 queue, because inference from free text is exactly where a pattern is most likely to be confidently wrong.
+
+## Multilingual titles
+
+The taxonomy carries French alongside English — `Fondatrice`, `Responsable`, `Directeur`, `Commercial`, `Vente` — because a list drawn from a European market is routinely half non-English, and a taxonomy that only reads English routes all of it to review.
+
+It doesn't cover every language. A title in one the taxonomy misses lands in review and gets resolved in pass 2, which is the correct failure mode: visible and recoverable rather than silently mis-sorted.
+
+## Noise titles
+
+Student, intern, open-to-work, retired, investor and similar route to `no_match` rather than `review`. They aren't ambiguous — they're clearly not buyers — and putting them in review inflates the bucket that a human has to read.
+
+The distinction is worth holding to generally: `review` means *the engine declined to guess*, not *this lead is unusual*.

--- a/skills/erwann-lefevre/audience-icp-filter/references/coverage-and-icp.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/coverage-and-icp.md
@@ -1,0 +1,112 @@
+# The coverage gate and the ICP questions
+
+Run in this order. Coverage first, always — it decides which questions are worth asking.
+
+## Coverage
+
+```bash
+python3 scripts/build.py --coverage leads.json
+```
+
+Reports fill rates per field and names which criteria the data cannot support.
+
+| Field | Needed for | Below threshold |
+|---|---|---|
+| Job title | Seniority and function detection | Classification degrades; most leads land in review |
+| Company name | Company-based exclusion | Exclusion is unreliable |
+| Bio | Catching people whose company **and** email are both empty | Own-team and competitor exclusion **will leak** |
+| Work email | Domain-based exclusion | Job-changers slip through |
+| Location | Geography filtering | Geo criteria **cannot** be applied |
+| Industry | Industry filtering | Industry criteria **cannot** be applied |
+
+The bio row is the one people skip. It's the only field that catches a colleague whose company field is blank and who has no email on file — and that's the exact profile of someone imported from a social export.
+
+## Enrichment
+
+When the gate flags gaps, offer profile enrichment, quote the exact cost, and wait for an explicit yes. The coverage output returns the number of leads that would need it.
+
+Enrichment aimed at finding email addresses is a different, more expensive product and contributes nothing to ICP scoring. If someone asks for it here, say plainly that it serves deliverability rather than filtering, and let them decide.
+
+If enrichment is declined, proceed — and state which criteria were dropped and that exclusion is now best-effort.
+
+## The ICP questions
+
+Ask after coverage, and don't offer criteria the data can't support.
+
+| # | Question | Feeds |
+|---|---|---|
+| 1 | Which seniority levels qualify? Founder/C-level · VP/Head of · Manager/Lead · IC | `icp.seniority` |
+| 2 | Which functions? Sales · Growth/Marketing · RevOps/GTM · Partnerships · Product/Tech | `icp.functions` |
+| 3 | Do founders qualify regardless of stated function? | `founder_qualifies_regardless_of_function` |
+| 4 | Any geography or industry constraint? *(only if coverage supports it)* | `icp.locations`, `icp.industries` |
+| 5 | Who is excluded outright — own company, competitors, agencies? | `exclusions` |
+
+**Question 3 carries more weight than it looks.** Most founder titles state no function at all: `Co-Founder`, `Fondatrice`, `Founder @ Stealth`. If founders don't auto-qualify, every one of them lands in review. On a real 150-lead list this single answer moved about fifteen leads. Ask it explicitly and explain the trade-off rather than assuming.
+
+If the ICP comes back vague — "good leads", "decision makers" — push once for specifics. A vague ICP produces an enormous review bucket, which is the problem this skill exists to remove.
+
+## The spec
+
+`build.py` reads one JSON object:
+
+```json
+{
+  "icp": {
+    "seniority": ["founder_c", "vp_head", "manager_lead"],
+    "functions": ["sales", "growth_marketing", "revops"],
+    "founder_qualifies_regardless_of_function": false,
+    "locations": ["France", "Paris"],
+    "industries": ["saas"]
+  },
+  "exclusions": {
+    "domains": ["yourcompany.com"],
+    "companies": ["Your Company"],
+    "keywords": ["competitor-a", "competitor-b"]
+  },
+  "leads": [
+    {
+      "leadId": "...", "jobTitle": "...", "companyName": "...",
+      "proEmail": "...", "shortBio": "...", "location": "...", "industry": "..."
+    }
+  ]
+}
+```
+
+Include `locations` and `industries` only when coverage supports them. Each lead needs an id, or both a first and last name.
+
+Then:
+
+```bash
+python3 scripts/build.py spec.json > pass1.json
+```
+
+It refuses invalid input rather than emitting a best-effort sort. When it errors, fix the spec — never work around it by classifying by hand.
+
+For pass 2, pass `{"result": <pass1 output>, "overrides": [{"_key": "...", "bucket": "...", "reason": "..."}]}` to `--adjudicate`. It re-runs the same reconciliation and rejects an override on a lead that doesn't exist, an invalid bucket, a duplicate, or a reclassification with no substantive reason.
+
+## Two spec traps
+
+**Geography matches on substring, so list the real variants.** Enrichment writes `"Greater Paris Metropolitan Region"` and `"Greater Lyon Area"` — neither contains the string `"France"`, so `locations: ["France"]` silently drops both. Glance at the actual location values before writing the spec and include the metros and regions that appear.
+
+**Industry expands automatically — don't hand-list variants.** Pass a canonical bucket (`saas`, `software`, `tech`, `fintech`, `healthtech`, `ecommerce`) and the script expands it to the platform labels that mean the same thing, so `["saas"]` also catches `Software Development`, `Technology, Information and Internet` and `IT Services`. This matters: real software companies routinely get labelled "Technology, Information and Internet" and would otherwise be dropped. For a bucket outside the synonym map, list the variants yourself, or let the geo/industry queue flag surface the misses in pass 2.
+
+## The buckets
+
+| Bucket | Meaning |
+|---|---|
+| `match` | Seniority and function both in ICP, constraints satisfied |
+| `review` | The engine declined to guess — unclear title, missing function, absent geo/industry data |
+| `no_match` | Out of ICP, or a noise title (student, intern, open-to-work, investor) |
+| `excluded` | Own team, competitor, or a listed exclusion |
+
+Every lead lands in exactly one, with a reason, and the counts reconcile against the input.
+
+A review bucket around a third is normal on thin data. Say so plainly and name the cause rather than presenting it as a finding.
+
+## Self-test
+
+```bash
+python3 scripts/build.py --test
+```
+
+Covers seniority precedence, multi-function collection, bio fallback, each exclusion leak mode, the short-token guard, industry synonym expansion, count reconciliation, and every refusal path.

--- a/skills/erwann-lefevre/audience-icp-filter/references/coverage-and-icp.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/coverage-and-icp.md
@@ -23,7 +23,9 @@ The bio row is the one people skip. It's the only field that catches a colleague
 
 ## Enrichment
 
-When the gate flags gaps, offer profile enrichment, quote the exact cost, and wait for an explicit yes. The coverage output returns the number of leads that would need it.
+When the gate flags gaps, offer profile enrichment, quote the exact cost, and wait for an explicit yes.
+
+The coverage output returns `leads_needing_enrichment` — the number of rows actually missing at least one of the fields that came back insufficient, not the size of the list. On an audience that is mostly complete those are very different numbers, and quoting the total overstates the cost of the fix.
 
 Enrichment aimed at finding email addresses is a different, more expensive product and contributes nothing to ICP scoring. If someone asks for it here, say plainly that it serves deliverability rather than filtering, and let them decide.
 

--- a/skills/erwann-lefevre/audience-icp-filter/references/exclusion-doctrine.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/exclusion-doctrine.md
@@ -1,0 +1,49 @@
+# Exclusion doctrine
+
+Naive exclusion on company name leaks. It leaks in the direction that hurts most: the team's own colleagues end up in a cold prospecting sequence.
+
+Three failure modes, all observed on real lists, all handled deterministically in pass 1.
+
+## 1. Empty company and empty email
+
+The company field is blank, there's no email, and the only trace of the employer is the bio: `Client Partner @ Acme`.
+
+Filtering on the company field lets this person straight through. This is the standard shape of a lead imported from a social export, which is to say it's common.
+
+**Fix:** match exclusions across the whole identity surface — company name, work email, personal email, bio, and company URL. This is why bio coverage is a gate condition and not a nice-to-have.
+
+## 2. Job-changers
+
+The company field says `Vantage Digital` and the work email says `j.moreau@acmelabs.com`. The company is stale, the email is current — or the reverse. Either field read alone gives the wrong answer.
+
+**Fix:** a hit on *either* field excludes. Don't try to decide which one is fresher.
+
+## 3. Collapsed spellings
+
+`@AcmeLabs` and `acme-labs` contain none of the literal string `"Acme Labs"`. Anyone writing the company without its spaces evades a plain substring match.
+
+**Fix:** run a second comparison with all punctuation and spacing stripped from both sides.
+
+**With a length guard.** Below about five characters, a squashed substring match collides constantly — a three-letter company acronym starts firing inside unrelated words and excludes real prospects. Short tokens stay word-bounded; only longer terms get the squashed comparison.
+
+## Always seed with their own company
+
+The single most common leak, and the most embarrassing one. Add the team's own company name and email domain to the exclusion list before anything else, whether or not anyone thought to mention it.
+
+## Extending exclusions in pass 2
+
+Pass 2 can add competitors nobody listed. Say which ones you added and why.
+
+**But a competitor's name in a bio is not an employer.** People list the tools they use in their bios. On real data, two competitor product names appeared in prospects' bios as tools they worked with — excluding those leads was wrong, and it removed real pipeline.
+
+Before excluding on a competitor signal, confirm it appears as the employer or in the email domain, not merely somewhere in the bio text.
+
+## Junk company values
+
+Values like `Nothing`, `-`, `N/A`, `Freelance` and `Self-employed` are not employers. They're either placeholder data or a statement that the person has no company, and treating them as company names produces nonsense exclusions and nonsense matches alike.
+
+Agency, freelance and consultant signals don't get excluded automatically — a consultant can be a genuine buyer — but they do get flagged into the pass-2 queue, because the two cases look identical to a pattern and completely different to a reader.
+
+## What exclusion is not
+
+Exclusion is not a quality filter. It answers "must we never contact this person", not "is this person a good lead". Someone out of ICP goes to `no_match`; someone at a competitor or on the team goes to `excluded`. Collapsing the two loses the distinction between *we chose not to* and *we must not*, which is exactly the distinction anyone auditing the list later needs.

--- a/skills/erwann-lefevre/audience-icp-filter/references/pass-two-review.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/pass-two-review.md
@@ -14,8 +14,11 @@ On a clean, on-target list the queue is fifteen to twenty-five leads. That's the
 | `bio-inferred match` | matched from the bio, not the title | confirm the bio really indicates an in-ICP function |
 | `agency/freelance` | a match whose company or bio reads like an agency, freelancer or consultant | keep if they're a real buyer, drop if they're a service provider |
 | `dropped on geo/industry` | right seniority and function, failed the location or industry substring | rescue if the label is just a variant of an in-ICP value |
+| `bio-inferred drop` | left the ICP on a seniority or function read out of the bio, not the title | confirm the bio really means that, before discarding the lead |
 
 Note that false positives live in `match`, not only in `review` — which is why the queue pulls risky matches in alongside the ambiguous ones. That's how you catch them without re-reading the confident ones.
+
+The same logic runs in the other direction. A lead dropped because of a function or seniority read out of free text is the mirror image of a bio-inferred match: same weak signal, worse consequence, because a wrong drop is invisible by construction. Nothing leaves the ICP on an inference without passing through the queue first.
 
 ## What patterns can't catch
 

--- a/skills/erwann-lefevre/audience-icp-filter/references/pass-two-review.md
+++ b/skills/erwann-lefevre/audience-icp-filter/references/pass-two-review.md
@@ -1,0 +1,60 @@
+# Pass 2 — semantic review
+
+Pass 1 sorts on patterns. Pass 2 reads for meaning. It is mandatory, it is bounded, and it is the agent's work rather than the user's.
+
+## Review the queue, not the list
+
+Pass 1 returns a `pass2_queue`: the only leads worth inspecting. Reviewing anything outside it is the eight-minute mistake — on a 250-lead list, reading every lead individually took eight minutes and changed almost nothing, because the confident classifications were never in doubt.
+
+On a clean, on-target list the queue is fifteen to twenty-five leads. That's the whole job.
+
+| Flag | What it is | What to check |
+|---|---|---|
+| `ambiguous` | the entire review bucket | resolve to match or no_match where you honestly can |
+| `bio-inferred match` | matched from the bio, not the title | confirm the bio really indicates an in-ICP function |
+| `agency/freelance` | a match whose company or bio reads like an agency, freelancer or consultant | keep if they're a real buyer, drop if they're a service provider |
+| `dropped on geo/industry` | right seniority and function, failed the location or industry substring | rescue if the label is just a variant of an in-ICP value |
+
+Note that false positives live in `match`, not only in `review` — which is why the queue pulls risky matches in alongside the ambiguous ones. That's how you catch them without re-reading the confident ones.
+
+## What patterns can't catch
+
+| Lead | Pass 1 says | Reality |
+|---|---|---|
+| `Chief Happiness Officer` | C-level → match | HR role. Not a buyer. |
+| `Chief Medical Officer` | C-level → match | Clinical role. Not a buyer. |
+| `Head of Growth` at an unlisted competitor | match | Should be excluded |
+| `companyName: "Nothing"` | treated as a company | Junk data |
+| `Founder @ Stealth Mode` | review | Almost certainly in ICP |
+| A title in a language the taxonomy misses | review | Often a clear match |
+
+The `Chief … Officer` pattern is deliberately broad in pass 1 — it catches every real C-level, and pass 2 removes the happiness, medical and people officers. Narrowing the pattern to avoid the false positives would lose real buyers, which is the worse error.
+
+**Bare functional C-titles resolve for seniority but not for function.** `CMO @ Acme` is unambiguously C-level and carries no function token, so it lands in review. Read these as their function — CMO as marketing, CRO as sales, CTO as product/tech — rather than leaving them ambiguous.
+
+## Two rescues worth knowing
+
+Both came out of real runs and both are pure queue work:
+
+**Agencies and freelancers sitting in `match`.** The title and function are right, and the company is a five-person consultancy that will never buy. Or it's a genuine buyer who happens to be independent. Only reading tells you which.
+
+**Real target companies sitting in `no_match` on an industry label.** A software company labelled `Technology, Information and Internet` rather than `Software` fails an industry substring and gets dropped. The synonym expansion catches the common cases; the queue flag catches the rest.
+
+## Working the queue down is the deliverable
+
+Read each queued lead's full record — title, bio, industry, company — and resolve as many as you honestly can. Write the overrides with a substantive reason each; the adjudication step rejects reclassifications with no reason, duplicates, invalid buckets, and overrides on leads that don't exist. Nothing can be lost in pass 2 either.
+
+Leave only the genuinely ambiguous handful for a human decision. A fifty-lead review bucket handed back untouched is not a result — it's the hand-sorting this skill exists to eliminate, relabelled as output.
+
+## When the queue is large
+
+A queue of sixty or more is a diagnosis, not a workload. Two causes, in order of likelihood:
+
+1. **The list was never enriched.** Check coverage. Thin titles and empty bios push everything into ambiguity.
+2. **The ICP is under-specified.** Most often the founder question went unanswered, so every function-less founder title is sitting in review. Sometimes the function list is simply too narrow for the list in hand.
+
+Name the cause and fix it upstream. Re-running pass 1 with a corrected spec takes seconds; hand-reviewing sixty leads does not.
+
+## Report what changed, briefly
+
+What pass 2 reclassified is an audit detail, not a headline. One line: how many moved, and why in aggregate — "moved 3: 2 rescued on an industry-label variant, 1 competitor excluded". The buckets and counts are the result; the reclassification log is provenance.

--- a/skills/erwann-lefevre/audience-icp-filter/references/title-taxonomy.json
+++ b/skills/erwann-lefevre/audience-icp-filter/references/title-taxonomy.json
@@ -1,0 +1,122 @@
+{
+  "_comment": "Ordered pattern taxonomy. Seniority is evaluated top-down: the FIRST tier whose pattern matches wins. Order matters — 'Chief Executive Officer' must hit founder_c before 'executive' sends it to ic.",
+  "seniority": [
+    {
+      "tier": "founder_c",
+      "label": "Founder / C-level",
+      "patterns": [
+        "\\bfounder\\b", "\\bco-?founder\\b", "\\bfondat(eur|rice)\\b", "\\bfounding (member|partner)\\b",
+        "\\bceo\\b", "\\bcto\\b", "\\bcmo\\b", "\\bcro\\b", "\\bcoo\\b", "\\bcpo\\b", "\\bcfo\\b", "\\bciso\\b",
+        "chief [a-z ]{0,20}officer", "\\bpresident\\b", "\\bpr[ée]sident\\b",
+        "\\bowner\\b", "\\bmanaging (partner|director)\\b", "\\bg[ée]rant\\b", "\\bassoci[ée]\\b"
+      ]
+    },
+    {
+      "tier": "vp_head",
+      "label": "VP / Head of",
+      "patterns": [
+        "\\bvp\\b", "\\bs?vp\\b", "\\bevp\\b", "vice[- ]president",
+        "\\bhead of\\b", "\\bhead,", "\\bglobal head\\b",
+        "\\bdirector\\b", "\\bdirecteur\\b", "\\bdirectrice\\b", "\\bdirection\\b",
+        "\\bgeneral manager\\b", "\\bcountry manager\\b"
+      ]
+    },
+    {
+      "tier": "manager_lead",
+      "label": "Manager / Lead",
+      "patterns": [
+        "\\bmanager\\b", "\\bmanagement\\b", "\\blead\\b", "\\bleader\\b",
+        "\\bresponsable\\b", "\\bsupervisor\\b", "\\bprincipal\\b",
+        "\\bfounder'?s office\\b", "\\bchef de\\b"
+      ]
+    },
+    {
+      "tier": "ic",
+      "label": "Individual contributor",
+      "patterns": [
+        "\\bspecialist\\b", "\\bcoordinator\\b", "\\banalyst\\b", "\\bassociate\\b",
+        "\\baccount executive\\b", "\\bae\\b", "\\bsdr\\b", "\\bbdr\\b",
+        "\\brepresentative\\b", "\\bexecutive\\b", "\\bconsultant\\b",
+        "\\bengineer\\b", "\\bdeveloper\\b", "\\bdesigner\\b", "\\bscientist\\b",
+        "\\bintern\\b", "\\bjunior\\b", "\\bjr\\b", "\\bstudent\\b", "\\bfreelance\\b",
+        "\\bexpert\\b", "\\bstrategist\\b", "\\bofficer\\b"
+      ]
+    }
+  ],
+  "_function_comment": "Functions are NOT ordered — all matches are collected, then intersected with the ICP. A title can carry several (e.g. 'Sales and Marketing').",
+  "function": [
+    {
+      "key": "sales",
+      "label": "Sales / SDR / BDR",
+      "patterns": [
+        "\\bsales\\b", "\\bselling\\b", "\\bvente\\b", "\\bcommercial(e|ial)?\\b",
+        "\\baccount executive\\b", "\\bsdr\\b", "\\bbdr\\b", "\\bae\\b",
+        "business development", "\\bnew business\\b", "\\bd[ée]veloppement commercial\\b",
+        "\\bpipeline\\b", "\\bquota\\b", "\\bpre-?sales\\b"
+      ]
+    },
+    {
+      "key": "growth_marketing",
+      "label": "Growth / Marketing",
+      "patterns": [
+        "\\bgrowth\\b", "\\bmarketing\\b", "\\bmartech\\b", "\\bdemand gen",
+        "\\bacquisition\\b", "\\bbrand\\b", "\\bcontent\\b", "\\bseo\\b",
+        "\\bpaid\\b", "\\bads?\\b", "\\bcampaign\\b", "\\bcroissance\\b"
+      ]
+    },
+    {
+      "key": "revops",
+      "label": "RevOps / GTM engineering",
+      "patterns": [
+        "\\brevops\\b", "revenue operations", "revenue systems", "revenue strategy",
+        "sales operations", "\\bsales ops\\b", "\\bgtm\\b", "go-?to-?market",
+        "\\brevenue\\b", "\\bcrm\\b", "\\bautomation\\b", "\\benablement\\b"
+      ]
+    },
+    {
+      "key": "partnerships",
+      "label": "Partnerships / Alliances",
+      "patterns": ["\\bpartnership", "\\balliance", "\\bchannel\\b", "\\baffiliate", "\\bpartner\\b"]
+    },
+    {
+      "key": "product_tech",
+      "label": "Product / Engineering",
+      "patterns": [
+        "\\bproduct\\b", "\\bengineer", "\\bdeveloper\\b", "\\bsoftware\\b",
+        "\\bcto\\b", "\\bcpo\\b", "\\bdevops\\b", "\\bqa\\b", "\\bdata\\b", "\\bIT\\b",
+        "information system", "\\bsecurity\\b", "\\bdesign", "\\btechnical\\b",
+        "\\btechnolog(y|ies|ie)\\b", "\\bplatform\\b", "\\barchitect\\b", "\\bR&D\\b"
+      ]
+    },
+    {
+      "key": "other",
+      "label": "Other / support functions",
+      "patterns": [
+        "\\bhr\\b", "\\brecruit", "\\btalent\\b", "\\bfinance\\b", "\\baccounting\\b",
+        "\\bcompta\\b", "\\blegal\\b", "\\boffice manager\\b", "\\bcustomer success\\b",
+        "\\bsupport\\b", "\\bcoach", "\\bteacher\\b", "\\bjournalist", "\\b[ée]ditorial"
+      ]
+    }
+  ],
+  "_noise_comment": "Titles that indicate the person is not a buyer for a GTM tool regardless of seniority. Used to route to no_match, never silently dropped.",
+  "noise_patterns": [
+    "\\bstudent\\b", "\\bintern\\b", "\\bopen to work\\b", "\\bseeking\\b",
+    "\\bjob seeker\\b", "\\bretired\\b", "\\bventure scout\\b", "\\bangel investor\\b"
+  ],
+  "_industry_synonyms_comment": "When the user's ICP industries list contains a key (or the key contains it), the variants are added before matching. LinkedIn writes SaaS a dozen ways; this keeps a real SaaS company from being wrongly dropped as no_match. Match is substring, case-insensitive.",
+  "industry_synonyms": {
+    "saas": ["software development", "computer software", "software", "technology, information and internet", "information technology", "it services", "internet", "saas", "b2b software", "enterprise software"],
+    "software": ["software development", "computer software", "software", "technology, information and internet", "information technology", "it services", "internet", "saas"],
+    "tech": ["software development", "computer software", "technology, information and internet", "information technology", "it services", "internet", "information services", "data infrastructure and analytics", "technology"],
+    "fintech": ["financial services", "fintech", "banking", "software development", "technology, information and internet"],
+    "healthtech": ["hospitals and health care", "health, wellness and fitness", "medical devices", "biotechnology research", "software development"],
+    "ecommerce": ["retail", "e-commerce", "consumer goods", "internet", "software development"]
+  },
+  "_agency_comment": "Agency / freelance / consulting signals. NOT an auto-exclude (some agencies are ICP) — a lead whose company or bio hits these is FLAGGED so pass 2 gives it a look instead of trusting the auto-match. Checked against company name and bio.",
+  "agency_patterns": [
+    "\\bagenc(e|y|ies)\\b", "\\bfreelance", "\\bfreelanc", "\\bind[eé]pendant", "\\bfractional\\b",
+    "\\bconsult(ing|ant|ance)\\b", "\\bconseil\\b", "\\bstudio\\b", "\\bcollective\\b", "\\bcollectif\\b",
+    "\\bself-?employed\\b", "\\bauto-?entrepreneur\\b", "\\b\\bEI\\b", "\\bsole trader\\b", "\\bportage\\b",
+    "\\bsolopreneur\\b", "\\bexternalis", "\\boutsourc"
+  ]
+}

--- a/skills/erwann-lefevre/audience-icp-filter/scripts/build.py
+++ b/skills/erwann-lefevre/audience-icp-filter/scripts/build.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+"""build.py — classify an audience into ICP buckets. Refuses invalid input.
+
+TWO-PASS BY DESIGN. Neither pass is optional.
+
+  Pass 1 (this script, default mode) — deterministic. Sorts every lead into
+  exactly one of excluded / match / review / no_match using the pattern
+  taxonomy, and reconciles the counts. Guarantees nothing is lost and that
+  exclusions are applied uniformly.
+
+  Pass 2 (the model, then --adjudicate) — semantic. Patterns cannot read
+  meaning: 'Chief Happiness Officer' matches the C-level pattern but is an HR
+  role; 'Nothing' is not a company; a competitor absent from the exclusion list
+  is invisible to a regex. The model reviews EVERY bucket, proposes overrides
+  with reasons, and this script re-validates them so the model cannot lose or
+  duplicate a lead either.
+
+Pass 1 alone is fast and wrong at the edges. Pass 2 alone is unauditable and
+leaks. The combination is the point.
+
+Usage:
+    python3 scripts/build.py spec.json                 # pass 1
+    cat spec.json | python3 scripts/build.py -
+    python3 scripts/build.py --adjudicate review.json  # pass 2, validated
+    python3 scripts/build.py --test
+"""
+import sys, os, json, re, argparse
+
+TAXONOMY_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "..", "references", "title-taxonomy.json")
+
+VALID_SENIORITY = {"founder_c", "vp_head", "manager_lead", "ic"}
+BUCKETS = ("match", "review", "no_match", "excluded")
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _load_taxonomy(path=TAXONOMY_PATH):
+    with open(path, encoding="utf-8") as fh:
+        raw = json.load(fh)
+    tax = {
+        "seniority": [(t["tier"], [re.compile(p, re.I) for p in t["patterns"]])
+                      for t in raw["seniority"]],
+        "function": {f["key"]: [re.compile(p, re.I) for p in f["patterns"]]
+                     for f in raw["function"]},
+        "noise": [re.compile(p, re.I) for p in raw["noise_patterns"]],
+        "industry_synonyms": {k.lower(): [v.lower() for v in vs]
+                              for k, vs in raw.get("industry_synonyms", {}).items()},
+        "agency": [re.compile(p, re.I) for p in raw.get("agency_patterns", [])],
+    }
+    return tax
+
+
+def expand_industries(industries, tax):
+    """Add known LinkedIn industry variants for any canonical bucket the user
+    named. 'SaaS' alone would miss a company labelled 'Technology, Information
+    and Internet'; expanding it up front stops that lead becoming a false
+    no_match the model then has to repair. Returns a de-duplicated list."""
+    if not industries:
+        return industries
+    syn = tax.get("industry_synonyms", {})
+    out = []
+    for term in industries:
+        t = term.strip().lower()
+        out.append(term)
+        for key, variants in syn.items():
+            if key in t or t in key:
+                out.extend(variants)
+    seen, dedup = set(), []
+    for x in out:
+        xl = x.lower()
+        if xl not in seen:
+            seen.add(xl)
+            dedup.append(x)
+    return dedup
+
+
+def is_agency(lead, tax):
+    """True if the lead's company or bio reads like an agency / freelance /
+    consulting shop. Not an exclusion — a flag so pass 2 double-checks."""
+    hay = (_norm(lead.get("companyName")) + " | " + _norm(lead.get("shortBio")))
+    return any(p.search(hay) for p in tax.get("agency", []))
+
+
+# ---------------------------------------------------------------- validation
+
+def validate_spec(spec):
+    """Raise ValidationError on anything that would produce a wrong sort."""
+    if not isinstance(spec, dict):
+        raise ValidationError("spec must be a JSON object")
+
+    icp = spec.get("icp")
+    if not isinstance(icp, dict):
+        raise ValidationError("spec.icp is required and must be an object")
+
+    sen = icp.get("seniority")
+    if not isinstance(sen, list) or not sen:
+        raise ValidationError("icp.seniority must be a non-empty list")
+    bad = set(sen) - VALID_SENIORITY
+    if bad:
+        raise ValidationError(
+            f"unknown seniority tier(s): {sorted(bad)}. Valid: {sorted(VALID_SENIORITY)}")
+
+    fns = icp.get("functions")
+    if not isinstance(fns, list) or not fns:
+        raise ValidationError("icp.functions must be a non-empty list")
+
+    leads = spec.get("leads")
+    if not isinstance(leads, list):
+        raise ValidationError("spec.leads must be a list")
+    if not leads:
+        raise ValidationError("spec.leads is empty — nothing to classify")
+
+    for i, ld in enumerate(leads):
+        if not isinstance(ld, dict):
+            raise ValidationError(f"leads[{i}] must be an object")
+        has_id = bool(str(ld.get("leadId") or "").strip())
+        has_name = bool(str(ld.get("firstname") or "").strip()) and \
+                   bool(str(ld.get("lastname") or "").strip())
+        if not (has_id or has_name):
+            raise ValidationError(
+                f"leads[{i}] needs a leadId, or both firstname and lastname — "
+                "without an identifier it cannot be written back safely")
+
+
+def validate_result(leads, result):
+    """Nothing lost, nothing duplicated, nothing in two buckets."""
+    total = sum(len(result[b]) for b in BUCKETS)
+    if total != len(leads):
+        raise ValidationError(
+            f"count mismatch: {len(leads)} leads in, {total} classified out")
+    seen = {}
+    for b in BUCKETS:
+        for row in result[b]:
+            key = row["_key"]
+            if key in seen:
+                raise ValidationError(
+                    f"lead {key!r} classified into both {seen[key]} and {b}")
+            seen[key] = b
+
+
+# ------------------------------------------------------------ classification
+
+def _norm(v):
+    return str(v or "").strip()
+
+
+def _haystack(lead):
+    """Every field that can reveal who someone really works for.
+
+    Deliberately includes shortBio: attendees routinely have an empty company
+    and no email while their bio says 'Client Partner @ Acme'. Matching on
+    company alone lets those through.
+    """
+    return " | ".join([
+        _norm(lead.get("companyName")),
+        _norm(lead.get("proEmail")),
+        _norm(lead.get("persoEmail")),
+        _norm(lead.get("shortBio")),
+        _norm(lead.get("companyUrl")),
+    ]).lower()
+
+
+def detect_seniority(title, tax):
+    for tier, patterns in tax["seniority"]:
+        for pat in patterns:
+            if pat.search(title):
+                return tier
+    return None
+
+
+def detect_functions(title, tax):
+    found = []
+    for key, patterns in tax["function"].items():
+        if any(p.search(title) for p in patterns):
+            found.append(key)
+    return found
+
+
+def _squash(s):
+    """Strip everything but letters and digits.
+
+    People write the same company a dozen ways: 'Northwind Labs',
+    '@NorthwindLabs', 'northwind-labs'. Matching the spaced form alone
+    misses the collapsed one, which is exactly how a colleague ends up in your
+    prospect list. Squashing both sides makes the comparison spelling-agnostic.
+    """
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+# Below this length, a squashed substring match is too collision-prone to trust
+# ('nwl' would fire inside unrelated words), so short terms stay word-bounded.
+_SQUASH_MIN = 5
+
+
+def check_exclusions(lead, exclusions):
+    hay = _haystack(lead)
+    hay_squashed = _squash(hay)
+
+    for dom in exclusions.get("domains", []):
+        d = dom.strip().lower().lstrip("@")
+        if not d:
+            continue
+        if d in hay:
+            return f"excluded domain: {dom}"
+        # 'northwindlabs.com' should also catch a bare '@NorthwindLabs'
+        stem = _squash(d.rsplit(".", 1)[0])
+        if len(stem) >= _SQUASH_MIN and stem in hay_squashed:
+            return f"excluded domain: {dom}"
+
+    for comp in exclusions.get("companies", []):
+        c = comp.strip().lower()
+        if not c:
+            continue
+        if re.search(r"(?<![a-z0-9])" + re.escape(c) + r"(?![a-z0-9])", hay):
+            return f"excluded company: {comp}"
+        cs = _squash(c)
+        if len(cs) >= _SQUASH_MIN and cs in hay_squashed:
+            return f"excluded company: {comp}"
+
+    for kw in exclusions.get("keywords", []):
+        k = kw.strip().lower()
+        if not k:
+            continue
+        if k in hay:
+            return f"excluded keyword: {kw}"
+        ks = _squash(k)
+        if len(ks) >= _SQUASH_MIN and ks in hay_squashed:
+            return f"excluded keyword: {kw}"
+
+    return None
+
+
+def _criterion_ok(lead, field, wanted):
+    """Return True / False / None (None = data missing, cannot judge)."""
+    if not wanted:
+        return True
+    val = _norm(lead.get(field)).lower()
+    if not val:
+        return None
+    return any(w.strip().lower() in val for w in wanted)
+
+
+def classify(lead, icp, exclusions, tax):
+    """Return (bucket, reason)."""
+    reason_excl = check_exclusions(lead, exclusions)
+    if reason_excl:
+        return "excluded", reason_excl
+
+    title = _norm(lead.get("jobTitle"))
+    if not title:
+        return "review", "no job title — cannot judge seniority or function"
+
+    tl = title.lower()
+    for pat in tax["noise"]:
+        if pat.search(tl):
+            return "no_match", f"noise title: {title}"
+
+    # The title is the primary signal, but since enrichment now exposes the bio,
+    # use it as a fallback: many people write their function in the bio, not the
+    # title ("Managing Director" + bio "Développement commercial"). Only fall
+    # back when the title is silent — the title is more reliable when present.
+    bio = _norm(lead.get("shortBio")).lower()
+
+    seniority = detect_seniority(tl, tax)
+    sen_src = "title"
+    if seniority is None and bio:
+        seniority = detect_seniority(bio, tax)
+        sen_src = "bio"
+
+    functions = detect_functions(tl, tax)
+    fn_src = "title"
+    if not functions and bio:
+        functions = detect_functions(bio, tax)
+        fn_src = "bio"
+
+    if seniority is None:
+        return "review", f"seniority unclear from title or bio: {title}"
+
+    if seniority not in icp["seniority"]:
+        return "no_match", f"seniority {seniority} not in ICP"
+
+    founder_pass = (seniority == "founder_c" and
+                    icp.get("founder_qualifies_regardless_of_function", False))
+
+    if not founder_pass:
+        if not functions:
+            return "review", f"function unclear from title or bio: {title}"
+        if not set(functions) & set(icp["functions"]):
+            return "no_match", f"function {functions} not in ICP"
+
+    for field, key in (("location", "locations"), ("industry", "industries")):
+        ok = _criterion_ok(lead, field, icp.get(key))
+        if ok is None:
+            return "review", f"{field} required by ICP but missing on this lead"
+        if ok is False:
+            return "no_match", f"{field} outside ICP"
+
+    detail = f"{seniority}"
+    if functions:
+        detail += f" / {'+'.join(functions)}"
+    src = []
+    if sen_src == "bio":
+        src.append("seniority from bio")
+    if fn_src == "bio":
+        src.append("function from bio")
+    if src:
+        detail += f" (inferred: {', '.join(src)} — worth a pass-2 glance)"
+    return "match", f"ICP match: {detail}"
+
+
+def build(spec):
+    validate_spec(spec)
+    tax = _load_taxonomy()
+
+    icp = dict(spec["icp"])
+    # expand SaaS/tech/etc. into their real LinkedIn industry variants up front
+    if icp.get("industries"):
+        icp["industries"] = expand_industries(icp["industries"], tax)
+    exclusions = spec.get("exclusions", {}) or {}
+    leads = spec["leads"]
+
+    result = {b: [] for b in BUCKETS}
+    queue = []
+    for i, lead in enumerate(leads):
+        bucket, reason = classify(lead, icp, exclusions, tax)
+        key = _norm(lead.get("leadId")) or \
+            f"{_norm(lead.get('firstname'))} {_norm(lead.get('lastname'))}#{i}"
+        row = dict(lead)
+        row["_key"] = key
+        row["_bucket"] = bucket
+        row["_reason"] = reason
+
+        # Flag the leads pass 2 should actually look at — so it reviews ~a few
+        # dozen, not the whole audience. Three risk classes:
+        flag = None
+        if bucket == "review":
+            flag = "ambiguous"                                   # always
+        elif bucket == "match":
+            if "inferred:" in reason:
+                flag = "bio-inferred match"                      # soft match
+            elif is_agency(lead, tax):
+                flag = "agency/freelance — confirm it's the ICP" # false-positive risk
+        elif bucket == "no_match":
+            # dropped ONLY on a soft substring criterion → likely false negative
+            if reason.startswith("location outside") or reason.startswith("industry outside"):
+                flag = "dropped on geo/industry — check the variant"
+        if flag:
+            row["_flag"] = flag
+            queue.append(row)
+
+        result[bucket].append(row)
+
+    validate_result(leads, result)
+
+    return {
+        "pass": 1,
+        "adjudicated": False,
+        "counts": {b: len(result[b]) for b in BUCKETS} | {"total": len(leads)},
+        "pass2_queue_size": len(queue),
+        "pass2_queue": queue,
+        "buckets": result,
+    }
+
+
+# ----------------------------------------------------------- coverage report
+
+# Below these fill rates a criterion cannot be applied honestly: the engine
+# would send most leads to `review` for missing data and call it a result.
+COVERAGE_RULES = [
+    ("jobTitle",    0.80, "core",       "seniority and function detection"),
+    ("companyName", 0.60, "core",       "company-based exclusion"),
+    ("shortBio",    0.50, "exclusion",  "catching people whose company/email is empty"),
+    ("proEmail",    0.40, "exclusion",  "domain-based exclusion"),
+    ("location",    0.80, "locations",  "geography filtering"),
+    ("industry",    0.80, "industries", "industry filtering"),
+]
+
+
+def coverage(payload):
+    """Report field fill rates and say which ICP criteria the data can support.
+
+    Run this BEFORE the ICP Q&A. There is no point offering geography filtering
+    on an audience where `location` is empty everywhere — that just routes the
+    whole list to `review`. Better to see the gap and offer enrichment first.
+    """
+    leads = payload.get("leads") if isinstance(payload, dict) else None
+    if not isinstance(leads, list) or not leads:
+        raise ValidationError("payload.leads must be a non-empty list")
+
+    n = len(leads)
+    fields, blocked, degraded = {}, [], []
+    for field, threshold, kind, purpose in COVERAGE_RULES:
+        filled = sum(1 for ld in leads if _norm(ld.get(field)))
+        rate = filled / n
+        ok = rate >= threshold
+        fields[field] = {
+            "filled": filled, "rate": round(rate, 3),
+            "threshold": threshold, "sufficient": ok, "enables": purpose,
+        }
+        if not ok:
+            (blocked if kind in ("locations", "industries") else degraded).append(
+                {"field": field, "rate": round(rate, 3), "impact": purpose,
+                 "criterion": kind})
+
+    return {
+        "total_leads": n,
+        "fields": fields,
+        "blocked_criteria": blocked,
+        "degraded_checks": degraded,
+        "enrichment_recommended": bool(blocked or degraded),
+        "leads_needing_enrichment": n,
+    }
+
+
+# ------------------------------------------------------- pass 2: adjudication
+
+MIN_REASON_LEN = 12
+
+
+def adjudicate(payload):
+    """Apply the model's pass-2 overrides to a pass-1 result, and re-validate.
+
+    The model may move any lead between buckets, but must justify each move.
+    We re-run the same reconciliation as pass 1 so a semantic pass cannot
+    silently drop someone — the exact failure mode the two-pass design exists
+    to prevent.
+    """
+    if not isinstance(payload, dict):
+        raise ValidationError("adjudication payload must be a JSON object")
+
+    result = payload.get("result")
+    if not isinstance(result, dict) or "buckets" not in result:
+        raise ValidationError(
+            "payload.result must be the output of a pass-1 run (with .buckets)")
+
+    overrides = payload.get("overrides", [])
+    if not isinstance(overrides, list):
+        raise ValidationError("payload.overrides must be a list (use [] for none)")
+
+    index = {}
+    for b in BUCKETS:
+        for row in result["buckets"].get(b, []):
+            index[row["_key"]] = (b, row)
+    original_total = len(index)
+    if original_total == 0:
+        raise ValidationError("pass-1 result contains no leads")
+
+    audit, seen_keys = [], set()
+    for i, ov in enumerate(overrides):
+        if not isinstance(ov, dict):
+            raise ValidationError(f"overrides[{i}] must be an object")
+        key = str(ov.get("_key") or "").strip()
+        if not key:
+            raise ValidationError(f"overrides[{i}] is missing _key")
+        if key in seen_keys:
+            raise ValidationError(f"overrides[{i}]: duplicate override for {key!r}")
+        if key not in index:
+            raise ValidationError(
+                f"overrides[{i}]: {key!r} is not a lead from the pass-1 result")
+        new_bucket = str(ov.get("bucket") or "").strip()
+        if new_bucket not in BUCKETS:
+            raise ValidationError(
+                f"overrides[{i}]: bucket {new_bucket!r} invalid. Valid: {list(BUCKETS)}")
+        reason = str(ov.get("reason") or "").strip()
+        if len(reason) < MIN_REASON_LEN:
+            raise ValidationError(
+                f"overrides[{i}]: every override needs a substantive reason "
+                f"(at least {MIN_REASON_LEN} chars) — an unexplained "
+                "reclassification is not auditable")
+        seen_keys.add(key)
+
+        old_bucket, row = index[key]
+        if old_bucket != new_bucket:
+            audit.append({
+                "_key": key, "from": old_bucket, "to": new_bucket,
+                "pass1_reason": row.get("_reason"), "pass2_reason": reason,
+            })
+        row = dict(row)
+        row["_bucket"] = new_bucket
+        row["_reason"] = reason
+        row["_pass1_bucket"] = old_bucket
+        index[key] = (new_bucket, row)
+
+    final = {b: [] for b in BUCKETS}
+    for key, (bucket, row) in index.items():
+        final[bucket].append(row)
+
+    flat = [r for b in BUCKETS for r in final[b]]
+    if len(flat) != original_total:
+        raise ValidationError(
+            f"adjudication lost leads: {original_total} in, {len(flat)} out")
+    validate_result(flat, final)
+
+    return {
+        "pass": 2,
+        "adjudicated": True,
+        "counts": {b: len(final[b]) for b in BUCKETS} | {"total": original_total},
+        "changes": audit,
+        "buckets": final,
+    }
+
+
+# -------------------------------------------------------------------- self-test
+
+def _selftest():
+    tax = _load_taxonomy()
+    icp = {
+        "seniority": ["founder_c", "vp_head", "manager_lead"],
+        "functions": ["sales", "growth_marketing", "revops"],
+        "founder_qualifies_regardless_of_function": False,
+    }
+    excl = {"domains": ["northwindlabs.com"], "companies": ["Northwind Labs", "NWL"],
+            "keywords": ["coldmails"]}
+
+    cases = [
+        # (lead, expected_bucket, note)
+        ({"leadId": "1", "jobTitle": "Client Partner", "companyName": "",
+          "proEmail": "", "shortBio": "Client Partner @ NWL"},
+         "excluded", "empty company + empty email, only the bio reveals NWL"),
+        ({"leadId": "1b", "jobTitle": "Client Partner", "companyName": "",
+          "proEmail": "", "shortBio": "Client Partner @NorthwindLabs"},
+         "excluded", "collapsed spelling: @NorthwindLabs vs 'Northwind Labs'"),
+        ({"leadId": "1c", "jobTitle": "Growth Lead", "companyName": "northwind-labs"},
+         "excluded", "hyphenated spelling"),
+        ({"leadId": "2", "jobTitle": "Client Account Executive",
+          "companyName": "Vantage Digital", "proEmail": "j.moreau@northwindlabs.com"},
+         "excluded", "job-changer: stale company, current email"),
+        ({"leadId": "2b", "jobTitle": "Head of Sales", "companyName": "Algomo"},
+         "match", "must NOT trip the short-token 'nwl' exclusion"),
+        ({"leadId": "3", "jobTitle": "Founding Member", "companyName": "Coldmails.ai"},
+         "excluded", "competitor by keyword"),
+        ({"leadId": "4", "jobTitle": "Head of Global Business Development",
+          "companyName": "TBCASoft"}, "match", "vp_head + sales"),
+        ({"leadId": "5", "jobTitle": "Revenue Systems & Operations Lead",
+          "companyName": "Doormate"}, "match", "manager_lead + revops"),
+        ({"leadId": "6", "jobTitle": "Account Executive", "companyName": "Calderon"},
+         "no_match", "IC not in ICP"),
+        ({"leadId": "7", "jobTitle": "Chief Technology Officer", "companyName": "Narrio"},
+         "no_match", "C-level but product/tech function"),
+        ({"leadId": "8", "jobTitle": "Co-Founder", "companyName": "Concourse"},
+         "review", "founder with no stated function, founder_qualifies=False"),
+        ({"leadId": "9", "jobTitle": "", "companyName": "Smartelia"},
+         "review", "no title at all"),
+        ({"leadId": "10", "jobTitle": "Venture Scout", "companyName": "Bouken Capital"},
+         "no_match", "noise title"),
+        ({"leadId": "11", "jobTitle": "General Manager of Sales and Marketing",
+          "companyName": "20Cube"}, "match", "vp_head + sales/marketing"),
+        ({"leadId": "12", "jobTitle": "Managing Director", "companyName": "Acme",
+          "shortBio": "Développement commercial B2B"},
+         "match", "function comes from bio, not the title"),
+        ({"leadId": "13", "jobTitle": "Principal", "companyName": "Acme",
+          "shortBio": "Woodworking hobbyist and dad of three"},
+         "review", "bio has no function signal either — stays in review"),
+    ]
+
+    failures = 0
+    for lead, expected, note in cases:
+        got, reason = classify(lead, icp, excl, tax)
+        if got != expected:
+            failures += 1
+            print(f"FAIL [{note}] expected={expected} got={got} ({reason})",
+                  file=sys.stderr)
+
+    # founder toggle flips case 8 to match
+    icp_f = dict(icp, founder_qualifies_regardless_of_function=True)
+    got, _ = classify({"leadId": "8", "jobTitle": "Co-Founder",
+                       "companyName": "Concourse"}, icp_f, excl, tax)
+    total = len(cases) + 1
+    if got != "match":
+        failures += 1
+        print(f"FAIL [founder toggle] expected=match got={got}", file=sys.stderr)
+
+    # bad specs must be refused, not best-efforted
+    bad_specs = [
+        ({"icp": icp}, "missing leads"),
+        ({"icp": {"seniority": ["cxo"], "functions": ["sales"]},
+          "leads": [{"leadId": "x"}]}, "unknown seniority tier"),
+        ({"icp": icp, "leads": [{"jobTitle": "CEO"}]}, "lead with no identifier"),
+        ({"icp": icp, "leads": []}, "empty lead list"),
+    ]
+    for spec, note in bad_specs:
+        total += 1
+        try:
+            build(spec)
+            failures += 1
+            print(f"FAIL [{note}] should have raised ValidationError", file=sys.stderr)
+        except ValidationError:
+            pass
+
+    # reconciliation: every lead lands in exactly one bucket
+    total += 1
+    out = build({"icp": icp, "exclusions": excl,
+                 "leads": [c[0] for c in cases]})
+    if out["counts"]["total"] != len(cases) or \
+       sum(out["counts"][b] for b in BUCKETS) != len(cases):
+        failures += 1
+        print("FAIL [reconciliation] counts do not add up", file=sys.stderr)
+
+    # --- industry synonym expansion: 'saas' must catch a LinkedIn-labelled variant ---
+    icp_saas = {"seniority": ["founder_c", "vp_head"], "functions": ["growth_marketing"],
+                "founder_qualifies_regardless_of_function": False, "industries": ["saas"]}
+    total += 1
+    got, reason = classify(
+        {"leadId": "s1", "jobTitle": "Head of Marketing", "companyName": "Implicity",
+         "industry": "Technology, Information and Internet"},
+        {**icp_saas, "industries": expand_industries(icp_saas["industries"], tax)}, {}, tax)
+    if got != "match":
+        failures += 1
+        print(f"FAIL [industry synonym] expected match got {got} ({reason})", file=sys.stderr)
+
+    # a genuinely off-industry lead still drops
+    total += 1
+    got, _ = classify(
+        {"leadId": "s2", "jobTitle": "Head of Marketing", "companyName": "TotalEnergies",
+         "industry": "Oil and Gas"},
+        {**icp_saas, "industries": expand_industries(icp_saas["industries"], tax)}, {}, tax)
+    if got != "no_match":
+        failures += 1
+        print(f"FAIL [off-industry] expected no_match got {got}", file=sys.stderr)
+
+    # --- pass2_queue is bounded: only ambiguous / risky / soft-drops, not everything ---
+    total += 1
+    qout = build({"icp": {**icp_saas, "industries": ["saas"]}, "exclusions": {}, "leads": [
+        {"leadId": "q1", "jobTitle": "Head of Marketing", "companyName": "Acme",
+         "industry": "Software Development"},                       # clean match, NOT queued
+        {"leadId": "q2", "jobTitle": "Head of Marketing", "companyName": "Freelance Studio",
+         "industry": "Software Development", "shortBio": "Freelance CMO / consultant"},  # agency match → queued
+        {"leadId": "q3", "jobTitle": "Head of Marketing", "companyName": "EnergyCo",
+         "industry": "Renewables & Environment"},                   # dropped on industry → queued
+        {"leadId": "q4", "jobTitle": "Software Engineer", "companyName": "Acme",
+         "industry": "Software Development"},                       # dropped on FUNCTION → NOT queued
+    ]})
+    qkeys = {r["_key"] for r in qout["pass2_queue"]}
+    if qkeys != {"q2", "q3"} or qout["pass2_queue_size"] != 2:
+        failures += 1
+        print(f"FAIL [pass2_queue] expected {{q2,q3}} got {qkeys}", file=sys.stderr)
+
+    # --- pass 2: the semantic failures regex cannot see ---
+    # 'Chief Happiness Officer' matches the C-level pattern but is an HR role.
+    # Pass 1 must call it a match; pass 2 must be able to correct it.
+    icp_f = dict(icp, founder_qualifies_regardless_of_function=True)
+    total += 1
+    got, _ = classify({"leadId": "hr1", "jobTitle": "Chief Happiness Officer"},
+                      icp_f, excl, tax)
+    if got != "match":
+        failures += 1
+        print(f"FAIL [pass1 baseline] expected match got {got}", file=sys.stderr)
+
+    p1 = build({"icp": icp_f, "exclusions": excl, "leads": [
+        {"leadId": "hr1", "jobTitle": "Chief Happiness Officer"},
+        {"leadId": "ok1", "jobTitle": "Head of Sales", "companyName": "Acme"},
+    ]})
+
+    total += 1
+    adj = adjudicate({"result": p1, "overrides": [
+        {"_key": "hr1", "bucket": "no_match",
+         "reason": "Chief Happiness Officer is an HR role, not a GTM buyer"},
+    ]})
+    if adj["counts"]["match"] != 1 or adj["counts"]["no_match"] != 1 \
+       or len(adj["changes"]) != 1 or adj["counts"]["total"] != 2:
+        failures += 1
+        print(f"FAIL [adjudicate] bad result: {adj['counts']}", file=sys.stderr)
+
+    bad_adj = [
+        ({"result": p1, "overrides": [{"_key": "ghost", "bucket": "match",
+                                       "reason": "this lead does not exist"}]},
+         "override on an unknown lead"),
+        ({"result": p1, "overrides": [{"_key": "hr1", "bucket": "nope",
+                                       "reason": "invalid bucket name here"}]},
+         "invalid bucket"),
+        ({"result": p1, "overrides": [{"_key": "hr1", "bucket": "no_match",
+                                       "reason": "hr"}]},
+         "reason too short to be auditable"),
+        ({"result": p1, "overrides": [
+            {"_key": "hr1", "bucket": "no_match", "reason": "HR role, not a buyer"},
+            {"_key": "hr1", "bucket": "match", "reason": "contradictory duplicate"}]},
+         "duplicate override for the same lead"),
+        ({"overrides": []}, "missing pass-1 result"),
+    ]
+    for payload, note in bad_adj:
+        total += 1
+        try:
+            adjudicate(payload)
+            failures += 1
+            print(f"FAIL [{note}] should have raised ValidationError", file=sys.stderr)
+        except ValidationError:
+            pass
+
+    # --- coverage gate ---
+    rich = [{"leadId": str(i), "jobTitle": "Head of Sales", "companyName": "Acme",
+             "proEmail": "a@acme.com", "shortBio": "Sales leader",
+             "location": "Paris", "industry": "SaaS"} for i in range(10)]
+    total += 1
+    cov = coverage({"leads": rich})
+    if cov["enrichment_recommended"] or cov["blocked_criteria"]:
+        failures += 1
+        print("FAIL [coverage] complete data flagged as needing enrichment",
+              file=sys.stderr)
+
+    thin = [{"leadId": str(i), "jobTitle": "Head of Sales", "companyName": "Acme"}
+            for i in range(10)]
+    total += 1
+    cov = coverage({"leads": thin})
+    blocked = {b["field"] for b in cov["blocked_criteria"]}
+    if blocked != {"location", "industry"} or not cov["enrichment_recommended"] \
+       or cov["leads_needing_enrichment"] != 10:
+        failures += 1
+        print(f"FAIL [coverage] thin data misreported: {cov}", file=sys.stderr)
+
+    total += 1
+    try:
+        coverage({"leads": []})
+        failures += 1
+        print("FAIL [coverage] empty list should raise", file=sys.stderr)
+    except ValidationError:
+        pass
+
+    print(f"{total - failures}/{total} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(
+        description="Classify an audience against an ICP (two-pass).")
+    p.add_argument("spec", nargs="?", help="path to JSON, or - for stdin")
+    p.add_argument("--coverage", action="store_true",
+                   help="step 0: report field fill rates before defining the ICP")
+    p.add_argument("--adjudicate", action="store_true",
+                   help="pass 2: apply and re-validate the model's overrides")
+    p.add_argument("--test", action="store_true", help="run the self-test")
+    a = p.parse_args()
+
+    if a.test:
+        sys.exit(_selftest())
+    if not a.spec:
+        p.error("provide a JSON file, - for stdin, or --test")
+
+    raw = sys.stdin.read() if a.spec == "-" else open(a.spec, encoding="utf-8").read()
+    try:
+        payload = json.loads(raw)
+        if a.coverage:
+            out = coverage(payload)
+        elif a.adjudicate:
+            out = adjudicate(payload)
+        else:
+            out = build(payload)
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+    except ValidationError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/skills/erwann-lefevre/audience-icp-filter/scripts/build.py
+++ b/skills/erwann-lefevre/audience-icp-filter/scripts/build.py
@@ -37,18 +37,33 @@ class ValidationError(Exception):
     pass
 
 
+def _compile(pattern):
+    """Compile a taxonomy pattern, case-sensitively when it carries an uppercase.
+
+    Short acronyms are indistinguishable from common words once case is thrown
+    away: `\bIT\b` under re.IGNORECASE matches the English pronoun, so a bio
+    reading "making it happen" scored as product_tech and the lead was dropped
+    from the ICP without ever reaching pass 2. Uppercase in a pattern is
+    therefore load-bearing — it means the capitals are part of the signal.
+
+    Everything else stays case-insensitive, which is why the detectors are fed
+    the original-case string rather than a lowercased one.
+    """
+    return re.compile(pattern, 0 if re.search(r"[A-Z]", pattern) else re.I)
+
+
 def _load_taxonomy(path=TAXONOMY_PATH):
     with open(path, encoding="utf-8") as fh:
         raw = json.load(fh)
     tax = {
-        "seniority": [(t["tier"], [re.compile(p, re.I) for p in t["patterns"]])
+        "seniority": [(t["tier"], [_compile(p) for p in t["patterns"]])
                       for t in raw["seniority"]],
-        "function": {f["key"]: [re.compile(p, re.I) for p in f["patterns"]]
+        "function": {f["key"]: [_compile(p) for p in f["patterns"]]
                      for f in raw["function"]},
-        "noise": [re.compile(p, re.I) for p in raw["noise_patterns"]],
+        "noise": [_compile(p) for p in raw["noise_patterns"]],
         "industry_synonyms": {k.lower(): [v.lower() for v in vs]
                               for k, vs in raw.get("industry_synonyms", {}).items()},
-        "agency": [re.compile(p, re.I) for p in raw.get("agency_patterns", [])],
+        "agency": [_compile(p) for p in raw.get("agency_patterns", [])],
     }
     return tax
 
@@ -243,6 +258,9 @@ def _criterion_ok(lead, field, wanted):
     return any(w.strip().lower() in val for w in wanted)
 
 
+INFERRED_DROP = " (inferred from bio)"
+
+
 def classify(lead, icp, exclusions, tax):
     """Return (bucket, reason)."""
     reason_excl = check_exclusions(lead, exclusions)
@@ -253,24 +271,23 @@ def classify(lead, icp, exclusions, tax):
     if not title:
         return "review", "no job title — cannot judge seniority or function"
 
-    tl = title.lower()
     for pat in tax["noise"]:
-        if pat.search(tl):
+        if pat.search(title):
             return "no_match", f"noise title: {title}"
 
     # The title is the primary signal, but since enrichment now exposes the bio,
     # use it as a fallback: many people write their function in the bio, not the
     # title ("Managing Director" + bio "Développement commercial"). Only fall
     # back when the title is silent — the title is more reliable when present.
-    bio = _norm(lead.get("shortBio")).lower()
+    bio = _norm(lead.get("shortBio"))
 
-    seniority = detect_seniority(tl, tax)
+    seniority = detect_seniority(title, tax)
     sen_src = "title"
     if seniority is None and bio:
         seniority = detect_seniority(bio, tax)
         sen_src = "bio"
 
-    functions = detect_functions(tl, tax)
+    functions = detect_functions(title, tax)
     fn_src = "title"
     if not functions and bio:
         functions = detect_functions(bio, tax)
@@ -280,7 +297,8 @@ def classify(lead, icp, exclusions, tax):
         return "review", f"seniority unclear from title or bio: {title}"
 
     if seniority not in icp["seniority"]:
-        return "no_match", f"seniority {seniority} not in ICP"
+        return "no_match", (f"seniority {seniority} not in ICP"
+                            + (INFERRED_DROP if sen_src == "bio" else ""))
 
     founder_pass = (seniority == "founder_c" and
                     icp.get("founder_qualifies_regardless_of_function", False))
@@ -289,7 +307,8 @@ def classify(lead, icp, exclusions, tax):
         if not functions:
             return "review", f"function unclear from title or bio: {title}"
         if not set(functions) & set(icp["functions"]):
-            return "no_match", f"function {functions} not in ICP"
+            return "no_match", (f"function {functions} not in ICP"
+                                + (INFERRED_DROP if fn_src == "bio" else ""))
 
     for field, key in (("location", "locations"), ("industry", "industries")):
         ok = _criterion_ok(lead, field, icp.get(key))
@@ -347,6 +366,10 @@ def build(spec):
             # dropped ONLY on a soft substring criterion → likely false negative
             if reason.startswith("location outside") or reason.startswith("industry outside"):
                 flag = "dropped on geo/industry — check the variant"
+            elif INFERRED_DROP in reason:
+                # Dropped on a signal read out of free text, not off the title.
+                # Nothing may leave the ICP on an inference without a second look.
+                flag = "bio-inferred drop — confirm before discarding"
         if flag:
             row["_flag"] = flag
             queue.append(row)
@@ -411,7 +434,13 @@ def coverage(payload):
         "blocked_criteria": blocked,
         "degraded_checks": degraded,
         "enrichment_recommended": bool(blocked or degraded),
-        "leads_needing_enrichment": n,
+        # Leads missing at least one field that came back insufficient — not the
+        # whole list. Quoting the total overstates the cost of enrichment on an
+        # audience that is mostly complete.
+        "leads_needing_enrichment": (
+            sum(1 for ld in leads
+                if any(not _norm(ld.get(d["field"])) for d in blocked + degraded))
+            if (blocked or degraded) else 0),
     }
 
 
@@ -717,6 +746,75 @@ def _selftest():
         print("FAIL [coverage] empty list should raise", file=sys.stderr)
     except ValidationError:
         pass
+
+    # --- regression: short acronyms must not match common words -------------
+    # `\bIT\b` under re.IGNORECASE matched the English pronoun, so a bio
+    # reading "making it happen" scored as product_tech and the lead left the
+    # ICP silently — with function-based drops absent from pass2_queue, nothing
+    # surfaced it. Both halves are covered here.
+    acro_icp = {"seniority": ["founder_c", "vp_head", "manager_lead"],
+                "functions": ["sales", "growth_marketing", "revops"],
+                "founder_qualifies_regardless_of_function": False}
+    acro_cases = [
+        ({"leadId": "it1", "jobTitle": "Managing Director",
+          "shortBio": "I love building teams and making it happen"},
+         "review", "pronoun 'it' must not read as the IT function"),
+        ({"leadId": "it2", "jobTitle": "Managing Director",
+          "shortBio": "it is what it is"},
+         "review", "repeated pronoun 'it' must not read as IT"),
+        ({"leadId": "it3", "jobTitle": "Head of Sales",
+          "shortBio": "we commit it weekly"},
+         "match", "pronoun in bio must not override a clear title"),
+    ]
+    for lead, want, note in acro_cases:
+        total += 1
+        got, why = classify(lead, acro_icp, {}, _load_taxonomy())
+        if got != want:
+            failures += 1
+            print(f"FAIL [{note}] expected={want} got={got} ({why})",
+                  file=sys.stderr)
+
+    # the acronym must still be detected when it is genuinely uppercase
+    tech_icp = {"seniority": ["vp_head"], "functions": ["product_tech"],
+                "founder_qualifies_regardless_of_function": False}
+    for title, note in (("Head of IT", "uppercase IT still detected"),
+                        ("Head of R&D", "uppercase R&D still detected")):
+        total += 1
+        got, why = classify({"leadId": "t", "jobTitle": title}, tech_icp, {},
+                            _load_taxonomy())
+        if got != "match":
+            failures += 1
+            print(f"FAIL [{note}] expected=match got={got} ({why})",
+                  file=sys.stderr)
+
+    # --- regression: a drop inferred from the bio must reach pass 2 ----------
+    # Nothing may leave the ICP on a free-text inference without a second look.
+    total += 1
+    drop = build({"icp": {"seniority": ["vp_head"], "functions": ["sales"],
+                          "founder_qualifies_regardless_of_function": False},
+                  "exclusions": {},
+                  "leads": [{"leadId": "d1", "jobTitle": "Head of Operations",
+                             "shortBio": "I lead the product roadmap"}]})
+    d1 = drop["buckets"]["no_match"]
+    if not d1 or "_flag" not in d1[0] or drop["pass2_queue_size"] != 1:
+        failures += 1
+        print(f"FAIL [bio-inferred drop] not queued for pass 2: {drop['buckets']}",
+              file=sys.stderr)
+
+    # --- regression: enrichment count is rows missing a gated field ---------
+    mixed = ([{"leadId": f"r{i}", "jobTitle": "Head of Sales",
+               "companyName": "Acme", "proEmail": "a@acme.com",
+               "shortBio": "Sales leader", "location": "Paris",
+               "industry": "SaaS"} for i in range(7)]
+             + [{"leadId": f"t{i}", "jobTitle": "Head of Sales",
+                 "companyName": "Acme"} for i in range(3)])
+    total += 1
+    cov = coverage({"leads": mixed})
+    if cov["leads_needing_enrichment"] != 3:
+        failures += 1
+        print("FAIL [coverage] enrichment count should be the rows actually "
+              f"missing a gated field, got {cov['leads_needing_enrichment']}",
+              file=sys.stderr)
 
     print(f"{total - failures}/{total} passed")
     return 1 if failures else 0


### PR DESCRIPTION
## What this skill does

Sorts an existing list — event attendees, registrants, a prospecting export, a CRM segment — into ICP match / needs review / no match, with a reason on every lead, the team's own colleagues and competitors stripped out, and reconciled counts so nobody is silently dropped.

Two things it does that most list-qualification advice skips:

**It measures the data before asking about the ICP.** Offering geography filtering on a list with empty location fields doesn't filter anything — it routes everyone to review and calls that a result. The coverage gate names which criteria the data can actually support, before the ICP conversation starts.

**It treats exclusion as its own problem.** Matching on company name alone leaks in three specific ways, all observed on real lists: a blank company with no email where only the bio names the employer; job-changers whose company field and email domain disagree; and collapsed spellings (`@AcmeLabs`, `acme-labs`) that a substring match misses entirely. `references/exclusion-doctrine.md` covers each, including why a competitor's name inside a bio is usually a tool they use rather than their employer.

**Ships a working engine.** `scripts/build.py` is stdlib-only, no network calls, and refuses invalid input rather than emitting a best-effort sort:

```
python3 scripts/build.py --test   →  35/35 passed
```

Covering seniority precedence, multi-function collection, bio fallback, each exclusion leak mode, the short-token guard, industry synonym expansion, count reconciliation, and every refusal path.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/erwann-lefevre/` only
- [x] `node tools/validate.mjs` passes locally
- [x] `author.md` already merged in #96 — not touched here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
