### PR TITLE
add quora-authority-answering

### DIFF
--- a/skills/vesselin-malev/quora-authority-answering/SKILL.md
+++ b/skills/vesselin-malev/quora-authority-answering/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: quora-authority-answering
+title: Quora authority answering
+description: |
+  Use this skill for any Quora answering program run as a lead generation channel:
+  "answer these Quora questions", "write Quora answers for our founder", "our Quora
+  answers read like AI", "how do we get leads from Quora", "which of these questions
+  should we answer". Produces linkless answers that survive moderation, earn upvotes
+  on the collapsed preview, and convert readers into profile visits, plus the triage
+  and posting order for a batch.
+category: Influencers
+tags: [Marketing, Demand Gen]
+---
+
+# Quora authority answering
+
+Applies to a personal expert profile answering questions in a commercial category. Produces batches of paste-ready answers, ordered for posting, that teach real methodology and never pitch.
+
+Most traffic arrives from search months or years after an answer posts, so an answer is an appreciating asset on a permanent URL. The credential line above every answer does all the selling. That is why the answer itself never has to, and why it outperforms the answers that do.
+
+## Set up the account before answer one
+
+Answer from a personal profile, never a branded one. Company-voiced accounts read as ads and get collapsed. A credentialed human gets read.
+
+Set a credential line per topic cluster — role, company, one clause on what the company does for whom — and build the profile bio and links before writing anything. In linkless mode the profile is the only destination. Both assets are specified in `references/credential-and-profile.md`.
+
+## Triage the batch
+
+Answer everything in a pasted batch unless the client says otherwise. Raise concerns as flags delivered alongside the work, never as withheld work.
+
+Five conditions get flagged and still get written: off-position questions, vendor-seeded clusters, near-duplicate threads, tool questions where the tool is unknown, and regulatory questions. Each carries its own handling and its own effect on posting order — read `references/triage-flags.md` before sequencing a batch.
+
+## Pace the posting
+
+Ten to twenty answers a day is safe. The platform cap sits far higher, near fifty per rolling day, and the count is not what flags accounts — velocity, link density, and thin answers are.
+
+Spread posts across the day. Fifteen in one sitting looks automated. Ramp a cold account at three to five a day for the first two weeks with no links at all, then scale once there is upvote history.
+
+## Win the collapsed preview
+
+The preview shows roughly the first two lines, and that is where the upvote decision starts. Line one carries the whole thesis, stated the way nobody else in the thread will state it.
+
+Every opener does one of two things: names a target — who is lying, who is getting paid, who is being played — or turns the knife on the reader or on the writer's own industry. Self-implication is the strongest move available. Contrarian alone is cheap on this platform; contrarian while holding the knife toward yourself reads as credible. Register, the capitalization device, and the openers that fail the bar are in `references/opener-craft.md`.
+
+## Build the body
+
+Pick one thing per answer to be genuinely worked up about and give it most of the words. Everything else gets a clause. Even, balanced coverage is the loudest machine tell in this format.
+
+Let paragraph endings fall flat — a kicker on every one produces a rhythm no human sustains. Vary the shape across a batch: an instruction, a refusal of the question's framing, a caveat. Three answers sharing a skeleton reads as templated. Leave loose ends. Keep length deliberately unequal, roughly 90 to 400 words, because a five-line answer standing among eighty long ones is the only thing on that page nobody has to scroll.
+
+Run `references/machine-tells.md` over the batch before delivery.
+
+## Carry real method
+
+Generic operator wisdom is the failure mode. "Do direct outreach" and "focus on quality" teach nothing, and they read as machine-written precisely because they carry no knowledge.
+
+Every answer holds at least one mechanic only a practitioner knows — how a signal-based list gets built against a database export, what personalization off a job posting looks like next to flattery, how sending infrastructure gets separated across domains and mailboxes, what the operator's own testing turned up. Name real tools where the tool is the answer, and withhold any the client has flagged as unmentionable.
+
+## Keep it linkless
+
+Zero links. Zero calls to action. The credential line and the profile carry the commercial load, and that is what keeps answers out of the moderation queue.
+
+One exception, on "which company is best" questions only: disclose the stake, refuse to rank anyone including themselves, offer free advice by direct message. It works once as a pattern — the sequence and the reason it fails elsewhere are in `references/credential-and-profile.md`.
+
+## Deliver the batch
+
+One file per batch, answers numbered in posting order: unanswered and freshly-followed questions first, crowded and stale threads last. Note where a batch exceeds a day's quota so the poster splits it rather than dumping it.
+
+## What good looks like
+
+The best operator judges a draft on the collapsed preview alone, because that is the only part most readers ever see, and treats a flat first line as a failed answer no matter how good the body is. The mediocre version is an answering service: every question covered evenly, every answer polished to the same length and shape, every paragraph closed with a tidy line — a batch that is individually competent and collectively obviously automated.
+
+The output is good when no two answers in a batch share a skeleton or a length, every answer carries at least one mechanic a competitor in the same thread could not have written, nothing was published on a subject the profile has already answered, and the commercial ask appears nowhere but the credential line.
+
+## Rules
+
+- MUST answer from a personal profile with a credential line matched to the topic cluster.
+- MUST carry at least one practitioner-level mechanic in every answer.
+- MUST deliver flagged questions as written answers with the flag attached, never as withheld work.
+- MUST vary opener shape and answer length deliberately across a batch.
+- MUST space a vendor-seeded cluster across days rather than answering it in one sitting.
+- NEVER include a link or a call to action, outside the disclosed "which company is best" pattern.
+- NEVER claim experience with a named product the writer has not used.
+- NEVER post two answers on the same subject from one profile.
+- NEVER answer incoherent or auto-generated questions — that is what farming profiles do.

