### PR TITLE
add reddit-authority-commenting

### DIFF
--- a/skills/vesselin-malev/reddit-authority-commenting/SKILL.md
+++ b/skills/vesselin-malev/reddit-authority-commenting/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: reddit-authority-commenting
+title: Reddit authority commenting
+description: |
+  Use this skill when Reddit is being worked as a durable authority channel rather
+  than a posting surface: "help me answer these Reddit threads", "we want leads from
+  Reddit", "our Reddit posts keep getting removed", "which subreddits should we be
+  in", "write a reply for r/[sub]". Treats the comment, not the post, as the unit of
+  authority, and works threads for the compounding payoff — Reddit answers feed AI
+  answer engines and search for years after they post. Covers thread selection and
+  first-hour timing, the disclosure norm, comment voice, and the account gates that
+  have to clear before any of it runs.
+category: Reddit
+tags: [Marketing, Demand Gen]
+---
+
+# Reddit authority commenting
+
+Applies to an operator or founder building presence in commercial subreddits. Produces comments that survive moderation, read as native, and compound into search and AI-answer visibility.
+
+Two payoffs, and the second is the larger one. Threads convert readers directly, and Reddit content sits heavily in what AI answer engines read when someone asks for a recommendation in a category. A comment that earns upvotes in the right subreddit keeps doing that work for years, which makes thread selection an infrastructure decision rather than a daily content one.
+
+The posture that wins here is the inverse of every other expert channel. Credentialed authority publishing answers is the exact stance Reddit is hostile to. What it rewards is a participant who happens to know things — same substance bar, opposite presentation.
+
+Two prerequisites gate everything below, and neither is optional: the account has to clear the subreddit's invisible karma and age thresholds (`references/account-gates.md`), and the subreddit has to be read before it is written in (`references/subreddit-recon.md`).
+
+## The comment is the unit of authority
+
+Not the post. Posts from commercially interested accounts get scrutinized as posts; helpful comments on other people's threads accumulate credibility invisibly and are far harder to remove. A profile with two hundred good comments and no posts is a stronger commercial asset than the reverse, and it is also the one that never trips a submission rule.
+
+Find conversations rather than starting them. Answer the question actually asked, and mention nothing of your own the first several dozen times.
+
+This inverts how most teams plan the channel. There is no calendar, no piece to ship, nothing to approve in advance — the work is showing up where the questions already are.
+
+## Move early, and pick the thread that will still be read
+
+Vote velocity in the first hour decides visibility, so a comment early on a rising thread outperforms a better comment posted a day later. Being first with an adequate answer beats being fifth with the best one.
+
+Sorting by new across a handful of target subreddits is the whole discovery method. That constrains coverage honestly: three to five subreddits worked properly beats fifteen checked occasionally.
+
+Because the payoff is measured in years, weight thread selection toward questions that will be asked again — category recommendations, "which tool for X", "how do you actually do Y". A thread answering a question nobody will search for converts whoever is in it that day and then stops. A thread answering an evergreen one keeps being retrieved, by people and by answer engines, long after it falls off the front page.
+
+## Disclose the affiliation
+
+State it the first time it becomes relevant in a thread, plainly and without apology. "I run an agency that does this, so weigh that accordingly" costs nothing and buys the right to say the rest.
+
+Hidden affiliation discovered later ends the account's credibility in that subreddit permanently, and the discovery is usually someone clicking a profile — which means it is not a risk that can be managed, only avoided.
+
+Disclosure is also what makes the strongest move available work: saying what does not work, including about things the commenter sells. Undisclosed, that reads as false modesty. Disclosed, it is the fastest way to be believed about everything else.
+
+## Carry real method
+
+One mechanic per comment that only a practitioner knows. Specifics over generalities.
+
+Two moves are rewarded here more than on any other platform: correcting confident misinformation, with the correction sourced; and answering the question the asker should have asked, as long as the literal question also gets answered first.
+
+Never link in a comment unless the subreddit explicitly permits it and the link genuinely answers the question. The profile does the work.
+
+## Write like a participant
+
+Marketing language is detected instantly, and formatting gives it away faster than vocabulary. Headers, bolded label lines, tidy bullet lists, and an emoji anywhere read as corporate output and get downvoted on shape alone.
+
+Write in paragraphs, lowercase where it feels natural, contractions throughout. Answer first, explain after. One-line replies are completely acceptable and often the strongest. Unique text for every comment — copy-pasting across threads trips spam filters regardless of quality. Full specification in `references/comment-voice.md`.
+
+## Stay in the thread
+
+Ignoring replies to your own comment reads as traffic farming, because that is what traffic farming looks like. Budget for the follow-up before posting: if there is no capacity to come back within a day, the comment is not ready to go out.
+
+## What good looks like
+
+The best operator picks threads on whether the question will still be asked in two years, and treats each subreddit's tolerance as the spec rather than applying one house voice everywhere. The mediocre version brings a content process to Reddit: a calendar, a post to ship, the same reply shaped for every thread, formatted like a document, affiliation mentioned only once somebody asks.
+
+The output is good when a comment is indistinguishable in shape from the natives around it, carries one thing nobody else in the thread could have said, discloses the stake before it becomes a problem, and would still be worth reading by someone who arrives from a search engine or an AI answer a year later.
+
+## Rules
+
+- MUST clear the subreddit's karma and account-age gate before commenting there.
+- MUST read twenty to thirty posts and the subreddit's own rules before the first comment.
+- MUST disclose affiliation the first time it becomes relevant in a thread.
+- MUST write unique text for every comment.
+- MUST answer the question actually asked before adding anything else.
+- MUST return to replies on threads the account has commented in.
+- NEVER run multiple accounts for the same product.
+- NEVER use headers, bold label lines, bullet lists, or emoji in a comment.
+- NEVER link unless the subreddit permits it and the link answers the question.
+- NEVER promote before the account has history in that subreddit.
+- NEVER manipulate votes or endorse from a second account.

