### PR TITLE
alon-goldenberg: intake repairs (placeholders, scoring calibration, windowing)

### DIFF
--- a/skills/alon-goldenberg/brand-mention-monitor/SKILL.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/SKILL.md
@@ -23,6 +23,8 @@ Do two research steps before asking the user anything:
 1. **Resolve brand variants.** Search the live web for the brand's alternate spellings, hashtags, handles, product names, and sub-brands that get mentioned independently. For common-word brand names, find the disambiguating terms (industry, founder, domain) so the sweep doesn't pull unrelated noise. Fold every confirmed variant into the query list silently — never ask the user to supply this.
 2. **Profile the brand.** Establish B2B vs B2C, industry, primary geography and language, and rough audience size. This picks the source profile and calibrates scoring — "high reach" means something different for a niche B2B tool than for a consumer app with millions of users.
 
+Replace before enabling: {{CRISIS_OWNER}} (who gets flagged on a Crisis hit) and {{ALERTS_CHANNEL}} (the team channel, if any, for Crisis/Watch pushes).
+
 Then confirm scope in a single message: the brand as you understood it plus any competitors to track alongside, the date window (default: last 7 days), depth (quick scan vs deep sweep; default deep), and who gets flagged on a Crisis-tier hit ({{CRISIS_OWNER}} — a PR lead, legal, founder, or the marketing team by default). Skip the questions entirely when the user already provided the answers or a prior run in this workspace configured them. If the brand name is still ambiguous after research, confirm which entity is meant before running anything.
 
 ## Pick the source profile
@@ -39,6 +41,8 @@ Four dimensions, each 0–100: **reach** (how many people can see this), **veloc
 
 ```
 composite = reach x 0.30 + velocity x 0.30 + max(risk_sentiment, risk_topic) x 0.25 + opportunity x 0.15
+
+Dimension scores are additive rows capped at 100 each — see the rubric for the cap rule and why the Crisis bar sits at 65.
 ```
 
 Velocity has an honesty gate: hourly growth rates need two data points. On a first pass with no baseline, score only observable proxies (cross-platform pickup, press pickup of a social post, crisis-scale absolute engagement) and label the velocity `~estimated`. The full point tables, baseline rules, and the rapid re-check upgrade path are in `references/scoring-rubric.md` — read it before scoring anything.
@@ -53,10 +57,10 @@ Assign every mention exactly one tier — teams act on tiers, not numbers.
 
 | Tier | Score | Action | Suggested owner | Window |
 |---|---|---|---|---|
-| Crisis | 80–100 | Route immediately | {{CRISIS_OWNER}} + legal + leadership | Respond < 2h |
-| Watch | 50–79 | Assign owner, monitor velocity | Marketing / comms | Respond < 24h |
+| Crisis | 65+ | Route immediately | {{CRISIS_OWNER}} + legal + leadership | Respond < 2h |
+| Watch | 45 up to 65 | Assign owner, monitor velocity | Marketing / comms | Respond < 24h |
 | Engage | Any score, positive + high reach | Amplify, thank, share | Marketing / social team | Act within 48h |
-| Log | < 50, no risk signals | None — searchable record | — | — |
+| Log | < 45, no risk signals | None — searchable record | — | — |
 
 Crisis mentions surface first, each as a full decision card: excerpt, all four scores, why it was flagged, who responds, by when, and a suggested draft action. If the user wants Crisis and Watch items pushed to a team channel ({{ALERTS_CHANNEL}}), post only those tiers — never the full feed.
 

--- a/skills/alon-goldenberg/brand-mention-monitor/references/scoring-rubric.md
+++ b/skills/alon-goldenberg/brand-mention-monitor/references/scoring-rubric.md
@@ -1,6 +1,6 @@
 # Scoring rubric — four dimensions, composite, tiers
 
-Score every mention 0–100 on each dimension, then compute the composite. Points come from evidence visible on the page (follower counts, reply counts, repost counts, domain, language) — never from guesses. When a value can't be verified, leave the points off and note it on the card.
+Score every mention 0–100 on each dimension, then compute the composite. Rows within a dimension are additive, and each dimension is capped at 100 — sum the matching rows, then clamp. Points come from evidence visible on the page (follower counts, reply counts, repost counts, domain, language) — never from guesses. When a value can't be verified, leave the points off and note it on the card.
 
 ## Reach / visibility (0–100) — how many people can see this?
 
@@ -79,9 +79,11 @@ Risk takes the stronger of the two risk reads — a legally dangerous mention wi
 
 | Tier | Rule |
 |---|---|
-| Crisis | composite 80–100 |
-| Watch | composite 50–79 |
+| Crisis | composite 65+ |
+| Watch | composite 45 up to 65 |
 | Engage | any composite, sentiment strongly positive and reach high — opportunity worth acting on |
-| Log | composite under 50 with no risk signals |
+| Log | composite under 45 with no risk signals |
+
+Why 65: the weights make 100 nearly unreachable (risk carries 0.25, opportunity 0.15 — a textbook crisis with zero opportunity tops out in the low 70s). A mention with high reach, climbing velocity, and a capped risk read composites to ~69; the Crisis bar sits below that on purpose.
 
 Engage is not a consolation tier: it exists so high-reach praise gets amplified within 48 hours instead of rotting in a log. A mention can be Engage even with a modest composite when opportunity and reach are both strong.

