### PR TITLE
add campaign-challenger

### DIFF
--- a/skills/erwann-lefevre/campaign-challenger/SKILL.md
+++ b/skills/erwann-lefevre/campaign-challenger/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: campaign-challenger
+title: Campaign challenger
+description: |
+  Use this skill when a sequence is written but not yet launched, and someone needs to know whether
+  it's actually good — benchmarked against the campaigns that team has already run rather than
+  against generic best practice. Produces a ranked comparison against their own history, an
+  absolute quality score with a launch threshold, and the three fixes worth making first. Trigger
+  phrasings: "challenge this campaign", "is this sequence any good", "benchmark this against my
+  best campaigns", "audit my copy", "pressure-test before launch", "should I launch this", "why is
+  this campaign underperforming".
+category: Outreach
+tags: [Sales, RevOps]
+---
+
+Applies to a sequence that's written and not yet launched. Produces a comparison against the team's own campaign history, an absolute score, and a prioritised fix list.
+
+## Judge against their history, not against best practice
+
+Generic copywriting advice is the weakest available benchmark. It averages across every offer, market and level of competence, so it can tell you a draft is catastrophically broken and nothing finer than that.
+
+The campaigns that team has already run are a far better instrument. They hold the offer constant, the market constant, and the sender's own credibility constant — so a difference between the draft and a past winner is a difference that means something. Run both reads and report both: comparative against their history, absolute against the quality bar. They fail differently, and a draft that passes one and fails the other is telling you something specific.
+
+Where there's no history at all, don't error out. Fall back to the absolute bar, and say plainly that's what you're doing.
+
+## Rank on meetings, not on replies
+
+Reply rate is the number everyone has and the number that misleads most. A campaign can triple its replies by asking a question anyone can answer and book nothing.
+
+Rank the existing campaigns on meetings booked first, reply rate second. When the two disagree — and they often do — that disagreement is usually the most useful finding available, because the campaign with the best reply rate and no meetings is generating conversations with the wrong people or at the wrong moment.
+
+## The copy is the explanation
+
+Stats alone tell you which campaign won. Only the copy tells you *why*, and why is the entire deliverable — a benchmark that can't be acted on is a scoreboard.
+
+So gather both. When someone offers past performance without the messages, ask for the messages; without them the comparison degrades into "your draft is longer than your best campaign", which is an observation, not a fix.
+
+Compare on things you can point at: sequence structure and length, how each opener works, the CTA shape per touch, angle variety across the sequence, and cadence.
+
+## Name the gap in both directions
+
+Two findings, and most benchmarks only produce the first:
+
+**What the top performers do that this draft doesn't.** The obvious one.
+
+**What the underperformers did that this draft repeats.** The one people skip, and usually the more actionable of the two — a team that already ran a campaign into the ground with a meeting ask on touch one has paid for that lesson, and repeating it in a new draft is the expensive kind of mistake.
+
+Then score the draft against the absolute rubric in `references/quality-check.md`, name the lowest-scoring dimensions, and hold the launch threshold. `references/benchmark-method.md` covers the ranking procedure, the comparison dimensions, and how to run the benchmark when history is thin or absent.
+
+## Fixes, ranked, with the evidence attached
+
+Three fixes, ordered by expected impact, each one sentence, each citing the gap that motivates it. "Shorten the opener to under 350 characters — your best-performing campaign opens at 280, this draft at 540" is a fix. "Make it more concise" is a wish.
+
+Stop at three. A list of eleven improvements doesn't get applied; it gets skimmed and abandoned, and the two that mattered are buried at position seven.
+
+## What good looks like
+
+The tell of a good operator: they look at the campaign that got replies but no meetings, and they treat that as the most interesting row in the table rather than a good result. They know their own median matters more than any published figure, and they can name which of their past campaigns the draft most resembles.
+
+The mediocre version scores the draft against a checklist, returns eleven suggestions, and never opens a past campaign — so it can't tell the team that their best-performing sequence breaks two of the rules it just cited. Rules that the team's own winners violate are rules that don't apply to this market, and only the comparison surfaces that.
+
+Good output is decidable. Someone reads it and knows whether to launch, and if not, what to change first. Every number carries its denominator, the benchmark names which campaigns it ran against, and where the comparison rests on pasted or partial data, it says so rather than implying a completeness it doesn't have.
+
+## When the campaign is already live
+
+Editing a running campaign changes what people receive mid-flight, and half the audience has already seen the old version — which also means the performance data becomes uninterpretable.
+
+Duplicate it, fix the copy on the duplicate, and let the original finish. Never edit a live campaign's messages in place without saying what's live and getting an explicit yes.
+
+## Rules
+
+- MUST rank campaigns on meetings booked first, reply rate second.
+- MUST gather the copy alongside the stats, and ask for it when only stats are offered.
+- MUST report both the comparative and the absolute read, and name which campaigns the comparison ran against.
+- MUST warn and offer to work on a duplicate before changing any campaign that is currently running.
+- MUST state when a benchmark rests on pasted, partial, or absent history.
+- NEVER rank on reply rate alone.
+- NEVER return more than three prioritised fixes.
+- NEVER give a fix without the gap that justifies it.

