### PR TITLE
add weekly-performance-advisor

### DIFF
--- a/skills/erwann-lefevre/weekly-performance-advisor/SKILL.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: weekly-performance-advisor
+title: Weekly performance advisor
+description: |
+  Use this skill for the recurring review of a running outbound book — the Monday question of what
+  needs attention this week. Produces a triaged list of replies waiting on an answer, the campaigns
+  that are genuinely underperforming with the one step to fix on each, and week-over-week movement
+  on the metrics that matter. Trigger phrasings: "how are my campaigns doing this week", "weekly
+  outbound review", "my Monday cockpit", "campaign health at a glance", "who do I need to reply
+  to", "which campaigns should I fix", "is my outbound trending up or down".
+category: RevOps
+tags: [Sales, RevOps]
+---
+
+Applies to a book of running campaigns on a recurring cadence. Produces a reply queue in urgency order, a ranked fix list, and the week's movement.
+
+## Two questions, in this order
+
+A weekly review answers *who is waiting on me* and *what is broken*, and the first outranks the second every time. A prospect who replied four days ago and got nothing is a lost deal that already happened; a campaign three points below benchmark is a problem that will still be there tomorrow.
+
+Most dashboards invert this, leading with aggregate performance because it's easier to compute. Lead with the people.
+
+## Nothing is scored below ten sends
+
+A campaign with six sends and one reply does not have a 17% reply rate. It has six sends.
+
+Set a floor — ten sends per metric before it gets a status at all — and render everything under it as insufficient volume rather than as a number. Without that floor, the smallest and newest campaigns dominate every ranking, and the weekly review turns into a tour of statistical noise.
+
+The same rule applies per step, not just per campaign: a sequence can have plenty of total volume and a fourth touch that only twelve people ever reached.
+
+## Aggregate on the ratio, not on the percentages
+
+Portfolio-level numbers are where this goes quietly wrong. Averaging campaign reply rates gives a 2,000-send campaign and a 40-send campaign equal weight in the number leadership reads.
+
+Sum the numerators, sum the denominators, divide once. A volume-weighted portfolio rate is the rate that actually happened; a mean of percentages is an artefact of how the work was split into campaigns.
+
+## Judge the campaign on its primary channel
+
+A multichannel campaign that sends 900 LinkedIn messages and 60 emails is a LinkedIn campaign. Letting the email leg's weak numbers flip the whole campaign to "broken" sends someone off to rewrite copy that 6% of the audience saw.
+
+Identify the primary channel by volume, treat a channel as co-primary only when it carries a meaningful share, and let only the driving channel's metrics set the campaign's status. A weak secondary channel is worth flagging as a leg to fix — not worth condemning the campaign for. Technical health is the exception: a bounce problem counts regardless of channel weighting, because it damages the sending domain rather than just this campaign.
+
+The zone thresholds, the scoring floor and the weighting rules are in `references/benchmark-zones.md`.
+
+## One fix per campaign, at the earliest broken step
+
+A campaign failing on three metrics does not need three fixes. Walk the funnel in order — deliverability, then connection acceptance, then opens, then replies — and name the *first* thing that's broken. Everything downstream of a broken step is measuring a filtered audience, so fixing the later metric first is treating a symptom.
+
+Two refinements that matter. Exclude the terminal break-up message from diagnosis: it's designed to underperform and flagging it wastes the fix. And cap how confidently you state a diagnosis when the flagged step's own volume is thin — a red metric on eighteen sends is a hypothesis, not a finding.
+
+Rank the fix list by severity multiplied by the number of people affected. The mildly-broken campaign touching four thousand prospects outranks the badly-broken one touching ninety. `references/campaign-diagnosis.md` covers the funnel order, the cause-to-action mapping, and the severity scoring.
+
+## Sort the replies by what they cost to ignore
+
+Explicit meeting requests first, then interested, then neutral — and inside each group, longest-waiting first. Past about three days a warm reply has cooled enough to flag.
+
+Only surface the replies that need an action. Rejections and wrong-fits collapse to a count; they're worth knowing and not worth reading. Where an automatic qualification was corrected on review, keep that visible — a classifier that keeps mislabelling one category is itself a finding. `references/reply-triage.md` has the classification and the sort.
+
+## Compare against two baselines
+
+Week over week tells you what changed. A trailing multi-week average tells you whether it matters — a single week's movement is mostly noise, and teams that react to it thrash their campaigns weekly.
+
+Show both. Get the direction right per metric: for bounce rate, down is the good direction, and an arrow pointing the wrong way is worse than no arrow. On the first run there is no history — say "baseline week" rather than rendering zeros as deltas. And when a review is re-run mid-week, a refresh may only add to the week's counts, never drop something already counted. `references/weekly-trends.md` covers the comparison and the recount rules.
+
+## What good looks like
+
+The tell of a good operator: they know their own numbers well enough that published benchmarks are a sanity check rather than a target, and they can name which campaign is dragging the portfolio average without opening anything. They treat one bad week as noise and three as a trend.
+
+The mediocre version leads with a portfolio reply rate, averages it wrong, celebrates a number that moved because a small campaign ended, and shows a tidy dashboard with no reply queue in it — so the team reads their metrics and still misses the person who asked for a call on Thursday.
+
+Good output is short and ordered by what to do first. Every rate carries its denominator, every campaign flagged for a fix names one step and one action, and anything with too little volume says so instead of showing a number. If someone reads it and doesn't know what to open first, it failed regardless of how much is on it.
+
+## Rules
+
+- MUST lead with replies waiting on an answer, before any performance metric.
+- MUST require a minimum send volume before scoring any metric, and render thin data as insufficient volume rather than as a rate.
+- MUST aggregate portfolio metrics as summed numerator over summed denominator, never as a mean of rates.
+- MUST set campaign status from the primary channel's metrics, flagging a weak secondary channel separately.
+- MUST name one fix per campaign, at the earliest broken step in the funnel.
+- MUST state the sample size alongside every rate.
+- NEVER diagnose a campaign on its break-up step.
+- NEVER present a single week's movement as a trend without a longer baseline alongside it.
+- NEVER let a mid-week refresh reduce a count already reported for that week.

