### PR TITLE
add multichannel-campaign-builder

### DIFF
--- a/skills/erwann-lefevre/multichannel-campaign-builder/SKILL.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: multichannel-campaign-builder
+title: Multichannel campaign builder
+description: |
+  Use this skill when someone needs a complete outbound sequence written — every touch across
+  LinkedIn and email, not a single cold email. Produces three distinct angles to choose from, then
+  the full sequence with each message ready to send, calibrated to the campaign type and channel
+  mix and self-checked against a copywriting bar before it's handed over. Trigger phrasings: "write
+  me a campaign", "build a sequence", "multichannel campaign", "cold outbound sequence", "social
+  selling sequence", "sequence the people who engaged with our post", "webinar follow-up campaign",
+  "LinkedIn and email sequence", "rewrite this campaign".
+category: Outreach
+tags: [Sales, Marketing]
+---
+
+Applies when a sequence needs writing, not a single message. Produces three angles, then every touch in the cadence, checked before delivery.
+
+## A sequence is not five emails about the same thing
+
+The common failure isn't a bad first message — it's five follow-ups that all say the same thing in a slightly more desperate tone. The prospect ignored the argument once; repeating it four times with "just bumping this" on top adds nothing except a reason to block the sender.
+
+Every touch needs its own reason to exist. That means a fresh angle each time, a different CTA shape than the one before it, and a subject line that isn't a variation on the last. Sequence coherence — angles progressing rather than repeating, consecutive cross-channel touches not doubling up — is what separates a campaign from a nag.
+
+## Get the brief before writing anything
+
+Ask once, in a single message, for whatever is missing: what they sell and the problem it solves in one sentence; the target persona, company type and size; whether a signal or trigger exists; and the channel mix. Ask about tone and any banned words if they have them.
+
+If something essential is missing — the persona, what they actually sell — ask one short question and stop. Don't fill the gap with a plausible guess; a sequence written for the wrong buyer is worse than no sequence, because it reads finished.
+
+The campaign type follows from whether a signal exists and where it came from, and it drives the framing, the cadence and the sequence shape:
+
+- **Cold outbound** — no signal. Relevance has to be argued from research. `references/campaign-type-cold-outbound.md`.
+- **Social selling** — the prospect engaged with something. `references/campaign-type-social-selling.md`.
+- **Employee advocacy** — reaching people who engaged with a colleague's post. `references/campaign-type-employee-advocacy.md`.
+
+Load only the one that applies.
+
+## Three angles, then commit
+
+Produce exactly three distinct angles and recommend one. Distinct means they'd land differently on the same reader, not three phrasings of one idea. Where a signal exists, the first angle is built on it.
+
+Offering angles before writing the sequence isn't ceremony — it's the cheapest possible correction point. Changing the angle after five messages are written means rewriting five messages. `references/angle-framework.md` covers how to build them and the angle bank the follow-ups draw from.
+
+## The CTA is where outreach dies
+
+*"Would you be open to a 30-minute call?"* in message one is the single most common way a good sequence fails. It's high-friction, seller-centric, and it forces a binary the prospect has no reason to resolve in your favour yet.
+
+The alternative is a CTA that delivers something usable whether or not they ever buy — an insight, a benchmark, a resource, a question worth answering. It earns a reply out of curiosity rather than obligation. Never the same CTA shape twice in a row, and never a meeting ask in the opener. `references/cta-framework.md` has the six types and the quality bar.
+
+## Check it before handing it over
+
+Run the sequence against the bar in `references/quality-check.md` before output, and rewrite anything that fails. Not as a formality — these are the defects that survive an otherwise good draft:
+
+- Em-dashes, which read as machine-written to most people who read a lot of outreach.
+- Punctuation glued to a URL, which breaks link detection and quietly costs clicks.
+- More than one question in a message, which reliably gets the easier one answered and the important one ignored.
+- Two email subjects that are variations of each other.
+- A CTA repeating the previous touch's shape.
+- Cadence that drifted from the campaign type's playbook.
+
+The channel rules — length, formatting, what each medium tolerates — are in `references/linkedin-rules.md` and `references/email-rules.md`. The universal voice and banned-phrase rules that apply to every message are in `references/base-copywriting-rules.md`.
+
+## What good looks like
+
+The tell of a good operator: they can say what each touch is *for* — this one earns attention, this one reframes, this one gives something away, this one closes. When every message has a job, the sequence has a shape. When it doesn't, you get five reminders.
+
+The mediocre version personalises the first line and nothing else. "Loved your post on X" followed by two paragraphs of undifferentiated pitch reads worse than no personalisation, because it proves the sender knew enough to be relevant and chose not to be.
+
+Good output is sendable without editing. Every message is a copyable block, the sequence overview shows channel and day per touch, and nothing in it needs a decision from the reader before it can go out. If a message contains a bracketed placeholder the sender has to resolve, it isn't finished — either the brief was thin enough to warrant a question, or the angle was too vague to write from.
+
+## Rules
+
+- MUST ask one specific question and stop when the persona, the offer, or the channel mix is missing.
+- MUST produce three genuinely distinct angles before writing any message.
+- MUST give every follow-up a fresh angle and a different CTA shape than the touch before it.
+- MUST run the quality check and rewrite failures before handing anything over.
+- NEVER ask for a meeting in the first touch.
+- NEVER repeat a CTA type in consecutive touches, or ship two email subjects that are variations of each other.
+- NEVER leave a placeholder in a delivered message.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/angle-framework.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/angle-framework.md
@@ -1,0 +1,138 @@
+# Angle Framework
+
+How to find the angles a campaign will run on — **before** writing any copy. An angle is the pain, trigger or tension a message leans on. Generate **exactly 3 distinct angles**, each targeting a different reason the prospect would stop and read.
+
+Skipping this step is the most common reason a campaign feels generic: the copy is fine, but it leans on a weak or obvious angle.
+
+## Step 1 — Gather context
+
+Check what is already known. Ask only for what's missing, in a single message.
+
+**Required:**
+- **Target persona** — the role being targeted (title, seniority). If the user gives a raw title, work with it directly.
+- **Target company context** — type, size, industry, stage.
+- **What the user sells** — in one sentence, and the specific problem it solves for this persona.
+- **Triggers / signals available** — is there a known buying signal? (LinkedIn post, hire, funding, tool change, new role, post engagement, event.)
+
+**Optional but useful:**
+- Competitors this persona typically uses
+- Angles already tested (do not repeat them)
+- Real customer stories available (real only — never fabricate)
+
+## Step 2 — Deconstruct the persona
+
+Before generating angles, internalize who you're writing to:
+
+- **Mindset** — how does this persona think? What excites them? How do they talk about their job?
+- **Difficulties & unmet needs** — their documented pain points.
+- **Pressures** — what are they accountable for?
+  - Technical / operational buyers (RevOps, ops, engineers): pressure on stack, integration, adoption, proving impact, not being technically limited.
+  - Executive / leadership buyers (Heads of, VPs): pressure on pipeline, ROI, team adoption, clean reporting, accountability to the C-suite.
+- **Trigger mapping** — if a trigger is given, use it as the first-rank angle. If not, identify 2–3 plausible triggers in the context (timing, growth, internal pressure, tool switch).
+- **Emotional drivers** — beyond the functional: overwhelmed, ambitious, skeptical, cautious, curious? This guides each angle's tone.
+
+## Step 3 — Generate 3 angles
+
+Each angle must be:
+- **Distinct** — a different pain, trigger or emotional driver. Never two angles on the same core pain.
+- **Specific** — no generic "we help you grow".
+- **Tension-driven** — built around a moment of pressure or a cost of inaction.
+- **Rooted in their world** — their language, their metrics, their reality.
+
+Rules: no fabricated outcome, metric or customer story. No forbidden phrases (see `base-copywriting-rules.md`). If a signal-based trigger exists, angle 1 must be signal-based.
+
+For each angle, produce this block:
+
+```
+ANGLE [N] — [Name]
+
+Core tension:
+The specific pressure or pain this angle targets. One sentence, visceral and
+specific. This is the angle's "why now".
+
+Why it works for this persona:
+2–3 sentences. Why does this resonate with this exact persona? What
+observation makes it non-generic?
+
+Pain focus:
+The single problem this angle diagnoses. Their symptom, in their language —
+not your solution.
+
+Campaign hook (opening line):
+The first 10–20 words of an email or DM using this angle.
+- Never start with a question
+- Never mention your product or company
+- Must sound peer-to-peer
+- Must create a tension they recognize immediately
+
+Email subject (3–5 words):
+Lowercase, internal-email feel.
+
+Preferred CTA type:
+Insight / Benchmark / Resource / Trigger-Based / Diagnostic Question
+(see cta-framework.md).
+
+Best used when:
+The context or signal that makes this angle most relevant.
+
+Avoid:
+The specific traps to avoid with this angle.
+```
+
+## Step 4 — Recommendation & A/B logic
+
+After the 3 angles:
+
+- **Which to start with** — recommend the first-wave angle, with 2–3 sentences of reasoning. If a trigger exists, always start with the signal-based angle.
+- **A/B split** — how to split the 3 angles across segments or sequence waves.
+- **What to measure** — reply rate per angle (not open rate); reply sentiment (positive / neutral / OOO / negative); decision threshold: after 50+ sends per angle, kill the weakest.
+
+## Step 5 — Output format
+
+```
+PERSONA TARGETED: [role, seniority]
+COMPANY CONTEXT: [size, industry, stage]
+TRIGGER / SIGNAL: [if any]
+
+---
+
+ANGLE 1 — [Name]
+[full block]
+
+ANGLE 2 — [Name]
+[full block]
+
+ANGLE 3 — [Name]
+[full block]
+
+---
+
+RECOMMENDATION
+Which to start with: [angle + reasoning]
+A/B split: [how to split across segments]
+What to measure: [primary + secondary signals + threshold]
+```
+
+## Angles across a follow-up sequence
+
+The 3 angles above seed the campaign. But a multi-step sequence needs a fresh angle at *every* follow-up — repeating the angle of a previous message confirms the delete. Each follow-up must earn its place with something new.
+
+Before writing any follow-up, confirm the angle is genuinely different from every previous message. Pull from the Angle Bank:
+
+- **Pain angles** — the root cause of the problem named earlier; a second-order consequence; another co-occurring pain; the hidden cost of the current workaround.
+- **Stakeholder angles** — what their board / leadership sees vs. their team's reality; what their team lives that leadership ignores; the cross-functional dependency that worsens it.
+- **Timing angles** — end-of-quarter or planning-cycle pressure; a recent company signal (hire, funding, expansion, launch); market or competitive pressure; a looming deadline.
+- **Risk angles** — what happens if the status quo lasts another quarter; the moment the workaround visibly breaks; the personal credibility risk for the prospect.
+- **Resource angles** — give something genuinely useful with no ask attached: a framework, template, checklist, or a non-obvious insight.
+
+Rule: if a follow-up's angle overlaps with any previous message — same pain, same lens, same framing — pick another.
+
+## Anti-patterns
+
+- Generating more or fewer than 3 angles (always exactly 3)
+- Two angles on the same core pain
+- Hooks that start with a question
+- Hooks with fabricated metrics
+- Hooks that mention your product
+- Recommending a non-signal-based angle when a signal exists
+- Ignoring the real persona in favor of a generality

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/base-copywriting-rules.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/base-copywriting-rules.md
@@ -1,0 +1,130 @@
+# Base Copywriting Rules
+
+Universal rules for any outbound message — email, LinkedIn invite note, LinkedIn DM — across any persona. These are hard constraints: a message that breaks them is rewritten before it ships.
+
+These rules are channel- and persona-agnostic. Channel specifics live in `linkedin-rules.md` and `email-rules.md`. The CTA framework lives in `cta-framework.md`. The angle method lives in `angle-framework.md`.
+
+## 1. Length per channel
+
+| Channel | Target | Hard limit |
+|---|---|---|
+| Email body | 50–100 words | 120 words |
+| Email subject | 3–5 words | 6 words |
+| LinkedIn invite note | 150–200 chars | 200 chars (hard limit, no exception) |
+| LinkedIn DM | 40–70 words | 90 words |
+
+Shorter beats longer. If a message exceeds the target, cut before sending.
+
+## 2. Message structure
+
+**Email**
+```
+Subject: [3–5 words, lowercase, internal-email feel]
+[Opening: 10–20 words, names a tension or signal, never a question]
+[Body: 2–3 sentences, develop the tension, no product pitch]
+[Bridge: 1 sentence, what becomes possible]
+[CTA: 1 ask, low-friction, value-framed — see cta-framework.md]
+```
+
+**LinkedIn DM (post-acceptance)**
+```
+[Opening: 10–15 words, an observation about their world, no question]
+[1–2 sentences developing the observation]
+[Soft close: a genuine question or open door, not a meeting request]
+```
+
+**LinkedIn invite note**
+```
+[1–2 sentences max, 200 chars strict, signal- or tension-based, no pitch, no link]
+```
+
+## 3. Opening rules
+
+**Required:** 10–20 words max; names a specific tension, signal or insight the reader recognizes instantly; peer-to-peer tone.
+
+**Forbidden:**
+- Starting with a question
+- Starting with "I" (sender-focused, not prospect-focused)
+- Starting with a compliment ("Loved your post", "Impressive...")
+- "I came across your profile / your company"
+- "I hope this finds you well"
+- Mentioning your product or company in the first line
+- Corporate buzzwords ("leverage synergies", "optimize revenue", "drive impact")
+
+## 4. Body rules
+
+- **One problem per message.** Never stack two pains.
+- **Short sentences.** One sentence = one line on mobile, max 20 words.
+- **Active voice always.** "You can track X", not "X can be tracked".
+- **Pronouns: "you" / "your team" / "your stack"** — never "I" as the subject.
+- **No feature or benefit dumping** in a first-touch body.
+- **Talk in problems and outcomes**, not "saving time" or "saving money".
+- **Concrete over abstract.** "skip the manual data entry" beats "we save you time".
+
+## 5. CTA rules (summary)
+
+- One ask per message. Never two questions or multiple options.
+- Low-friction, value-framed: what the prospect gains from the conversation.
+- Never ask for a meeting in step 1 — value first, ask later.
+- Full framework: see `cta-framework.md`.
+
+## 6. Read-aloud test
+
+Before a message ships, read it aloud:
+- It must flow in under 15 seconds.
+- It must sound like a person talking, not a sales script.
+- No sentence should force a breath mid-way.
+- If a sentence sounds corporate or plastic, rewrite it.
+
+## 7. Anti-AI-tells checklist
+
+A message must never contain these patterns — they flag it as machine-written instantly:
+
+| AI tell | Why it breaks |
+|---|---|
+| Em-dash (—) or en-dash (–) in the body | The most obvious LLM signature |
+| "Furthermore", "Moreover", "Additionally" | Corporate connectors |
+| "Thus", "Hence", "Therefore" | Academic tone |
+| "It is worth noting that..." | Filler hedging |
+| "Imagine a world where..." | ChatGPT signature |
+| Perfect triplets ("X, Y, and Z" repeated across consecutive sentences) | Generative pattern |
+| Long sentences with multiple subordinate clauses | LLM over-formulation |
+| Uniformly polite tone with no variation | "Plastic perfection" |
+| 2+ exclamation marks in one message | LLM over-emphasis |
+| ALL CAPS words | Pseudo-emphasis |
+
+## 8. Forbidden phrases — universal
+
+Always rewrite if any of these appear. (This list is universal — it applies to every user. Positioning-specific banned words are separate; see §10.)
+
+**Opener clichés:** "I hope this finds you well", "I hope you're doing well", "I came across your profile/company", "I noticed you/your company...", "I wanted to reach out because", "I'm reaching out to", "Quick question:".
+
+**Follow-up clichés:** "Just checking in", "Following up on", "Circling back", "Bumping this", "Did you see my last email?", "Did you have a chance to", "I haven't heard back".
+
+**CTA clichés:** "Would you be open to a 30-min call?", "Can we jump on a quick call?", "Let me know if interested!", "Click here/link/below", "Book a slot in my calendar", "When works for you?".
+
+**Filler / weak verbs:** leverage, utilize, optimize, streamline, facilitate, enable, empower, unlock, robust, synergies, best-in-class, world-class, cutting-edge, next-generation. → Use a strong, specific action verb instead.
+
+**Hedging:** "I believe", "I think", "Perhaps", "It might be possible that", "imagine if you did X". → State it directly or cut it.
+
+## 9. Creepy / boundary phrases
+
+Technically informative but signal stalking. Avoid even when a real signal exists.
+
+| Avoid | Use instead |
+|---|---|
+| "Saw you engaged with..." | "[Topic] is a real tension at [stage] right now" |
+| "I noticed you visited our website" | Don't mention it |
+| "I see you opened my last email" | Don't mention it |
+| "Your colleague [Name] mentioned you..." | Don't fabricate name-drops |
+
+Reference the *theme or content* a signal points to, never the individual action.
+
+## 10. Two things that come from the user, not this file
+
+- **Tone of voice** — match the user's brand voice, based on whatever the user has told you about how their company writes. Otherwise, default to a clear, confident, peer-to-peer "expert colleague" register and ask the user if a specific tone is required.
+- **Positioning-specific banned words** — some companies ban words tied to their positioning (e.g. a premium brand banning "cheap", a platform banning "tool"). If the user has named such words, enforce them on top of §8. Default: none.
+
+## 11. Variable / merge-tag rule
+
+The only merge tag assumed safe in a message body is the first-name tag of the user's outreach tool (commonly `{{firstname}}`). Do not invent custom variables (`{{company}}`, `{{role}}`) unless the user states they have configured them. The skill generates full-text messages, not templates with intermediate slots.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-cold-outbound.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-cold-outbound.md
@@ -1,0 +1,42 @@
+# Campaign Type — Cold Outbound
+
+A campaign with **no signal** — the prospect did nothing observable. They are targeted only because they fit the ICP. This is the hardest mode: there is no warm hook, so every message has to earn attention purely through tension and insight.
+
+Use this playbook when the user has a list that matches their ICP but has no engagement, intent or trigger data on it.
+
+## Targeting discipline
+
+With no signal, targeting *is* the campaign's quality. The message can't be personalized to an individual action, so it must be sharply true for the **segment**.
+
+- Keep the segment tight. One persona, one industry, one size band per campaign.
+- If the segment is broad, the copy goes generic. Sub-segment instead.
+- The message must read as "written for people exactly like me" — even though it wasn't written for *me* specifically.
+
+## Angles — no signal crutch
+
+Signal-based angles are unavailable here. Lean on:
+
+- **Pattern A — Tension / Irony** — name a tension the segment lives, purely by observation.
+- **Pattern C — Insight-based** — reframe something the segment thinks they understand.
+
+See `email-rules.md` for the patterns and `angle-framework.md` for building the 3 angles. The opening must make the reader think "how do they know this?" — without any signal to lean on.
+
+## Channel mix & cadence
+
+| Mix | Sequence | Cadence |
+|---|---|---|
+| Email-only | 3 emails | J0 / J+4 / J+8 |
+| Multichannel (recommended) | LinkedIn invite + email + LinkedIn DM + 2 emails | J0 / J+4 / J+7 / J+11 / J+15 |
+| LinkedIn-only | invite + 2 DMs | J0 / J+5 / J+12 |
+
+LinkedIn-only is the weakest cold mix: with no signal, the invite has no hook, so acceptance rates drop and it spends limited weekly invite quota on prospects qualified by ICP alone. Prefer multichannel; use LinkedIn-only only when email isn't viable.
+
+## Sequence shape
+
+- **Touch 1** — a tension or insight the whole segment recognizes. No product, no pitch.
+- **Middle touches** — deepen the root cause, then shift to a different pain, lens or risk. Fresh angle each time (see `angle-framework.md`).
+- **Last touch** — clean breakup with a conditional resource offer.
+
+## Expectations
+
+Cold is the lowest-converting mode — target the cold benchmarks in `quality-check.md` (5–15% reply, 0.5–2% booking). Do not promise warm-campaign numbers. The lever is segment tightness and angle quality, not volume.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-employee-advocacy.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-employee-advocacy.md
@@ -1,0 +1,44 @@
+# Campaign Type — Employee Advocacy
+
+A campaign that engages the people who engage with **your own company members' LinkedIn posts** — founders, executives, GTM or growth people who post publicly. Most of that engagement never converts on its own. This playbook turns a colleague's LinkedIn audience into pipeline.
+
+Use this playbook when the user wants to reach the engagers of a specific colleague's (an "advocate's") posts.
+
+## What makes it different from social selling
+
+In a standard social-selling campaign, the engagement must never be referenced directly (it reads as surveillance — see `social-selling.md`).
+
+Here it's the opposite: **the engagement can be referenced openly.** The sender is a *colleague* of the post's author, so mentioning the advocate's post is a legitimate professional relationship, not monitoring.
+
+- ✅ "[Advocate] is our [role] — their post on [topic] clearly landed with you."
+- ❌ "I noticed you liked [advocate]'s post." (still surveillance framing)
+
+Frame it as a **relationship**, never as monitoring.
+
+## Per-advocate objective
+
+The same playbook serves different goals depending on the advocate. Ask the user the objective up front — it drives the CTA touches:
+
+| Objective | CTA touch | Re-engagement touch |
+|---|---|---|
+| `direct-signup` | the signup / trial link | a re-engagement resource |
+| `resource-adoption` | the resource itself, soft framing | secondary content / community |
+| `nurture` | soft value share, no ask | keep the contact, door open |
+
+## Sequence shape — 5-touch LinkedIn
+
+LinkedIn-only, peer framing. Cadence J0 / J+2 / J+5 / J+12 / J+18.
+
+| Touch | Day | Role |
+|---|---|---|
+| T1 | J0 | Invite — references the advocate's post topic + the colleague relationship |
+| T2 | J+2 | DM1 — peer opener + a concrete pain question, no pitch |
+| T3 | J+5 | DM2 — deepen, fresh angle |
+| T4 | J+12 | DM3 — the CTA, content driven by the objective |
+| T5 | J+18 | DM4 — re-engagement, content driven by the objective |
+
+Each touch uses a fresh angle (see `angle-framework.md`). The engagement-with-a-colleague's-post is a warm signal — target the warm benchmarks in `quality-check.md`.
+
+## Optional advanced move
+
+If the user sells the very tool running this sequence (an outreach / automation product), a mid-sequence reveal can work: "this whole sequence is running on [product] — you're literally inside it." Use only if true and only if it lands as clever, not gimmicky. Skip it otherwise.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-social-selling.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-social-selling.md
@@ -1,0 +1,45 @@
+# Campaign Type — Social Selling
+
+A campaign triggered by a **social intent signal**: the prospect did something observable that suggests interest. The signal is the warm hook — but how you reference it makes or breaks the campaign.
+
+Use this playbook when the user's campaign starts from one of these signals.
+
+## Supported intents
+
+| Intent | Trigger |
+|---|---|
+| Post engagers | Liked / commented / reposted a relevant LinkedIn post |
+| Webinar participants | Registered for or attended a webinar |
+| Content downloaders | Downloaded a guide, ebook or template |
+| Event attendees | Attended a physical or virtual event |
+| Profile viewers | Viewed the sender's LinkedIn profile |
+
+## The golden rule — anti-creepy
+
+Reference the **theme or content the signal points to** — never the individual action. Mentioning that you saw someone like, click, register or visit reads as surveillance and kills trust instantly.
+
+| Intent | ❌ Never | ✅ Instead |
+|---|---|---|
+| Post engagers | "Saw you engaged with [post]" | "[Topic] is a real tension at [stage] right now" |
+| Webinar | "Saw you registered for our webinar" | "[Webinar topic] surfaces a specific tension for [persona]" |
+| Content downloaders | "Saw you downloaded our [content]" | "[Content topic] is one of those areas where [observation]" |
+| Event attendees | "Saw you were at [event]" | "[Event theme] tends to surface [tension] right after these conversations" |
+| Profile viewers | "Saw you visited my profile" | Don't mention it — treat as cold, just with a bit more confidence |
+
+The signal tells you *what to talk about*. It is never something you talk *about*.
+
+## Channel mix & cadence
+
+| Mix | Sequence | Cadence |
+|---|---|---|
+| LinkedIn-only | invite + 2 DMs | J0 / J+5 / J+12 |
+| Multichannel (recommended) | 3 LinkedIn + 3 emails, alternating | J0 / J+4 / J+7 / J+10 / J+14 |
+| Email-only | 3 emails | J0 / J+4 / J+8 |
+
+## Sequence shape
+
+- **Touch 1** — open on the theme the signal points to (anti-creepy). Tension- or topic-based hook.
+- **Middle touches** — deepen, then shift. Each touch a fresh angle (see `angle-framework.md`).
+- **Last touch** — soft breakup with a conditional resource offer.
+
+The signal makes this a warm campaign — target the warm benchmarks in `quality-check.md` (30–50% reply).

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/cta-framework.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/cta-framework.md
@@ -1,0 +1,105 @@
+# CTA Framework — Permissionless Value Promise (PVP)
+
+How to write the call-to-action of an outbound message. Most outreach dies at the CTA. *"Would you be open to a 30-min call?"* is high-friction, seller-centric, and forces a lose-lose binary: the prospect ignores it, or commits to something they don't want yet.
+
+A **Permissionless Value Promise (PVP)** flips that. The CTA itself delivers standalone value — an insight, a resource, a benchmark, a question — that the prospect can use *before* buying anything. They reply out of curiosity, not pressure.
+
+## The PVP quality bar
+
+A CTA passes if:
+- ✅ The prospect can use the insight / resource even if they never buy
+- ✅ The product is not mentioned
+- ✅ The reply it asks for fits in one word or one sentence
+- ✅ It is specific — it could not be sent to 1,000 random people
+- ✅ No urgency, no implicit pressure
+
+If a CTA fails any of these, rewrite it.
+
+## The 6 CTA types
+
+### 1. Insight CTA
+Share a specific public observation about their company or industry, then offer deeper analysis.
+> *"Noticed [Company] has been [expanding into X / hiring for Y]. Put together a quick breakdown of how similar companies handle [related pain]. Happy to forward, useful or not?"*
+
+Best for: step 1 cold email; data-driven buyers.
+
+### 2. Benchmark CTA
+Offer a comparison to peers — everyone wants to know where they stand.
+> *"Tracking [metric] across [industry / segment]. Companies like [Company] are typically around [X]. Curious how you compare — want the full breakdown?"*
+
+Best for: leadership / executive buyers; data-driven roles. Step 1 or 2.
+
+### 3. Resource CTA
+Offer a specific, named asset tied to their pain. Not a generic "guide" — something tangible and pre-built.
+> *"Put together a [checklist / one-pager / set of templates] on [specific pain]. Built it from talking to [type of companies]. Want me to send it?"*
+
+Breakup-friendly variant (signal-based):
+> *"If [topic] is on your roadmap, I can send you the [resource]."*
+
+This variant shines in a breakup: it forces a one-word yes/no, qualifies softly, and makes an active offer with no pressure.
+
+Best for: buyers who like concrete outputs. Step 2 follow-up + soft breakup.
+
+### 4. Trigger-Based CTA
+Use a buying signal (funding, hire, product launch, tool switch) as the hook, then offer something contextually relevant.
+> *"Saw [Company] just [raised / launched / expanded into X]. When that happens, [related challenge] tends to come up. Have a short playbook on how similar companies navigated it — worth a send?"*
+
+Best for: any persona when a strong signal exists.
+
+### 5. Diagnostic Question CTA
+Instead of offering something, ask a sharp question that surfaces the pain and signals you know their world.
+> *"One thing I'm seeing across [persona / industry] right now: [pattern]. Curious if that matches what you're seeing on your side."*
+
+Best for: peer-to-peer with hands-on buyers. Step 3, when you want to qualify without offering a resource.
+
+### 6. Comparison Mirror CTA
+Reference a competing tool or approach the prospect has likely tried, and how the angle differs. Use **only at step 3+**, once a little trust exists.
+> *"Most [persona] at your stage end up trying [common tool / approach] at some point. The pattern we see is [observation about its limit]. Worth a comparison if you're heading there?"*
+
+Best for: buyers who have already tested alternatives. Step 3+. **Never step 1.**
+
+## Prioritization logic
+
+| Situation | Best type |
+|---|---|
+| Strong buying trigger | Trigger-Based |
+| Data-driven buyer (RevOps, Finance, Analytics) | Benchmark |
+| Buyer with a concrete recurring pain | Resource |
+| You know their company context well | Insight |
+| You want to qualify before offering | Diagnostic Question |
+| LinkedIn DM (shorter = better) | Diagnostic or Trigger-Based |
+| Cold email, step 1 | Insight or Benchmark |
+| Follow-up, step 2 | Resource (justifies why you're back) |
+| Follow-up, step 3+ | Diagnostic or Comparison Mirror |
+| Technical / operational buyer | Resource or Diagnostic |
+| Executive / leadership buyer | Benchmark or Insight |
+
+## Evolution across the sequence
+
+CTAs must evolve — **never the same type twice in a row.**
+
+| Step | Recommended type |
+|---|---|
+| Step 1 (first touch) | Insight or Benchmark |
+| Step 2 (follow-up, deepen) | Resource |
+| Step 3 (follow-up, shift) | Diagnostic Question or Comparison Mirror |
+| Step 4+ (late follow-up) | Soft proof; a 15-min ask is acceptable once trust exists |
+
+Across the sequence the ask can get slightly more direct — never more desperate. Just more specific and more value-loaded.
+
+## Forbidden CTA patterns
+
+| Banned | Why |
+|---|---|
+| "Would you be open to a 30-min call?" | High friction, seller-centric |
+| "Can we jump on a quick call?" | Vague, no value |
+| "Let me know if interested!" | Passive, no clear ask |
+| "Click here / link / below" | Low-trust, banned |
+| "Book a slot in my calendar" | No value framing |
+| "When works for you?" | Vague — prefer two specific options |
+
+See `base-copywriting-rules.md` §8 for the full forbidden-phrase list.
+
+## Output
+
+For each message, pick the type, write the CTA ready to paste, and confirm it clears the PVP quality bar. At least one CTA in any sequence should be low-friction. Never ask for a meeting in step 1.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/email-rules.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/email-rules.md
@@ -1,0 +1,51 @@
+# Email Rules
+
+Channel-specific rules for outbound email. These sit on top of `base-copywriting-rules.md` — length, structure, forbidden phrases and anti-AI-tells apply to every channel. This file covers what is specific to email.
+
+## The 3-second rule
+
+A prospect decides in 3 seconds whether to read or delete. Those 3 seconds go to: subject line → sender name → first line. Everything else is irrelevant if those three miss.
+
+## First-touch doctrine
+
+The first email has one job: earn the right to a second message. Not to pitch, not to impress, not to explain the product. Just create enough recognition and curiosity that the prospect replies — or reads email 2.
+
+## Subject lines
+
+- Exactly 3–5 words, all lowercase.
+- Must sound like an internal email, not a marketing email.
+- Creates mild curiosity, or names a topic they care about.
+- Never: "quick question", "following up", product names, superlatives.
+- Test: would a colleague send this subject to another colleague? If yes, it works.
+- Each email in a sequence has a different subject.
+
+## Email structure
+
+```
+Subject: [3–5 words, lowercase]
+[Opening: 10–20 words, names a tension or signal, never a question]
+[Body: 2–3 sentences, develop the tension, no product mention]
+[Bridge: 1 sentence, what becomes possible — no product name]
+[CTA: 1 ask — see cta-framework.md]
+[Optional PS, follow-ups only: a real resource]
+```
+
+The **bridge sentence** connects their pain to a better state without naming a product. E.g. *"There's usually a structural reason this keeps happening. It's fixable."*
+
+## The 3 opening patterns
+
+- **Pattern A — Tension / Irony** — name a tension purely by observation. The default when no signal exists. *"Most teams have the dashboards. The pipeline number still doesn't match what reps forecast."*
+- **Pattern B — Signal-based** — lead with a real trigger (hire, funding, tool switch, a post). The strongest pattern — use it whenever a signal exists.
+- **Pattern C — Insight-based** — share a non-obvious insight that reframes something they thought they understood. Good for analytical buyers.
+
+## Follow-up positions
+
+- **Email 2 — Deepen** — go one layer deeper into the pain of E1. Name the root cause, not the symptom. Reference E1 indirectly, never quote it. A real, useful resource in the PS.
+- **Email 3 — Shift** — a completely different entry point: new pain, new lens, or a larger consequence. Fresh start in the opening — don't reference E1 or E2.
+- **Breakup** — 3–5 sentences, the shortest message in the sequence. One last value statement, a clean breakup line, warm tone, zero resentment.
+
+Each follow-up uses a fresh angle — see `angle-framework.md`, "Angles across a follow-up sequence". Never "just checking in", never "did you see my last email".
+
+## PS rules (follow-ups)
+
+The PS carries a **real, useful resource** — an article, framework, template or checklist tied to their pain. Not a product link, not a marketing case-study page. Safe social proof only: *"Companies like [Name] often find..."* with no fabricated outcome.

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/linkedin-rules.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/linkedin-rules.md
@@ -1,0 +1,58 @@
+# LinkedIn Rules
+
+Channel-specific rules for LinkedIn outreach. These sit on top of `base-copywriting-rules.md` and cover what is specific to LinkedIn.
+
+LinkedIn is not email. It's social, conversational, visible. A prospect who accepted a connection is semi-warm — not opted in to a pitch. Messages must read as the natural continuation of a professional connection, not a cold email pasted into a chat.
+
+## Read the profile first
+
+Before writing, scan the prospect's profile for signals — it's what makes the message non-generic:
+
+- **Headline** — the words they chose to present themselves. Role-based or value-based?
+- **About** — the story they tell, the language they use, tools or methods mentioned.
+- **Recent activity** — highest signal value: topics they post, content they engage with, frustrations voiced.
+- **Experience** — company type and stage, recent promotions, job changes.
+- **Timing signals** — new role (<6 months), recent promotion, hiring for their team, company just raised, posted about a relevant pain.
+
+Don't invest in deep personalization for a prospect who clearly doesn't fit the target — flag a weak fit to the user and proceed in "lower-conversion expected" mode.
+
+## The two first-touch messages
+
+LinkedIn first contact is two messages:
+1. The **invite note** — sent with the connection request
+2. The **first DM** — sent after the connection is accepted
+
+## Invite note
+
+- The invite note applies **only to profiles sourced through Sales Navigator**. For any other audience, send the connection request **without a note**.
+- **Always 200 characters maximum.** Hard limit, no exception.
+- Target 150–200 characters.
+- Soft, signal-based when possible.
+- No product mention, no link, no meeting request.
+- One idea only. Warm, peer-to-peer tone.
+
+## First DM (post-acceptance)
+
+- 40–70 words. No subject line.
+- **No pitch in the first DM, ever.** No product mention.
+- Structure: `[opening: 10–15 words, an observation about their world, never a question]` / `[1–2 sentences developing it]` / `[soft close: a genuine question or open door, not a meeting request]`.
+- Conversational tone, like a message to a peer. No emoji.
+
+## Follow-up DM
+
+Two modes:
+
+- **Value-add** — 3–10 days after DM1. Offer something standalone-useful: an insight, a sharp observation, a concrete resource. Fresh angle, different from DM1.
+- **Soft breakup** — 14+ days after DM1, or when the timing clearly isn't right. A clean, warm close that frees the prospect and leaves the door open.
+
+**Fresh start:** a follow-up DM never references the previous DM. Pick a fresh angle — see `angle-framework.md`. Never "just bumping this", never "did you see my last message".
+
+## Email vs LinkedIn
+
+| | Email follow-up | LinkedIn follow-up |
+|---|---|---|
+| Length | 50–100 words | 40–70 words |
+| Subject | Required | None |
+| Reference to previous | OK, indirect | None — fresh start |
+| Tone | Slightly formal | Conversational |
+| Pitch tolerance | Low | Even lower |

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/quality-check.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/quality-check.md
@@ -1,0 +1,69 @@
+# Quality Check
+
+How to score and pressure-test an outbound message — a cold email or a LinkedIn message — against copywriting standards. This is the absolute, best-practice check (is the copy good?). The comparative check — how the copy stacks up against the user's own past campaigns — is a separate concern.
+
+Used in two places:
+- `multichannel-campaign-builder` — a light self-check on every message it generates.
+- `campaign-challenger` — the best-practice baseline, especially when the user has no past campaigns to compare against.
+
+## Step 1 — Detect the campaign type
+
+The benchmark targets depend on the campaign type. Detect it before scoring.
+
+| Type | Characteristics | Target reply | Target booking |
+|---|---|---|---|
+| Warm trigger-based | Engagement, post like, profile view, recent hire, funding, tool switch | 40–50% | 5% |
+| Warm intent | Demo request, content download, webinar attendee | 30–40% | 5% |
+| Cold targeted | ICP + persona match, no signal | 8–15% | 1–2% |
+| Cold pure | List-based, no personalization signal | 5–8% | 0.5–1% |
+| Re-engagement | Old / no-reply 60+ days | 10–15% | 1–2% |
+
+If the user states the type, use it. Otherwise infer from the message: a trigger referenced in the opening → warm trigger-based; an obvious intent → warm intent; ICP match but no signal → cold targeted; otherwise → cold pure (conservative fallback).
+
+## Step 2 — Score the 12 dimensions (1–10 each)
+
+Score each with a cited excerpt as evidence.
+
+| # | Dimension | What to assess |
+|---|---|---|
+| 1 | Authenticity & human voice | Sounds human, natural contractions, confident, passes the 15-second read-aloud |
+| 2 | Pattern breaking & opening | 10–20 word opener, trigger / tension / insight, no flattery, "why now" relevance |
+| 3 | Optimal length & structure | 50–100 words email / 40–70 LinkedIn, no sentence over 20 words, body max 3 sentences |
+| 4 | Concrete value & impact | Specific pain, concrete outcome, active phrasing, prospect's language |
+| 5 | Loss-aversion framing | Risks avoided, cost of inaction — not gain-only framing |
+| 6 | CTA structure | Low-friction, value-framed, follows the PVP framework (see `cta-framework.md`) |
+| 7 | Persona fit | Right altitude and language for the target buyer persona the user is going after |
+| 8 | Value proposition relevance | Trigger → capability alignment, differentiated, business outcome |
+| 9 | Safe social proof | "Companies like..." phrasing, no fabricated metrics, sector-relevant |
+| 10 | Factual accuracy | Every claim traceable, no hallucinations (see Step 4) |
+| 11 | Strategic question / insight | Non-generic, reply-driving, curiosity-driving |
+| 12 | Positioning alignment | Consistent with the user's positioning: no positioning-banned words, claims on-message |
+
+Dimension 12 is the only one that depends on the user's own context. If the user has shared their positioning and a banned-word list, check the copy against them. If not, check only that claims are coherent and not off-brand, and skip the banned-word part.
+
+## Step 3 — Performance killers (penalties)
+
+Apply before computing the overall score.
+
+**Red flags (−3 each):** the word "click"; an exclamation count of 2+ in one message; ALL CAPS words; an em-dash (—) anywhere in the body; an emoji in a professional email; a vanity metric stated as the headline result; a ROI or % claim with no traceable source (also a Critical Error — see Step 4); "checking in / following up / circling back".
+
+**Moderate issues (−1 to −2 each):** over the word limit without justification; tone too formal / corporate; generic opening with no business relevance; missing CTA components; weak challenge-to-value link; generic "I saw on LinkedIn..." opener; "I hope this finds you well" / "I came across" / "Quick question"; filler verbs (leverage, utilize, optimize, streamline).
+
+User-configurable: if the user has named positioning-banned words, treat each occurrence as a −3 red flag too.
+
+## Step 4 — Accuracy assessment
+
+Classify every key claim in the message:
+
+- ✅ **Verified Fact** — cites a source the user provided
+- 🔵 **Reasonable Inference** — logical, generic, makes no claim of certainty
+- ⚠️ **Unsupported Claim** — not traceable, assumes internal context
+- 🚨 **Critical Error** — fabricated metric, false claim, risky assertion
+
+Any 🚨 must be rewritten before the message ships.
+
+## Step 5 — Output
+
+Produce: the campaign type + targets; the 12 dimension scores with excerpts; the penalties applied; the accuracy breakdown; the overall score (1–10); and the top 3–5 transformation priorities — the changes that will most improve replies and credibility.
+
+When used as a self-check inside `multichannel-campaign-builder`, keep it lightweight: flag only messages scoring below 7/10, and rewrite those before output. When used inside `campaign-challenger`, produce the full breakdown.


### PR DESCRIPTION
## What this skill does

Writes a complete outbound sequence — every touch across LinkedIn and email — rather than a single cold email. Produces three distinct angles to pick from, then the full cadence with each message sendable as-is, self-checked against a copywriting bar before handover.

The argument it makes: the common failure isn't a bad first message, it's five follow-ups that restate it in a progressively more desperate tone. So every touch needs its own reason to exist — a fresh angle, a different CTA shape than the one before it, and a subject that isn't a variation on the last.

Nine reference pages carry the depth: the angle framework and angle bank, the CTA framework (six types, built around a CTA that delivers something usable whether or not the prospect ever buys), universal copywriting rules, per-channel rules for LinkedIn and email, the pre-delivery quality check, and three campaign-type playbooks (cold outbound, social selling, employee advocacy) loaded one at a time depending on whether a signal exists and where it came from.

Some of the defects the quality check catches are unobvious — punctuation glued to a URL breaks link detection and quietly costs clicks; more than one question per message reliably gets the easier one answered and the important one ignored.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/erwann-lefevre/` only
- [x] `node tools/validate.mjs` passes locally
- [x] `author.md` already merged in #96 — not touched here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