--- a/skills/erwann-lefevre/campaign-challenger/references/benchmark-method.md
+++ b/skills/erwann-lefevre/campaign-challenger/references/benchmark-method.md
@@ -1,0 +1,71 @@
+# Running the benchmark
+
+## 1. Get the draft
+
+Take the sequence to be challenged — every touch, not just the opener. A benchmark on message one misses the failure mode that kills most sequences, which is four follow-ups that repeat it.
+
+If no draft was supplied, ask for it and stop. There is nothing to do without one.
+
+## 2. Gather the comparison set
+
+Pull the team's past campaigns with both their performance and their copy. Detect what's available yourself rather than asking someone to describe their own tooling.
+
+Three cases, in descending order of quality:
+
+**Full history — stats and copy.** The real benchmark. Use it.
+
+**Stats only.** Ask for the copy of at least the top and bottom performers. Without it the comparison can only produce shape observations, not causes. If it can't be had, say the benchmark is running on structure alone.
+
+**No history.** Don't error. Fall back to the absolute rubric and the typical performance range for that campaign type, and state plainly that the comparison layer is missing.
+
+A practical note: campaign copy is sometimes not retrievable as clean templates — stored per-variant, per-sender, or only ever materialised as sent messages. Reconstructing the structure from a handful of real sent messages is a valid fallback. The personalisation is already resolved, but structure, angle, length and CTA all survive, and those are what the benchmark reads. Say which path you're on so nobody mistakes a reconstruction for the source.
+
+## 3. Rank
+
+Meetings booked first. Reply rate second. Where the two disagree, that's a finding — surface it rather than smoothing it.
+
+Always carry the sample size. A 14% reply rate on 40 sends is noise wearing a percentage sign, and a campaign ranked on it will send someone in the wrong direction with confidence.
+
+## 4. Compare on nameable dimensions
+
+Put the draft next to the ranked campaigns and compare on things that can be pointed at:
+
+| Dimension | What to read |
+|---|---|
+| Sequence length | Number of touches, and days end to end |
+| Message length | Characters per touch, especially the opener |
+| Opening pattern | Question, observation, statement, signal reference |
+| CTA shape per touch | And whether any shape repeats consecutively |
+| Angle variety | Whether follow-ups add an argument or restate the first |
+| Cadence | Channel order and gaps between touches |
+
+For each dimension, two readings:
+
+- What the **top performers** do that this draft doesn't.
+- What the **underperformers** did that this draft repeats.
+
+The second is the one that gets skipped and usually the more valuable. A team that already burned a list with a meeting ask on touch one has paid for that lesson; a benchmark that doesn't catch the draft repeating it wasted the history it had access to.
+
+## 5. Score against the absolute bar
+
+Independently of the comparison, score the draft on the rubric in `quality-check.md` and hold the launch threshold. Name the lowest-scoring dimensions specifically — a bare number tells nobody what to fix.
+
+Report both reads. A draft that beats the team's history but fails the absolute bar means their history is weak, not that the draft is ready. A draft that passes the absolute bar but sits below their own median means the bar is generic and their market is harder than average. Both are useful; neither is visible from one read alone.
+
+## 6. Three fixes
+
+Ordered by expected impact. One sentence each. Each cites the gap that motivates it.
+
+> Shorten the opener to under 350 characters — your best campaign opens at 280, this draft at 540.
+
+> Move the meeting ask off touch one to touch four — the two campaigns that asked on touch one sit bottom of your book on meetings.
+
+> Give touch three a new angle — it currently restates touch two, which is the pattern in the campaign that stalled at 2% replies.
+
+Stop at three. Longer lists don't get applied.
+
+## A note on rules the winners break
+
+When a team's best-performing campaign violates a rule from the absolute rubric, the rule loses in that market. Say so, rather than flagging the draft for the same thing.
+
+This is the main reason to run the comparative read at all. Generic copywriting rules encode an average, and any team with real history has evidence about their specific market that outranks it.