--- a/skills/vesselin-malev/reddit-authority-commenting/references/account-gates.md
+++ b/skills/vesselin-malev/reddit-authority-commenting/references/account-gates.md
@@ -1,0 +1,47 @@
+# Account gates
+
+The gate is invisible from outside. Subreddits set their own thresholds through automated moderation, most do not publish them, and a blocked comment usually disappears without a notification. Assume a gate exists everywhere and clear it before it matters.
+
+## Enforcement bands by subreddit size
+
+Thresholds scale with member count. Observed tiers:
+
+| Subreddit size | Typical comment karma | Typical account age |
+|---|---|---|
+| Under 50K | often no gate | none |
+| 50K – 500K | 50 – 200 | 7 – 30 days |
+| 500K – 5M | 200 – 500 | 14 – 30 days |
+| 5M and up | 500 – 2,000 | 30 days or more |
+
+Treat these as planning figures, not published rules. They move, individual subs sit well outside their band, and the only reliable confirmation is a comment that stays up.
+
+## How to build the karma
+
+Across varied subreddits, never only the commercial targets. An account whose entire history sits in three subs where the operator has something to sell is a recognizable shape, and moderators of those exact subs are the people most practiced at recognizing it. Interests unrelated to the business are the point, not a distraction from it.
+
+Sustained recent activity beats an old dormant history. An account created years ago and used twice reads worse than a two-month-old account commenting most weeks — dormancy followed by sudden commercial interest is the pattern behind most bought accounts.
+
+Comment karma is the figure that gates. Post karma accumulates differently and does not substitute.
+
+## The multi-account rule
+
+Never run multiple accounts for the same product. Major subreddits treat linked accounts as one actor, and detection does not depend on catching an obvious slip — shared behaviour, timing, and interest overlap are enough.
+
+The penalty is not proportionate to the offense. It is a ban of every linked account plus a blacklist of the product domain across that subreddit, which forecloses the channel for everyone at the company including people who never touched it.
+
+Separate accounts run by genuinely different humans, each with their own history and their own interests, are the only accepted version. That is a real constraint on how fast this channel scales, and it should be planned around rather than worked around.
+
+## Shadowbans
+
+Invisible from inside the account. Comments appear normally when logged in and are visible to nobody else, which can run for weeks before anyone notices the silence is not just poor performance.
+
+Check periodically by viewing the profile logged out. Build it into the routine rather than reaching for it once results go flat.
+
+## Sequencing
+
+1. Clear the band for the largest target subreddit, not the smallest. The gate that matters is the highest one.
+2. Comment without any commercial mention for long enough to have a history that survives a click on the profile.
+3. Confirm comments are landing — logged-out profile check — before any promotional activity at all.
+4. Only then start disclosing an affiliation where it is relevant.
+
+Promoting before the account has history removes the post on a first offense and earns a permanent ban on repeats. Most promotional bans are not appealable, so the sequence is worth the wait it costs.

