### PR TITLE
Intake repairs: multichannel-campaign-builder, quora-authority-answering, audit-the-base-not-the-rate

### DIFF
--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-employee-advocacy.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-employee-advocacy.md
@@ -6,7 +6,7 @@ Use this playbook when the user wants to reach the engagers of a specific collea
 
 ## What makes it different from social selling
 
-In a standard social-selling campaign, the engagement must never be referenced directly (it reads as surveillance — see `social-selling.md`).
+In a standard social-selling campaign, the engagement must never be referenced directly (it reads as surveillance — see `campaign-type-social-selling.md`).
 
 Here it's the opposite: **the engagement can be referenced openly.** The sender is a *colleague* of the post's author, so mentioning the advocate's post is a legitimate professional relationship, not monitoring.
 

--- a/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-social-selling.md
+++ b/skills/erwann-lefevre/multichannel-campaign-builder/references/campaign-type-social-selling.md
@@ -33,7 +33,7 @@ The signal tells you *what to talk about*. It is never something you talk *about
 | Mix | Sequence | Cadence |
 |---|---|---|
 | LinkedIn-only | invite + 2 DMs | J0 / J+5 / J+12 |
-| Multichannel (recommended) | 3 LinkedIn + 3 emails, alternating | J0 / J+4 / J+7 / J+10 / J+14 |
+| Multichannel (recommended) | 3 LinkedIn + 2 emails, alternating | J0 / J+4 / J+7 / J+10 / J+14 |
 | Email-only | 3 emails | J0 / J+4 / J+8 |
 
 ## Sequence shape

--- a/skills/roman-palii/audit-the-base-not-the-rate/SKILL.md
+++ b/skills/roman-palii/audit-the-base-not-the-rate/SKILL.md
@@ -2,7 +2,7 @@
 name: audit-the-base-not-the-rate
 title: Audit the base, not the rate
 description: |
-  Use this skill whenever a percentage in a commercial term is being set, questioned, or is
+  Use this skill when a percentage in a commercial term is being set, questioned, or is
   producing a number nobody expected — sales commission, revenue share, affiliate and creator
   payouts, channel margin, agency fees, referral fees, rebates. Triggers: "reps are hitting quota
   but margin isn't moving", "what does this promo actually cost us", "our partner payouts are

--- a/skills/vesselin-malev/quora-authority-answering/SKILL.md
+++ b/skills/vesselin-malev/quora-authority-answering/SKILL.md
@@ -2,13 +2,13 @@
 name: quora-authority-answering
 title: Quora authority answering
 description: |
-  Use this skill for any Quora answering program run as a lead generation channel:
+  Use this skill when running a Quora answering program run as a lead generation channel:
   "answer these Quora questions", "write Quora answers for our founder", "our Quora
   answers read like AI", "how do we get leads from Quora", "which of these questions
   should we answer". Produces linkless answers that survive moderation, earn upvotes
   on the collapsed preview, and convert readers into profile visits, plus the triage
   and posting order for a batch.
-category: Influencers
+category: AEO
 tags: [Marketing, Demand Gen]
 ---
 
@@ -28,7 +28,7 @@ Set a credential line per topic cluster — role, company, one clause on what th
 
 Answer everything in a pasted batch unless the client says otherwise. Raise concerns as flags delivered alongside the work, never as withheld work.
 
-Five conditions get flagged and still get written: off-position questions, vendor-seeded clusters, near-duplicate threads, tool questions where the tool is unknown, and regulatory questions. Each carries its own handling and its own effect on posting order — read `references/triage-flags.md` before sequencing a batch.
+Four conditions get flagged and still get written: off-position questions, vendor-seeded clusters, tool questions where the tool is unknown, and regulatory questions. Near-duplicate threads are the one deliberate exception — pick the thread with the better traffic and skip the twin, per the triage reference. Each carries its own handling and its own effect on posting order — read `references/triage-flags.md` before sequencing a batch.
 
 ## Pace the posting
 
@@ -76,7 +76,7 @@ The output is good when no two answers in a batch share a skeleton or a length, 
 
 - MUST answer from a personal profile with a credential line matched to the topic cluster.
 - MUST carry at least one practitioner-level mechanic in every answer.
-- MUST deliver flagged questions as written answers with the flag attached, never as withheld work.
+- MUST deliver flagged questions as written answers with the flag attached, never as withheld work — except near-duplicate twins, which are skipped by design with the skip noted.
 - MUST vary opener shape and answer length deliberately across a batch.
 - MUST space a vendor-seeded cluster across days rather than answering it in one sitting.
 - NEVER include a link or a call to action, outside the disclosed "which company is best" pattern.


### PR DESCRIPTION
Publish-time repairs flagged in the Aug-20 reviews, applied to the repo so it matches the live DB copies (published same day):

- **multichannel-campaign-builder** (@R1LGM): companion filename fix + cadence row reconciled to 5 touches / 5 slots
- **quora-authority-answering** (@vesselinmalev): category → AEO, description lead, near-duplicate contradiction reconciled toward the triage reference's deliberate-skip
- **audit-the-base-not-the-rate**: description 'whenever' → 'when'

Contributors: push back on any of these in comments if you'd word them differently.

Needs a maintainer approval (Ariel pushed this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)