--- a/skills/erwann-lefevre/campaign-challenger/references/quality-check.md
+++ b/skills/erwann-lefevre/campaign-challenger/references/quality-check.md
@@ -1,0 +1,69 @@
+# Quality Check
+
+How to score and pressure-test an outbound message — a cold email or a LinkedIn message — against copywriting standards. This is the absolute, best-practice check (is the copy good?). The comparative check — how the copy stacks up against the user's own past campaigns — is a separate concern.
+
+Used in two places:
+- `multichannel-campaign-builder` — a light self-check on every message it generates.
+- `campaign-challenger` — the best-practice baseline, especially when the user has no past campaigns to compare against.
+
+## Step 1 — Detect the campaign type
+
+The benchmark targets depend on the campaign type. Detect it before scoring.
+
+| Type | Characteristics | Target reply | Target booking |
+|---|---|---|---|
+| Warm trigger-based | Engagement, post like, profile view, recent hire, funding, tool switch | 40–50% | 5% |
+| Warm intent | Demo request, content download, webinar attendee | 30–40% | 5% |
+| Cold targeted | ICP + persona match, no signal | 8–15% | 1–2% |
+| Cold pure | List-based, no personalization signal | 5–8% | 0.5–1% |
+| Re-engagement | Old / no-reply 60+ days | 10–15% | 1–2% |
+
+If the user states the type, use it. Otherwise infer from the message: a trigger referenced in the opening → warm trigger-based; an obvious intent → warm intent; ICP match but no signal → cold targeted; otherwise → cold pure (conservative fallback).
+
+## Step 2 — Score the 12 dimensions (1–10 each)
+
+Score each with a cited excerpt as evidence.
+
+| # | Dimension | What to assess |
+|---|---|---|
+| 1 | Authenticity & human voice | Sounds human, natural contractions, confident, passes the 15-second read-aloud |
+| 2 | Pattern breaking & opening | 10–20 word opener, trigger / tension / insight, no flattery, "why now" relevance |
+| 3 | Optimal length & structure | 50–100 words email / 40–70 LinkedIn, no sentence over 20 words, body max 3 sentences |
+| 4 | Concrete value & impact | Specific pain, concrete outcome, active phrasing, prospect's language |
+| 5 | Loss-aversion framing | Risks avoided, cost of inaction — not gain-only framing |
+| 6 | CTA structure | Low-friction, value-framed, follows the PVP framework (see `cta-framework.md`) |
+| 7 | Persona fit | Right altitude and language for the target buyer persona the user is going after |
+| 8 | Value proposition relevance | Trigger → capability alignment, differentiated, business outcome |
+| 9 | Safe social proof | "Companies like..." phrasing, no fabricated metrics, sector-relevant |
+| 10 | Factual accuracy | Every claim traceable, no hallucinations (see Step 4) |
+| 11 | Strategic question / insight | Non-generic, reply-driving, curiosity-driving |
+| 12 | Positioning alignment | Consistent with the user's positioning: no positioning-banned words, claims on-message |
+
+Dimension 12 is the only one that depends on the user's own context. If the user has shared their positioning and a banned-word list, check the copy against them. If not, check only that claims are coherent and not off-brand, and skip the banned-word part.
+
+## Step 3 — Performance killers (penalties)
+
+Apply before computing the overall score.
+
+**Red flags (−3 each):** the word "click"; an exclamation count of 2+ in one message; ALL CAPS words; an em-dash (—) anywhere in the body; an emoji in a professional email; a vanity metric stated as the headline result; a ROI or % claim with no traceable source (also a Critical Error — see Step 4); "checking in / following up / circling back".
+
+**Moderate issues (−1 to −2 each):** over the word limit without justification; tone too formal / corporate; generic opening with no business relevance; missing CTA components; weak challenge-to-value link; generic "I saw on LinkedIn..." opener; "I hope this finds you well" / "I came across" / "Quick question"; filler verbs (leverage, utilize, optimize, streamline).
+
+User-configurable: if the user has named positioning-banned words, treat each occurrence as a −3 red flag too.
+
+## Step 4 — Accuracy assessment
+
+Classify every key claim in the message:
+
+- ✅ **Verified Fact** — cites a source the user provided
+- 🔵 **Reasonable Inference** — logical, generic, makes no claim of certainty
+- ⚠️ **Unsupported Claim** — not traceable, assumes internal context
+- 🚨 **Critical Error** — fabricated metric, false claim, risky assertion
+
+Any 🚨 must be rewritten before the message ships.
+
+## Step 5 — Output
+
+Produce: the campaign type + targets; the 12 dimension scores with excerpts; the penalties applied; the accuracy breakdown; the overall score (1–10); and the top 3–5 transformation priorities — the changes that will most improve replies and credibility.
+
+When used as a self-check inside `multichannel-campaign-builder`, keep it lightweight: flag only messages scoring below 7/10, and rewrite those before output. When used inside `campaign-challenger`, produce the full breakdown.