--- a/skills/alon-goldenberg/company-deep-dive/references/report-format.md
+++ b/skills/alon-goldenberg/company-deep-dive/references/report-format.md
@@ -65,4 +65,4 @@ The rest of the report follows in full, updated where signals changed. The "What
 
 ## Quick-mode variant
 
-Same skeleton, but built from search snippets only (no full-page extraction): shorter sections, no executive quotes unless a snippet contained one, and the Strategic Outlook trimmed to 2–3 sentences. Still fully dated and sourced — quick mode shortens the report, never the honesty.
+Same skeleton, but built from search snippets only (no full-page extraction): shorter sections, no executive quotes unless a snippet contained one, and the Strategic Outlook trimmed to 2–3 sentences. One exception survives quick mode: the P1 verification gate in `signal-dating.md` still applies — a P1 signal (funding, M&A, leadership change) found only in a snippet either gets its corroboration search run anyway or ships labeled **unverified**, never presented as confirmed. Still fully dated and sourced — quick mode shortens the report, never the honesty.

--- a/skills/alon-goldenberg/competitor-monitoring/references/briefing-format.md
+++ b/skills/alon-goldenberg/competitor-monitoring/references/briefing-format.md
@@ -10,8 +10,8 @@ Decided from the profile's last-run date, before any searching:
 |---|---|---|
 | Never (first run) | **Full** | Past 14 days |
 | More than 14 days ago | **Full** | Past 14 days |
-| 3–14 days ago | **Quick refresh** | Since the last run date |
-| Under 3 days ago | **Quick refresh** | Past 7 days (never narrower — near-empty windows read as false quiet) |
+| 3–14 days ago | **Quick refresh** | Since the last run date, but never narrower than 7 days |
+| Under 3 days ago | **Quick refresh** | Past 7 days (the same floor — near-empty windows read as false quiet) |
 | Today, and today's briefing exists | **Same-day repeat** | Ask before re-running; never silently duplicate |
 
 Tune the 14-day boundary to the market's tempo — weekly for fast-moving spaces, monthly for slow ones — but keep the structure: a wide window with the full format, a narrow window with the delta format.

--- a/skills/alon-goldenberg/competitor-positioning/SKILL.md
+++ b/skills/alon-goldenberg/competitor-positioning/SKILL.md
@@ -30,11 +30,11 @@ If you also keep business-signal notes on these companies (funding, hiring, lead
 
 ## Confirm scope
 
-Work from {{COMPETITOR_LIST}}. Four or fewer competitors: analyze all. More: ask which to focus on this run — group them by category and let the user pick. Every competitor costs real research time; don't spend it on companies nobody asked about.
+Work from the confirmed competitor list. If a competitor profile already exists in this workspace (from a prior run or a competitor-monitoring setup), load it and confirm it's still current; otherwise ask the user for their domain and the competitors they care about, propose any obvious additions, and get an explicit yes on the final list before spending research time. Four or fewer competitors: analyze all. More: ask which to focus on this run — group them by category and let the user pick. Every competitor costs real research time; don't spend it on companies nobody asked about.
 
 ## Capture your own baseline first
 
-Before touching any competitor, capture your own positioning from {{YOUR_DOMAIN}} the exact same way you'll capture theirs — otherwise the messaging matrix has an empty row where "us" should be, and the comparison collapses into a list.
+Before touching any competitor, capture your own positioning from the user's own domain (confirmed during setup) the exact same way you'll capture theirs — otherwise the messaging matrix has an empty row where "us" should be, and the comparison collapses into a list.
 
 1. Map the site (sitemap or crawl) to find the real features/product and pricing URLs — don't guess paths.
 2. Extract the homepage, features page, and pricing page as clean text: tagline, hero copy, primary CTA, value props, tier names.


### PR DESCRIPTION
The intake repairs promised in the #101/#104/#100/#102 reviews, applied repo-side so the source of truth matches what's already live in the DB (published via the manual sync backfill, 2026-08-18):

- **competitor-positioning**: replaces the undefined `{{COMPETITOR_LIST}}`/`{{YOUR_DOMAIN}}` placeholders with a first-run setup flow (load the workspace profile or ask + confirm), matching how competitor-monitoring does it.
- **brand-mention-monitor**: adds the cap-each-dimension-at-100 rule and recalibrates tiers (Crisis 65+, Watch 45–65, Log <45) — as submitted, a textbook crisis composited to 69.5 against an 80 threshold, making Crisis unreachable. Also declares `{{CRISIS_OWNER}}`/`{{ALERTS_CHANNEL}}` the way launch-monitor does.
- **competitor-monitoring**: applies the 7-day quick-refresh window floor to the 3–14-day row (briefing-format table contradicted SKILL.md).
- **company-deep-dive**: quick mode now states P1 signals still get corroborated or ship labeled unverified (report-format contradicted signal-dating's mandatory P1 gate).

@alongoldenberg — these are the fixes flagged in your reviews; push back on any calibration you'd do differently.

Needs a maintainer approval (Ariel pushed this branch, so his approval won't count under the ruleset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)