### PR TITLE
Add optional companyLogoUrl to author profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ contributors: []        # other creators' slugs, if any — omit if none
 - The depth that makes a skill worth installing lives in `references/<topic>.md` pages: full scoring rubrics with real numbers, worked examples, templates, edge-case playbooks, channel variants. The body says when to read each one. **The library's flagship skills ship 2–5 reference pages** — a submission with no references usually means the interview stopped too early, and a bare checklist gets sent back.
 - Don't reference other skills by name; describe the next action in verbs.
 
-**`skills/<author>/author.md`** (first submission): frontmatter `name`, `avatarUrl`, `title`, `linkedinUrl`, `companyDomain`, `email`; the bio is the body text. The directory name is the slug — there is no slug field.
+**`skills/<author>/author.md`** (first submission): frontmatter `name`, `avatarUrl`, `title`, `linkedinUrl`, `companyDomain`, `companyLogoUrl`, `email`; the bio is the body text. The directory name is the slug — there is no slug field.
 
 This is a **people-first marketplace** — every skill is published under a real person's name and face, and maintainers verify identity before merging. Four fields are load-bearing:
 
@@ -84,6 +84,8 @@ This is a **people-first marketplace** — every skill is published under a real
 - **`avatarUrl` — optional, but when present it must be a real photo of the person.** A clear headshot, roughly square, at least 400px. Not a logo, not a mascot, not a GitHub identicon, not an AI-generated face. **If you leave it out (or the URL is unusable), maintainers will take your profile photo from the LinkedIn profile above and re-host it at gtmskills.com — submitting means you're OK with that.** Prefer a durable URL if you do supply one (LinkedIn image URLs expire), or attach the image to the PR and note it.
 - **`email` — required.** How maintainers reach you about your skills: review questions, a missing file, a heads-up when something ships or needs a refresh. Use a work address you are comfortable having public — this repo is open, so the file (email included) is visible to anyone.
 - **The bio (body text)** — 2–4 sentences about the person, written person-first ("Jane built…", not "Acme is…"). Every claim should be verifiable on the person's own site, LinkedIn, or press — maintainers check, and unverifiable claims get trimmed.
+
+**`companyLogoUrl` — optional.** A square company mark, at least 256px, transparent PNG or SVG, at a durable URL. When it is absent the library derives a logo from `companyDomain`; for domains the upstream logo source does not carry, that fallback renders a screenshot of the company homepage instead of a mark.
 
 Submitting several skills at once? Include `author.md` in your **first** PR only — every PR duplicating it will conflict after the first one merges.
 

--- a/skills/tanyo-gochev/author.md
+++ b/skills/tanyo-gochev/author.md
@@ -4,6 +4,7 @@ avatarUrl: https://www.gtmskills.com/authors/tanyo-gochev.jpg
 title: "Co-Founder & Head of GTM, The Demand Department"
 linkedinUrl: https://www.linkedin.com/in/tanyo/
 companyDomain: demanddept.com
+companyLogoUrl: https://raw.githubusercontent.com/tanyo-cell/gtm-skills/brand-assets/demanddept-logo-512.png
 email: tanyo@copytg.com
 ---
 

--- a/skills/vesselin-malev/author.md
+++ b/skills/vesselin-malev/author.md
@@ -3,6 +3,7 @@ name: "Vesselin Malev"
 title: "Managing Director, The Demand Department"
 linkedinUrl: "https://www.linkedin.com/in/vesselinmalev/"
 companyDomain: demanddept.com
+companyLogoUrl: https://raw.githubusercontent.com/tanyo-cell/gtm-skills/brand-assets/demanddept-logo-512.png
 email: office@demanddept.com
 ---
 

--- a/templates/author.md
+++ b/templates/author.md
@@ -4,6 +4,7 @@ avatarUrl: https://…            # optional: a real PHOTO OF YOU — headshot, 
 title: Role, Company            # e.g. "Head of Growth, Acme"
 linkedinUrl: https://www.linkedin.com/in/…   # YOUR OWN profile — required. Not a company or product page. This is how maintainers verify you.
 companyDomain: example.com
+companyLogoUrl: https://…   # optional: a square COMPANY MARK — ≥256px, transparent PNG or SVG. Omit it and the library derives one from companyDomain.
 email: you@company.com          # required — how maintainers reach you about your skills; use a work address you're OK having public (this repo is open)
 ---
 


### PR DESCRIPTION
Follows up #74 — Ariel asked me to open a PR for it.

### The problem

The company logo on a profile is derived from `companyDomain`. When the upstream logo source doesn't carry a domain, `/api/company-logo` falls back to a **screenshot of the company homepage** rather than a mark. On `demanddept.com` that screenshot is currently rendering on two profiles and all 14 of our skills.

### The change

Adds an **optional** `companyLogoUrl` to the author profile spec, so a creator can supply the mark directly when the derived one is wrong:

- `templates/author.md` — the field, with the size/format note
- `AGENTS.md` — added to the frontmatter enumeration, plus a short paragraph on when to use it
- `skills/tanyo-gochev/author.md` and `skills/vesselin-malev/author.md` — set to our mark

Purely additive. Every profile without the field keeps the derived behaviour exactly as it is today, so nothing else in the library moves.

### The asset

512×512 transparent PNG, hosted on a durable public branch of my fork:

https://raw.githubusercontent.com/tanyo-cell/gtm-skills/brand-assets/demanddept-logo-512.png

Happy to point it anywhere you'd rather — if you re-host company marks at gtmskills.com the way you do avatars, say the word and I'll update the two lines, or just swap the URL on merge.

`node tools/validate.mjs` passes: *ok — 310 skills across 58 creators, all checks passed*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)