--- a/skills/vesselin-malev/quora-authority-answering/references/credential-and-profile.md
+++ b/skills/vesselin-malev/quora-authority-answering/references/credential-and-profile.md
@@ -1,0 +1,47 @@
+# The credential line and the profile
+
+Built before the first answer is written. In linkless mode these two assets carry the entire commercial load, and an answering program that starts before they exist is generating intent with nowhere to send it.
+
+## Personal profile, never branded
+
+A company-voiced account reads as an ad and gets collapsed. A credentialed human gets read. The same sentence, posted from a brand account and from a person, does not perform the same — and the gap is not fairness, it is that readers on this platform are looking for someone who has done the thing.
+
+This holds even when the company is the more recognizable name. The profile is a person who happens to run something, not the something.
+
+## The credential line
+
+It renders above every answer. Readers see it before the first word of the answer and again on every other answer the profile has posted. It is the funnel.
+
+Format: role, company, one clause on what the company does for whom. The last clause is the working part — it is where a reader with the problem recognizes themselves.
+
+Set one per topic cluster rather than one for the account. An answer about outbound sitting under a credential about brand strategy loses the reader in the gap between them, and the gap is the first thing they see. Matching the credential to the cluster is what makes the answer read as coming from the right person rather than an adjacent one.
+
+Vary the wording across clusters even where the role is identical. Identical credential text under every answer, across every topic, is a pattern like any other.
+
+## The profile as the only destination
+
+Answers generate intent. The profile catches it. There is nothing else in the chain, which means the bio and links do work that in any other channel would be spread across a landing page and a CTA.
+
+Build them first:
+
+- A bio that reads as the same person who wrote the answers. A polished company boilerplate under a blunt answering voice breaks the impression the answers built.
+- Links that resolve to something a reader arriving cold can act on without being sold to.
+- Enough answered questions in the cluster that a visitor who came from one answer finds three more. A profile with one good answer converts worse than the same answer on a profile with twenty.
+
+## Why zero links wins anyway
+
+Links are the density signal that flags accounts, and they move answers into the moderation queue where the appreciating-asset economics stop working — a collapsed answer earns nothing from search for as long as it stays collapsed.
+
+Removing links entirely also changes what the answer can be. An answer with nowhere to send the reader has to be worth reading on its own, and answers written that way are the ones that rank and keep earning. The credential line still sells; it just does it without asking.
+
+## The one exception
+
+On "which company is best" questions, and nowhere else:
+
+1. Open with a disclosure that names the company and implicates the writer alongside everyone else in the thread. Not a modest aside — an admission that the writer has a stake and so does every other answer on the page.
+2. Refuse to rank anyone, including themselves. The refusal is the credibility, and it has to be genuine: no ranking smuggled in as a description.
+3. Offer free advice by direct message.
+
+It works because the question format makes the conflict of interest unavoidable, so naming it first is the only honest move available and reads that way. Used on any other question type, the same pattern is a pitch with extra steps, and a profile running it repeatedly starts smelling like a funnel — which costs more than the exception ever returns.
+
+Once as a pattern. Not once per batch.