--- a/skills/erwann-lefevre/campaign-challenger/references/quality-check.md
+++ b/skills/erwann-lefevre/campaign-challenger/references/quality-check.md
@@ -31,13 +31,31 @@ Score each with a cited excerpt as evidence.
 | 3 | Optimal length & structure | 50–100 words email / 40–70 LinkedIn, no sentence over 20 words, body max 3 sentences |
 | 4 | Concrete value & impact | Specific pain, concrete outcome, active phrasing, prospect's language |
 | 5 | Loss-aversion framing | Risks avoided, cost of inaction — not gain-only framing |
-| 6 | CTA structure | Low-friction, value-framed, follows the PVP framework (see `cta-framework.md`) |
+| 6 | CTA structure | Low-friction, value-framed, passes the permissionless-value bar below |
 | 7 | Persona fit | Right altitude and language for the target buyer persona the user is going after |
 | 8 | Value proposition relevance | Trigger → capability alignment, differentiated, business outcome |
 | 9 | Safe social proof | "Companies like..." phrasing, no fabricated metrics, sector-relevant |
 | 10 | Factual accuracy | Every claim traceable, no hallucinations (see Step 4) |
 | 11 | Strategic question / insight | Non-generic, reply-driving, curiosity-driving |
 | 12 | Positioning alignment | Consistent with the user's positioning: no positioning-banned words, claims on-message |
+
+## Scoring dimension 6 — the permissionless-value bar
+
+Most outreach dies at the CTA. *"Would you be open to a 30-minute call?"* is high-friction and seller-centric: it forces a binary the prospect has no reason to resolve in your favour yet, so they resolve it by ignoring the message.
+
+A CTA that carries **permissionless value** delivers something standalone — an insight, a benchmark, a resource, a question worth answering — that the reader can use whether or not they ever buy. The reply comes from curiosity rather than obligation.
+
+Score dimension 6 against five checks. A CTA passes only if all five hold:
+
+- The prospect can use the insight or resource even if they never buy.
+- The product is not mentioned.
+- The reply it asks for fits in one word or one sentence.
+- It is specific — it could not be sent to a thousand random people.
+- No urgency, no implicit pressure.
+
+Failing any one of them caps dimension 6 below the launch threshold, and the fix is a rewrite of the CTA rather than an edit.
+
+Two structural faults score here as well, independent of the wording: a meeting ask in the opening touch, and the same CTA shape repeated in consecutive touches. Both are sequence-level defects that a per-message read will miss, so check them across the whole cadence before scoring.
 
 Dimension 12 is the only one that depends on the user's own context. If the user has shared their positioning and a banned-word list, check the copy against them. If not, check only that claims are coherent and not off-brand, and skip the banned-word part.
 


### PR DESCRIPTION
## What this skill does

Benchmarks a written-but-not-yet-launched sequence against the campaigns that team has already run, rather than against generic best practice. Produces a ranked comparison, an absolute quality score with a launch threshold, and the three fixes worth making first.

The core argument: published copywriting benchmarks average across every offer, market and level of competence, so they can tell you a draft is catastrophically broken and nothing finer. A team's own past campaigns hold the offer, the market and the sender's credibility constant — so a gap between the draft and a past winner means something specific. Run both reads and report both; a draft that passes one and fails the other is telling you something useful.

Three pieces of judgment that took a while to get right:

**Rank on meetings booked, not reply rate.** A campaign can triple replies by asking a question anyone can answer and book nothing. When the two rankings disagree, that disagreement is usually the most useful finding available.

**Name the gap in both directions.** What the top performers do that this draft doesn't — and what the underperformers did that this draft repeats. The second gets skipped and is usually more actionable: a team that already burned a list with a meeting ask on touch one has paid for that lesson.

**Rules the winners break don't apply.** When a team's best campaign violates a rule from the absolute rubric, the rule loses in that market — say so rather than flagging the draft for the same thing.

It also holds a safety rule worth noting for this repo: never edit a running campaign's messages in place. Duplicate it, fix the copy on the duplicate, let the original finish — otherwise half the audience got a different version and the performance data becomes uninterpretable.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/erwann-lefevre/` only
- [x] `node tools/validate.mjs` passes locally
- [x] `author.md` already merged in #96 — not touched here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