--- a/skills/erwann-lefevre/weekly-performance-advisor/references/benchmark-zones.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/references/benchmark-zones.md
@@ -1,0 +1,57 @@
+# Zones, floors and aggregation
+
+## Three zones per metric
+
+Each metric gets a good threshold and a floor, producing on target / watch / to fix.
+
+| Metric | Good | Floor | Direction |
+|---|---|---|---|
+| Connection acceptance | 30% | 20% | higher is better |
+| LinkedIn reply | 25% | 15% | higher is better |
+| Email open | 60% | 45% | higher is better |
+| Email reply | 6% | 3% | higher is better |
+| Email click | 8% | 4% | higher is better |
+| Bounce rate | 15% | 25% | **lower is better** |
+
+For a higher-is-better metric: on target at or above good, watch at or above floor, otherwise to fix. For bounce, invert both comparisons.
+
+**These are starting defaults, not truth.** They're calibrated for cold outbound to a B2B audience, and they will be wrong for warm re-engagement, for a different market, or for a notably different offer. Replace them with the team's own trailing median as soon as there's enough history to compute one — their own numbers already account for their offer, their market and their execution, which no published figure does.
+
+Email reply in particular swings hard by temperature. Six percent is a reasonable cold bar and a poor warm one.
+
+## The volume floor
+
+**Ten sends minimum before a metric is scored.** Below that, render "insufficient volume" — never a percentage.
+
+One reply on six sends is not a 17% reply rate. Without this floor the newest and smallest campaigns dominate every ranking, because small denominators produce extreme rates in both directions, and the weekly review becomes a tour of noise.
+
+Apply it per metric and per step, not once per campaign. A sequence with two thousand sends can easily have a fourth touch that only reached forty people — and that step's reply rate deserves the same floor.
+
+## Severity
+
+For ranking, measure how far below the floor a metric sits, as a proportion of the floor:
+
+- Higher-is-better: `(floor − value) / floor`, clamped at zero.
+- Lower-is-better: `(value − floor) / floor`, clamped at zero.
+
+This normalises across metrics with very different scales, so a bounce problem and a reply problem can be compared on one axis.
+
+## Portfolio aggregation
+
+**Sum the numerators, sum the denominators, divide once.**
+
+Averaging per-campaign rates gives a campaign with forty sends the same weight as one with two thousand. The resulting number describes nothing that happened — it's an artefact of how the work was divided into campaigns, and it moves whenever a small campaign starts or ends.
+
+Only campaigns that are active on that channel and above the volume floor feed a portfolio metric. Carry the count of contributing campaigns alongside the number, so a portfolio rate built from two campaigns is visibly different from one built from twenty.
+
+## On deliverability
+
+Where a platform computes delivered as sent minus bounced, "deliverability" is arithmetically `100 − bounce` and carries no independent information. It is not inbox placement, and showing it as a separate metric implies a measurement nobody made.
+
+Track bounce instead. It's the same information, honestly labelled, and it's the actionable half — bounce is a list-quality and warm-up problem with a known remedy.
+
+## Not every metric drives status
+
+Click-through is worth showing and shouldn't set a campaign's status: it depends heavily on whether the copy contains a link at all, so a campaign with no link scores zero and is fine.
+
+Distinguish metrics that diagnose from metrics that inform, and let only the former drive the red/yellow/green.