--- a/skills/vesselin-malev/reddit-authority-commenting/references/comment-voice.md
+++ b/skills/vesselin-malev/reddit-authority-commenting/references/comment-voice.md
@@ -1,0 +1,54 @@
+# Comment voice
+
+Reddit identifies marketing faster than any other public channel, and it does it on shape before it does it on content. A comment can be entirely true, genuinely useful, and still get downvoted to invisibility because it looks like it came out of a content process.
+
+## Formatting is the loudest tell
+
+Louder than vocabulary. These get a comment read as corporate output regardless of what it says:
+
+- Headers inside a comment.
+- Bolded label lines — **The problem:** followed by **The fix:**.
+- Tidy bullet lists, especially parallel ones.
+- Any emoji, anywhere.
+- Numbered frameworks.
+- A closing line that summarizes what was just said.
+
+Write in paragraphs. Lowercase where it feels natural. Contractions throughout. Let a sentence run long or stop short rather than trimming everything to the same length.
+
+One-line replies are completely acceptable and are often the strongest thing in a thread. The instinct to demonstrate value by writing more is the instinct to resist — a comment that answers in eight words and stops reads as someone who knows, where the same answer padded to four paragraphs reads as someone performing.
+
+## Vocabulary that triggers hostility
+
+"Revolutionary." "Game-changing." "The best solution." "Leverage." "Seamless." Superlatives generally, and any construction that would survive unchanged in a landing page.
+
+The deeper version of this rule: avoid any phrasing that implies the commenter is addressing an audience rather than a person. Reddit comments are replies to somebody. The moment the register shifts to broadcast, it reads as an ad.
+
+## Register
+
+Answer first, explain after. The opposite order — context, then reasoning, then finally the answer — is how documents work and not how replies work.
+
+Blunt is native here. Disagreement is native. Admitting the honest answer is "depends, and here's the one thing it depends on" is native. What is not native is hedged, balanced, comprehensive coverage of a topic nobody asked to have covered.
+
+Skip capitalized emphasis. On some platforms one capitalized word lands as a punch; here it reads as shouting.
+
+## Uniqueness
+
+Unique text for every comment. Copy-pasting a reply across threads trips spam filters regardless of how good the reply is, and the filters catch near-duplicates rather than only exact ones.
+
+This also holds across accounts and across time. A phrasing reused often enough becomes a fingerprint, and it is the thing someone links to when they accuse an account of astroturfing.
+
+## The two rewarded moves
+
+**Correct confident misinformation, with the correction sourced.** Reddit rewards this more than any other platform. The upvotes come from people who suspected the original was wrong and could not say why. Source it, and do not gloat.
+
+**Answer the question the asker should have asked** — as long as the literal question also gets answered first. Answering only the better question reads as evasion, or as someone steering toward their own topic. Answer what was asked, then say what the asker will hit next.
+
+## Substance
+
+One mechanic per comment that only a practitioner knows. Specifics over generalities. Willingness to say what does not work, including about things the commenter sells, which is the single fastest way to be believed about everything else.
+
+## Links
+
+Never, unless the subreddit explicitly permits it and the link genuinely answers the question. The profile does the work.
+
+A comment that would be worse without the link is usually a comment that should have contained the answer instead of pointing at it.