--- a/skills/vesselin-malev/quora-authority-answering/references/machine-tells.md
+++ b/skills/vesselin-malev/quora-authority-answering/references/machine-tells.md
@@ -1,0 +1,50 @@
+# Machine tells
+
+Run this over a finished batch before delivery. Most of these survive a read of any single answer and only surface when the batch is read together, which is also how a moderator and a regular reader of the topic encounter it.
+
+The tells are not vocabulary. Word-level scrubbing does nothing here. What gives a batch away is structure: evenness where a person would be lopsided.
+
+## Structural tells
+
+**Comprehensive, balanced coverage.** The loudest one. A person answering a question they care about spends most of the words on the part that irritates them and waves at the rest. Even coverage of every sub-topic is what a summarizer produces, not what an operator writes.
+
+Fix: pick the one thing worth being worked up about, give it most of the answer, and reduce everything else to a clause.
+
+**A tidy resolving line at the end of every answer.** Real replies trail off, qualify themselves, or stop once the point is made. A closing kicker every time is a template signature.
+
+**Uniform paragraph length.** Especially three-to-four-line blocks repeating down the page.
+
+**Punch-punch-punch rhythm.** A sharp line ending every paragraph. No one sustains that. Spike where it is earned and let the other endings fall flat.
+
+**Uniform answer length.** Length across a batch should be deliberately unequal, roughly 90 to 400 words. A five-line answer among eighty long ones is the only thing on the page nobody has to scroll, and it will often outperform the long ones.
+
+**Shared skeletons.** If three answers open with the same move, or run claim → three supports → close, the profile reads as templated even when every individual answer is good.
+
+## Sentence-level tells
+
+**Contrast flips.** "It's not X, it's Y." One in a batch is fine. It appears three times per batch by default and has to be cut back.
+
+**Triads.** Three parallel items, three parallel clauses, three examples. Use two, or four, or one.
+
+**Balanced parallel construction generally.** Symmetry reads as generated because irritation is asymmetric.
+
+## Content tells
+
+**Generic operator wisdom.** "Do direct outreach." "Focus on quality." "Build relationships." These teach nothing, and they read as machine-written precisely because they carry no knowledge — there is no way to write them from experience that distinguishes them from writing them without any.
+
+Fix: every answer carries at least one mechanic only a practitioner would know. Test it by asking whether a competent competitor sitting in the same thread could have written the line. If yes, it is not method, it is filler.
+
+**Nothing unresolved.** Human answers leave loose ends: an aside that does not advance the argument, a hedge where the honest answer is genuinely uncertain, a point raised and dropped. A batch with no loose ends anywhere is a batch that was generated.
+
+## Behavioural tells
+
+These are not about the writing, and they flag a profile faster than any prose problem.
+
+- Answering incoherent or auto-generated questions. That is what farming profiles do, and it is visible on a profile page at a glance.
+- Two answers on the same subject a few days apart.
+- A whole seeded cluster answered in one day.
+- Fabricated experience with a named product. Permanent damage, because the people who use that product are the ones reading.
+
+## The batch read
+
+Last pass before delivery: read only the first two lines of every answer in order, then only the last line of every answer in order. If either sequence reads as one voice repeating a habit, the batch is not ready. It should read as one person on different days.

--- a/skills/vesselin-malev/quora-authority-answering/references/opener-craft.md
+++ b/skills/vesselin-malev/quora-authority-answering/references/opener-craft.md
@@ -1,0 +1,48 @@
+# Opener craft
+
+The collapsed preview shows roughly the first two lines. Almost everyone who meets the answer meets only that, and the upvote decision starts there. Everything below the fold is for the minority who already decided the opener was worth expanding.
+
+So the first line is not an introduction to the answer. It is the answer, stated the way nobody else in the thread will state it.
+
+## The register
+
+A person answering bluntly, not an article beginning.
+
+- "Yes, and it's worse than you think."
+- "It works. I run a company on it, so discount that however you like."
+- "Views don't pay you."
+- "Wrong question, honestly."
+
+Short. Declarative. Willing to be disagreed with. The tell that separates this register from copywriting is that none of these lines could open a blog post — they only make sense as a reply to someone.
+
+## The two moves
+
+Every opener does one of these. Not both, not neither.
+
+**Name a target.** Who is lying, who is getting paid, who is being played. The reader gets oriented immediately: there is a conflict here, and the writer has picked a side.
+
+**Turn the knife.** On the reader, or on the writer's own industry. This is the stronger of the two. Contrarian is cheap on this platform — every thread has three contrarians — and contrarian while holding the knife toward yourself is the version that reads as credible, because it costs the writer something to say.
+
+Self-implication also does the commercial work indirectly. An operator conceding what is wrong with their own category is, structurally, the only person in the thread worth believing about the rest of it.
+
+## The capitalization device
+
+One or two capitalized words placed on the punch word. Not the whole phrase, not the first line of every answer.
+
+Use it on roughly half the answers in a batch. Applied to all of them it stops being emphasis and becomes the profile's signature, which is a pattern, which is the thing the whole method is avoiding.
+
+## Openers that fail the bar
+
+**Crafted scenes and vignettes.** "Somewhere in your CRM right now..." is a copywriter setting a stage. Nobody talks like that in a forum reply, and the register mismatch is obvious inside four words.
+
+**Balanced parallel aphorisms.** "X is A. Y is B." reads as machine-generated even when the content is true and useful. The symmetry is the tell — real irritation is not symmetrical.
+
+**Setup sentences that delay the answer.** "There are several factors to consider here." The preview is spent and the reader has learned nothing.
+
+**Restating the question before answering it.** Burns both preview lines on words the reader just read at the top of the page.
+
+## Checking an opener
+
+Read the first two lines with the rest of the answer covered. If they work alone as a complete, arguable statement, the opener holds. If they only make sense as a lead-in to what follows, the answer has no opener yet — it has a first paragraph.
+
+Then read the openers of the batch in sequence. If the same move runs through all of them, rewrite until the batch reads as one person on different days rather than one template on repeat.