--- a/skills/erwann-lefevre/weekly-performance-advisor/references/benchmark-zones.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/references/benchmark-zones.md
@@ -11,11 +11,17 @@ Each metric gets a good threshold and a floor, producing on target / watch / to 
 | Email open | 60% | 45% | higher is better |
 | Email reply | 6% | 3% | higher is better |
 | Email click | 8% | 4% | higher is better |
-| Bounce rate | 15% | 25% | **lower is better** |
+| Bounce rate | 2% | 5% | **lower is better** |
 
 For a higher-is-better metric: on target at or above good, watch at or above floor, otherwise to fix. For bounce, invert both comparisons.
 
+**Bounce is the one row not to loosen.** The others are calibration and can move with the market; this one is a hard technical limit. A bounce rate in the double digits burns the sending domain — mailbox providers read it as list abuse, and the damage lands on every campaign sent from that address, including the ones that were working. Treat 2% as the ceiling for healthy sending and 5% as the point where sending should stop until the list is verified and the domain re-warmed, rather than a number to watch decline over a few weeks.
+
+This is why bounce is always status-driving regardless of which channel a campaign leans on: it is the only metric here whose damage outlives the campaign.
+
 **These are starting defaults, not truth.** They're calibrated for cold outbound to a B2B audience, and they will be wrong for warm re-engagement, for a different market, or for a notably different offer. Replace them with the team's own trailing median as soon as there's enough history to compute one — their own numbers already account for their offer, their market and their execution, which no published figure does.
+
+The bounce row is excluded from that substitution. A team whose own history sits at 9% bounce has a domain problem, not a benchmark; adopting their median as the target would encode the damage as normal. Every other row moves with the market, that one doesn't.
 
 Email reply in particular swings hard by temperature. Six percent is a reasonable cold bar and a poor warm one.
 