--- a/skills/vesselin-malev/reddit-authority-commenting/references/subreddit-recon.md
+++ b/skills/vesselin-malev/reddit-authority-commenting/references/subreddit-recon.md
@@ -1,0 +1,43 @@
+# Subreddit recon
+
+Done once per target subreddit, before the first comment, and revisited when a sub's behaviour changes. Each subreddit is effectively its own platform with its own enforcement, and the cost of guessing wrong is usually permanent.
+
+## Read before writing
+
+Twenty to thirty posts, sorted by top and by new. What to extract:
+
+- **Tolerance.** How much commercial presence is visible at all? Are there operators in the comments who are obviously operators, and do they get upvoted or buried?
+- **Formality.** Some subs run on one-liners and jokes; some expect worked detail. A long careful answer in a joke sub reads as badly out of place as a flip one-liner in a technical sub.
+- **Trigger words.** Every sub has terms that reliably start a fight, usually a vendor, a methodology, or a phrase the community has decided is nonsense.
+- **What gets removed.** Read the modlog where the sub publishes one. It is the clearest available statement of what the rules mean in practice, as opposed to what they say.
+- **Who answers.** The accounts that consistently get upvoted are the model. Match their shape, not the shape of a good answer in the abstract.
+
+## Rules, then policy
+
+Read the subreddit's own rules and any wiki or pinned posting guide first. Sitewide policy caps self-promotion at a tenth of activity; treat that as a floor rather than a target, because moderators enforce their own version regardless of what the sitewide guidance says, and their version is the one that bans accounts.
+
+Where the two conflict, the subreddit wins. There is no appeal to sitewide policy that a moderator is obliged to honour, and subreddit bans are usually permanent.
+
+## The ratio in practice
+
+A tenth is the ceiling on self-promotional activity, not a quota to fill. Accounts that hit exactly one in ten look engineered, because they are.
+
+The workable version: comment where there is nothing to promote, most of the time, in subs that have nothing to do with the business as well as the target ones. Commercial mention becomes rare enough that it is unremarkable when it happens. If the ratio has to be calculated, it is already too high.
+
+## Discovery and timing
+
+Vote velocity in the first hour decides visibility, so a comment early on a rising thread outperforms a better comment posted a day later. Being first with an adequate answer beats being fifth with the best one.
+
+Sorting by new across a handful of target subreddits is the whole discovery method. Not search, not saved threads, not a weekly sweep — a short daily pass over new posts in a small set of subs.
+
+That constrains how many subreddits one person can genuinely cover. Three to five worked properly beats fifteen checked occasionally, and the difference shows up in whether the account is recognized by regulars.
+
+## Spread
+
+Never post the same content to many subreddits, and never to more than a couple in one day. Cross-posting identical material is the most reliably punished pattern on the platform, and it is trivially visible from a profile page.
+
+## Staying in the thread
+
+Ignoring replies to your own comment reads as traffic farming, because that is what traffic farming looks like. A comment that starts a conversation and then goes silent costs more credibility than never commenting.
+
+Budget for the follow-up before posting. If there is no capacity to come back to a thread within a day, the comment is not ready to go out.


### PR DESCRIPTION
## What this skill does

Works Reddit as a durable authority channel rather than a posting surface. Treats the comment — not the post — as the unit of authority, and selects threads for the compounding payoff: Reddit answers feed AI answer engines and search for years after they post, which makes thread selection an infrastructure decision rather than a daily content one. Covers thread selection and first-hour vote velocity, the disclosure norm, comment voice, and the account gates that gate everything else.

Fifth skill under `skills/vesselin-malev/`. `author.md` unchanged.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/vesselin-malev/` only
- [x] `node tools/validate.mjs` passes locally
- [ ] First contribution: `author.md` is included with a real name, avatar, and LinkedIn — n/a, existing creator; `author.md` unchanged
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for review

Three reference pages: `account-gates.md`, `comment-voice.md`, `subreddit-recon.md`.

**On overlap with the existing `Reddit` category.** I read the nine skills already in this category before drafting. `reddit-account-warmup`, `reddit-comment-safety`, `subreddit-pre-post-check`, and `advocate-voice-tuning` cover karma warmup, comment compliance, pre-post checks, and voice tuning respectively. This skill deliberately does not compete on those — the karma bands and voice material sit in references as prerequisites, and the spine is the part I don't think is covered elsewhere: comment-over-post as the authority model, thread selection weighted for evergreen retrieval and AI-answer citation, first-hour velocity as the discovery method, and disclosure as an asset rather than a compliance step. Happy to cut further into the references if you'd rather reduce the surface area.

The spine runs ~1,000 words against the ~600–800 guidance, same as my `quora-authority-answering` submission. Glad to tighten.