--- a/skills/vesselin-malev/quora-authority-answering/references/triage-flags.md
+++ b/skills/vesselin-malev/quora-authority-answering/references/triage-flags.md
@@ -1,0 +1,48 @@
+# Triage flags
+
+Run before a batch is written, not after. Triage sets two things: which questions carry a flag back to the client, and what order the batch posts in.
+
+The default is answer everything. A flag is a note delivered alongside a finished answer, never a reason to hand back less work than was asked for. The client decides what to do with the flag; the writer does not decide it for them by withholding.
+
+## Off-position questions
+
+Consumer hustle, career advice, unrelated verticals. They pull followers who never buy, and a profile weighted toward them stops reading as an expert in the commercial category.
+
+Write the answer. Flag it. Keep this class a minority of the mix rather than eliminating it — a profile that only ever answers inside its own commercial lane reads as a marketing asset, and some range is what makes it read as a person.
+
+## Vendor-seeded clusters
+
+The signature: several unanswered questions about one obscure tool, all followed within days of each other, sitting in a batch together.
+
+That is a seeded campaign, and answering it in one sitting puts the profile inside the seeding. Write the answers. Space them days apart. Never post more than one of the cluster in a day, and order the batch so the cluster is broken up by unrelated threads.
+
+The answers themselves are still written straight — category-level, honest, no more flattering to the seeded tool than the facts warrant.
+
+## Near-duplicate questions
+
+Two similar answers on one profile is a duplicate-content signal the platform penalizes, and it costs both threads rather than just the weaker one.
+
+Do not write both. Pick the thread with the better traffic — more followers, more existing answers, older and still ranking — post the answer there, and leave the twin alone. Flag the twin as intentionally skipped so it does not come back in the next batch as an oversight.
+
+## Tool questions where the tool is unknown
+
+Never fabricate usage. A single invented detail about a named product is the one failure that costs the profile its credibility permanently, because the people who use that product are exactly who reads the thread.
+
+Search first. If real knowledge turns up, answer from it. If it does not, answer at category level — the evaluation criteria that separate good from bad in that category, what to test before committing, what the pricing model usually hides — and state plainly that the writer is not a user. Not being a user, said openly, costs nothing. Being caught pretending costs the account.
+
+## Regulatory and legal questions
+
+Describe industry practice, not the current statute, unless the statute has been verified against a current source. Rules move, answers are permanent, and a confidently wrong compliance answer on a URL that ranks for years is a liability rather than an asset.
+
+Add one honest line pointing at counsel. One line, not a disclaimer paragraph — the hedge should read as a practitioner being straight, not as a legal department.
+
+## Posting order
+
+After flags are set, order the batch:
+
+1. Unanswered questions, and questions freshly followed by a real audience. Best odds of the answer being the one that ranks.
+2. Threads with few existing answers.
+3. Crowded threads where the answer has to beat established ones on the preview alone.
+4. Stale threads with no recent activity.
+
+Seeded clusters get broken across days regardless of where their individual questions land in that order. Note in the file where the batch exceeds a day's quota so it gets split rather than dumped.


### PR DESCRIPTION
## What this skill does

Runs a Quora answering program as a lead generation channel: triages a batch of questions into posting order, and produces linkless answers that survive moderation, win the collapsed preview, and route intent to the profile rather than to a link. Covers account architecture and the per-cluster credential line, opener craft, the structural tells that make a batch read as machine-written, and posting velocity.

Fourth skill under `skills/vesselin-malev/`. `author.md` already exists and is untouched.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/vesselin-malev/` only
- [x] `node tools/validate.mjs` passes locally
- [ ] First contribution: `author.md` is included with a real name, avatar, and LinkedIn — n/a, existing creator; `author.md` unchanged
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for review

Four reference pages: `triage-flags.md`, `opener-craft.md`, `machine-tells.md`, `credential-and-profile.md`.

The spine runs slightly long at ~1,000 words against the ~600–800 guidance. Happy to move another section into a reference if you'd prefer it tighter.

No existing skill in the library covers Quora; slug checked as globally unique.