--- a/skills/erwann-lefevre/weekly-performance-advisor/references/campaign-diagnosis.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/references/campaign-diagnosis.md
@@ -1,0 +1,62 @@
+# Diagnosing a campaign
+
+## Which channel sets the status
+
+A campaign sending 900 LinkedIn messages and 60 emails is a LinkedIn campaign that also sends some email. Its email reply rate is real and it should not decide whether the campaign is broken.
+
+- **Primary channel** = the one with more sends.
+- **Co-primary** when the smaller channel carries a meaningful share of total volume — around 30% is a reasonable line.
+- Only the primary (or both, when co-primary) sets campaign status.
+- **Bounce is always driving.** A bounce problem damages the sending domain and the deliverability of every other campaign from that address. It counts regardless of channel weighting.
+
+A red metric on a non-driving channel gets flagged as a leg to fix — "email leg to fix" — rather than condemning the campaign. This is the difference between "rewrite your sequence" and "the email half of this needs attention", and getting it wrong sends someone to rewrite copy that most of the audience never saw.
+
+## Status
+
+To fix if any driving metric is red. Watch if any driving metric is amber. On target otherwise.
+
+## One fix, at the earliest broken step
+
+Walk the funnel in order and take the **first** red:
+
+1. Bounce
+2. Connection acceptance
+3. Email open
+4. LinkedIn reply
+5. Email reply
+
+Everything downstream of a broken step is measuring a filtered audience. If connection acceptance is at 12%, the LinkedIn reply rate describes the unusual minority who accepted anyway — improving the message copy is treating a symptom while the targeting problem keeps selecting the wrong people.
+
+**Exclude the break-up message from diagnosis.** The final touch is designed to underperform — it exists to close the loop, not to convert — and flagging it burns the one fix on a step working as intended.
+
+## Cause and action
+
+| Broken metric | What it usually means | What to do |
+|---|---|---|
+| Bounce | List quality, or a domain that hasn't been warmed | Verify the list, check warm-up and sending volume |
+| Connection acceptance | Targeting, or the connection note | Revisit who's being targeted before touching copy |
+| Email open | Subject line, or sender reputation and setup | Rework subjects; check technical setup if it's severe |
+| LinkedIn reply | Message copy | Rewrite the opener and the CTA |
+| Email reply | Message copy | Rewrite the opener and the CTA |
+
+Note that the first two point away from copy. The reflex on any weak campaign is to rewrite the messages, and roughly half the time the messages aren't the problem.
+
+## Confidence
+
+State a diagnosis as strongly as the evidence supports.
+
+Severity above roughly 40% below floor is a confident call. Below that it's directional. And **cap confidence whenever the flagged step's own volume is thin** — under about twenty sends on that specific step, a red metric is a hypothesis regardless of how far below floor it sits.
+
+The failure this prevents is confidently telling someone their fourth touch is broken based on eleven sends.
+
+## Ranking the fix list
+
+Sort by **severity × people affected**.
+
+A campaign 5% below floor reaching four thousand prospects outranks one 40% below floor reaching ninety. Severity alone ranks the small broken campaigns to the top, and fixing those first is the wrong use of a Monday.
+
+## The channel recommendation
+
+When both channels are scored and one is clearly working while the other isn't, that's worth saying directly: favour the channel that's working, rework or drop the other leg.
+
+Teams frequently keep a failing email leg attached to a strong LinkedIn campaign because the sequence was designed multichannel and nobody revisited the assumption. The data says to stop.

--- a/skills/erwann-lefevre/weekly-performance-advisor/references/reply-triage.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/references/reply-triage.md
@@ -1,0 +1,52 @@
+# Triaging the reply queue
+
+The first section of any weekly review, and the one that decides whether the review was worth running.
+
+## Classify
+
+Four buckets, read from the whole thread rather than the last message:
+
+| Class | Meaning |
+|---|---|
+| `interested` | Positive intent — wants to know more, asks a question, engages with the offer |
+| `neutral` | Replied without committing — "not now", "send me info", a deflection to someone else |
+| `not_interested` | Explicit no |
+| `wrong_fit` | Not the right person or company at all |
+
+Flag explicit meeting or call requests separately. They aren't just interested — they're a scheduled loss if missed.
+
+## Only actionable replies get rows
+
+`interested` and `neutral` are listed. `not_interested` and `wrong_fit` collapse to a count.
+
+Rejections are worth knowing in aggregate and not worth reading individually. Listing them pads the queue with items requiring no action, which is how a triage list stops being read.
+
+Neutral belongs in the actionable set. "Not now" is a follow-up date, and it's the bucket most often silently dropped.
+
+## Urgency order
+
+Group, then sort within group:
+
+1. Meeting and call requests
+2. Interested
+3. Neutral
+
+Within each group, **longest-waiting first**. Show the wait in days on every row.
+
+Past about three days, a warm reply has cooled enough to mark as urgent. The specific threshold matters less than having one — the failure being prevented is a genuinely interested prospect sitting under a pile of newer, less interesting replies because the queue was sorted newest-first.
+
+Note that this ordering deliberately puts an old neutral below a fresh interested reply, but an old interested reply above a fresh one. Intent outranks recency across groups; recency decides within them.
+
+## Correcting automatic qualification
+
+Where a system pre-classifies replies, review the classification rather than trusting it — automatic qualification is reliably over-optimistic about anything containing polite language, and a courteous brush-off scores as interested.
+
+Keep a visible count of corrections. It's a small number that says something useful: a classifier consistently mislabelling one category is a finding in its own right, and it's invisible if corrections are made silently.
+
+Correct the working view, not the source system. The person reviewing should confirm changes there themselves — a weekly report shouldn't be quietly rewriting CRM state as a side effect of being generated.
+
+## Counting the week
+
+Count from every reply received this week, not from the queue of replies still awaiting an answer. Otherwise answering someone removes them from the week's total, and the weekly number falls as the team does more work.
+
+Two headline counts are enough: positive replies, and total replies. Positive is the one worth leading with — total replies moves with send volume and says little on its own.

--- a/skills/erwann-lefevre/weekly-performance-advisor/references/weekly-trends.md
+++ b/skills/erwann-lefevre/weekly-performance-advisor/references/weekly-trends.md
@@ -1,0 +1,37 @@
+# Week-over-week comparison
+
+## Two baselines, always
+
+**Versus last week** answers what changed. **Versus a trailing multi-week average** — four prior weeks is a reasonable window — answers whether it matters.
+
+Showing only the first is how teams end up rewriting a campaign every Monday in response to noise. Most single-week movement on a reply rate is sampling variation, and it reverses the following week without anyone touching anything.
+
+When the two disagree — down against last week, up against the trailing average — the trailing comparison is usually the true reading, and the disagreement itself is worth a line.
+
+## Get the direction right
+
+Up is good for acceptance, opens, replies and positive replies. **Down is good for bounce.**
+
+An arrow coloured the wrong way on a bounce improvement is worse than showing no arrow, because it converts good news into an alarm. Encode the direction per metric rather than assuming higher is better.
+
+Rates move in percentage points, counts move in units. Don't render a five-point rise in a reply rate as "+5%" — that's a different, smaller claim, and mixing the two makes a report untrustworthy in a way that's hard to pin down.
+
+## The first run
+
+With no history there is no delta. Say "baseline week — trends start once there's more than one week of history" rather than rendering zeros, which read as "no change" and imply a comparison that didn't happen.
+
+Two weeks gives a week-over-week comparison. The trailing average needs more; until then, show what exists and label it.
+
+## Re-running mid-week
+
+A weekly review gets re-run — Monday, then again Thursday.
+
+**A refresh may only add to the week's counts, never reduce them.** Keep the identifiers of what has already been counted and take the union with the fresh pull. Otherwise a reply that was counted on Monday and archived on Wednesday vanishes from Thursday's number, and the week's total falls while the team is doing more work, not less.
+
+Counts reset at the week boundary, which is expected and should be visible — a Monday morning number near zero is correct, not a bug.
+
+## What to trend
+
+Trend the counts that represent outcomes — positive replies above all — and the rates that diagnose the funnel.
+
+Resist trending everything. A comparison against two baselines on twelve metrics produces twenty-four numbers, which is not a weekly review, it's a spreadsheet. Pick the handful that would change a decision.


### PR DESCRIPTION
## What this skill does

The recurring review of a running outbound book — the Monday question of what needs attention. Produces a reply queue in urgency order, the campaigns genuinely underperforming with one step to fix on each, and week-over-week movement.

It leads with people, not metrics. A prospect who replied four days ago and got nothing is a lost deal that already happened; a campaign three points below benchmark will still be there tomorrow. Most dashboards invert this because aggregate performance is easier to compute.

Four bits of statistical discipline that make the difference between a review and a decorated spreadsheet:

**Nothing is scored below ten sends.** One reply on six sends is not a 17% reply rate. Without a floor, the smallest and newest campaigns dominate every ranking, because small denominators produce extreme rates in both directions. Applied per step, not just per campaign.

**Aggregate on the ratio, not the percentages.** Sum numerators, sum denominators, divide once. Averaging per-campaign rates gives a 40-send campaign the same weight as a 2,000-send one, producing a portfolio number that describes nothing that happened and moves whenever a small campaign starts or ends.

**Judge the campaign on its primary channel.** A campaign sending 900 LinkedIn messages and 60 emails is a LinkedIn campaign — letting the email leg flip it to "broken" sends someone off to rewrite copy that 6% of the audience saw. Bounce is the exception: it damages the sending domain, so it counts regardless of weighting.

**One fix, at the earliest broken step.** Everything downstream of a broken step is measuring a filtered audience. If connection acceptance is at 12%, the reply rate describes the unusual minority who accepted anyway. Excludes the break-up message from diagnosis — it's designed to underperform, and flagging it burns the fix.

One judgement call worth flagging for review: the zone thresholds in `references/benchmark-zones.md` are my own calibration for cold outbound to a B2B audience, and the reference says so explicitly — they're framed as starting defaults to be replaced by the team's own trailing median as soon as there's history to compute one. Happy to adjust the framing if you'd rather they read differently.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/erwann-lefevre/` only
- [x] `node tools/validate.mjs` passes locally
- [x] `author.md` already merged in #96 — not touched here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile
