### PR TITLE
add webinar-to-qualified-pipeline

### DIFF
--- a/skills/gerrit-kesten/webinar-to-qualified-pipeline/SKILL.md
+++ b/skills/gerrit-kesten/webinar-to-qualified-pipeline/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: webinar-to-qualified-pipeline
+title: Webinar to qualified pipeline
+description: |
+  Use this skill after a B2B webinar has registrations or engagement data but before treating
+  every registrant as a sales lead. Produces reconciled lifecycle states, fit and intent scores,
+  a prioritised sales-review queue, segment-specific follow-up, and a measurable handoff from
+  webinar registration to qualified pipeline and booked meetings.
+category: Events
+tags: [Sales, Demand Gen, RevOps]
+---
+
+Use this when a webinar has produced names but the revenue team cannot tell who deserves sales attention, useful follow-up, or no action. It turns verified engagement and fit into a controlled pipeline process.
+
+## Define the commercial job
+
+Write one sentence that names the audience, the problem taught, and the next buying step. A webinar for awareness, customer education, partner enablement, and opportunity acceleration cannot share one qualification rule.
+
+Define the conversion ladder:
+
+1. registration;
+2. attended live, watched replay, or no-show;
+3. meaningful engagement;
+4. sales review accepted;
+5. meeting booked;
+6. qualified opportunity created.
+
+Keep every rung separate. Registration is a content conversion, not pipeline. Attendance still does not prove fit, authority, a current problem, or willingness to buy.
+
+## Reconcile identities and states
+
+Create one record per person and preserve source, campaign, event, answers, permission, company, role, and existing relationship. Resolve duplicates conservatively. Uncertain identity matches go to review instead of merging.
+
+Assign one current state using `references/lifecycle-states-and-suppression.md`. A later, harder state overrules an earlier one. A confirmed meeting ends booking nurture. Customers and open opportunities route to their existing owner.
+
+## Score fit and intent separately
+
+Do not let watch time rescue a poor-fit account. Score three dimensions:
+
+- **Fit, 0–40:** account, persona, market, and use-case match.
+- **Engagement, 0–30:** attendance depth, replay, questions, polls, and calls to action.
+- **Buying intent, 0–30:** stated problem, decision-stage question, high-intent page visit, reply, or meeting request.
+
+Use `references/qualification-scorecard.md` for the rubric and these starting bands:
+
+- **0–24:** record only or low-frequency nurture;
+- **25–49:** relevant nurture, no sales task;
+- **50–69:** human sales review;
+- **70–100:** priority sales review and handoff.
+
+A score of 70 qualifies for handoff only when Fit is at least 20 and Buying Intent at least 10. Booked meetings move to sales. Suppression and existing relationships override scoring.
+
+## Use questions as buying evidence
+
+Separate educational questions from workflow and decision questions. Decision questions reveal commercial, rollout, integration, compliance, approval, timing, or capacity constraints.
+
+Preserve the buyer's wording. “Can we plan monthly target hours and see utilisation?” carries more context than “interested in workforce planning.” Aggregate repeated questions to find messaging and demo gaps without treating every questioner as sales-ready.
+
+## Route the next action
+
+Build the next step from state, score, and relationship. Priority records receive a context-rich handoff. Review-band records require human verification. Relevant but unqualified attendees receive topic-specific value. No-shows receive a replay or summary without manufactured urgency. Existing relationships route to their owner; suppressed contacts receive no nurture.
+
+Use `references/follow-up-and-handoff-matrix.md` for timing and approval. Individual sales messages, bulk sends, sequence enrolment, and ambiguous merges require explicit human approval.
+
+## Measure the complete funnel
+
+Report each rung by source, audience, and event topic:
+
+```text
+registrations → live/replay engagement → sales reviews accepted
+→ meetings booked → qualified opportunities → sourced or influenced revenue
+```
+
+Do not report registration as a lead, a sales task as pipeline, or a processed conversion event as revenue. Track source, duplicates, suppression, owner acceptance, rejection reasons, and whether meetings exited lower-level nurture. Compare cohorts only when definitions match.
+
+See `references/worked-webinar-case.md` for an anonymised operating pattern built from real B2B webinar question types.
+
+## What good looks like
+
+- The operator notices the gap between attendance and buying intent before celebrating registration volume.
+- Sales receives a short queue with account fit, exact engagement, buyer wording, source, existing relationship, and recommended next step.
+- No-show, attendee, replay viewer, customer, open opportunity, and booked meeting never receive the same treatment.
+- Every qualified handoff can be traced back to source evidence and every rejected handoff has a reason.
+- The weak version sends the same “thanks for attending, book a demo” email to everyone. The strong version protects trust, routes real intent quickly, and leaves low-signal contacts out of sales sequences.
+- Funnel reporting distinguishes sourced pipeline from influenced pipeline and preserves the difference between meeting and opportunity.
+
+## Rules
+
+- MUST keep registration, engagement, meeting, opportunity, and revenue as separate funnel events.
+- MUST score account fit independently from engagement and buying intent.
+- MUST preserve buyer wording, source, permission, and existing relationship in every handoff.
+- MUST stop booking nurture after a confirmed meeting and reroute customers or active opportunities to their owner.
+- NEVER infer marketing permission, buying intent, or qualification from attendance alone.
+- NEVER auto-send individual sales outreach, run bulk follow-up, merge uncertain identities, or enrol sequences without explicit human approval.
+- NEVER invent attendance, watch time, questions, attribution, or revenue when the event platform does not provide it.

--- a/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/follow-up-and-handoff-matrix.md
+++ b/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/follow-up-and-handoff-matrix.md
@@ -1,0 +1,63 @@
+# Follow-up and handoff matrix
+
+Timing starts when the underlying signal becomes available and reliable, not merely when the webinar ends.
+
+## Default matrix
+
+| Segment | Default timing | Content | Sales action |
+|---|---|---|---|
+| Priority score with decision signal | Same business day review | Reflect exact problem or question | Named owner reviews and approves personal follow-up |
+| Review score | Within one business day | Verify fit and relationship first | Accept, reject with reason, or return for research |
+| Attended, relevant, below sales threshold | Within one business day | Session takeaway or answer tied to attended topic | No sales task unless another signal appears |
+| Replay viewer with new intent | Within one business day of replay signal | Continue the topic they watched | Re-score; create review only if gates are met |
+| No-show | Within one business day of event end | Replay or concise summary | No sales task from no-show alone |
+| Existing customer | Same business day routing when signal is material | Customer-relevant context | Route to customer owner |
+| Active opportunity | Same business day routing | Add question and engagement to deal context | Route to opportunity owner |
+| Meeting booked | Immediate state update | Only meeting logistics and useful preparation | Stop booking nurture; prepare handoff |
+| Unsubscribed or disqualified | No marketing follow-up | None | Apply suppression and retain reason |
+
+These timings are operating defaults. If platform data arrives late or changes, use the verified state rather than sending against stale data.
+
+## Sales handoff packet
+
+Every accepted handoff should contain:
+
+```text
+Person and account:
+Role and fit evidence:
+Original source and campaign:
+Webinar and session/topic:
+Live/replay/no-show evidence:
+Exact registration answer or question:
+Fit score / Engagement score / Intent score:
+Existing customer, opportunity, or prior conversation:
+Recommended conversation angle:
+Reason to act now:
+Owner:
+Approval state:
+```
+
+The handoff should take less than a minute to understand. Link to source evidence rather than pasting unnecessary personal data into multiple systems.
+
+## Approval gates
+
+Require explicit human approval before:
+
+- sending an individual sales message;
+- launching or changing a bulk follow-up;
+- enrolling anyone in a sales or marketing sequence;
+- merging uncertain identities;
+- overriding an unsubscribe, customer owner, opportunity owner, or disqualification;
+- making product, pricing, legal, compliance, security, or timing promises.
+
+Automatic internal updates are acceptable when they are idempotent, reversible, and monitored: recording events, calculating scores, adding suppression, creating review tasks, and attaching source context.
+
+## Message rules
+
+- Reference the topic or exact question, not generic attendance.
+- Do not claim someone attended when only registration is known.
+- Do not say “sorry we missed you” unless no-show state is verified.
+- Do not manufacture scarcity or urgency.
+- Use one clear next step.
+- A replay link is value delivery, not permission for an unrelated sales sequence.
+- If a personal message is approved, read back the final recipient, text, and send result. An ambiguous result is investigated, not retried automatically.

--- a/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/lifecycle-states-and-suppression.md
+++ b/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/lifecycle-states-and-suppression.md
@@ -1,0 +1,77 @@
+# Lifecycle states and suppression
+
+A webinar record needs one current state plus its event history. Do not overwrite the history when the state advances.
+
+## State precedence
+
+Highest state wins for routing:
+
+1. unsubscribed or disqualified;
+2. customer or active opportunity;
+3. meeting booked;
+4. sales review accepted;
+5. priority sales review pending;
+6. attended live or watched replay;
+7. no-show;
+8. registered, event pending.
+
+Unsubscribed and disqualified are communication stops, not deletion instructions. Retain only the data that the organisation is permitted or required to keep.
+
+## State definitions
+
+| State | Required evidence | Allowed next action |
+|---|---|---|
+| Registered, pending | Valid registration for a future event | Event confirmation and permitted reminder |
+| Attended live | Verified event attendance | Score engagement and questions |
+| Watched replay | Verified replay event | Score replay and any later intent |
+| No-show | Registered; event ended; no verified live/replay activity | Replay or summary, subject to permission |
+| Sales review pending | Score and gates met; no hard suppression | Human checks fit, identity, relationship, and next step |
+| Sales review accepted | Named owner accepted the handoff | Personalised sales action with approval |
+| Meeting booked | Confirmed active meeting matched to the person | Stop lower-level booking nurture; prepare sales context |
+| Customer | Verified current customer relationship | Route to customer owner; treat as adoption or expansion context |
+| Active opportunity | Verified open opportunity | Route to opportunity owner; do not create a duplicate lead motion |
+| Unsubscribed | Valid opt-out or objection | Suppress external marketing and sales nurture |
+| Disqualified | Documented reason | Suppress or route according to the reason |
+
+## Hard stops
+
+Stop booking and qualification nurture when:
+
+- a meeting is confirmed;
+- the contact unsubscribes or objects;
+- sales disqualifies the record;
+- an active opportunity or customer relationship requires a different owner;
+- the event or registration is cancelled;
+- identity cannot be resolved safely.
+
+A cancelled or rescheduled meeting is not the same as a no-show. Re-open the correct state only after reading the current meeting status.
+
+## Conflict resolution
+
+Use this order:
+
+1. read current relationship and suppression state;
+2. verify identity and event;
+3. apply the latest harder state;
+4. retain earlier events as history;
+5. calculate the permitted next action;
+6. confirm that competing sequences or owners will not act simultaneously.
+
+## Reconciliation table
+
+```text
+Person/account:
+Original source:
+Event:
+Registration state:
+Attendance/replay evidence:
+Current relationship:
+Current lifecycle state:
+Suppression reason:
+Owner:
+Last permitted action:
+Next permitted action:
+Evidence checked at:
+```
+
+Reconcile event records against the customer system and meeting system after each webinar. A webinar platform can prove registration or viewing; it cannot by itself prove customer status, opportunity ownership, or a valid meeting.

--- a/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/qualification-scorecard.md
+++ b/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/qualification-scorecard.md
@@ -1,0 +1,73 @@
+# Qualification scorecard
+
+Score Fit, Engagement, and Buying Intent separately. The default maximum is 100. These are operating thresholds, not universal industry benchmarks; recalibrate them against accepted handoffs and created opportunities after several comparable events.
+
+## Fit: 0–40
+
+| Signal | Points | Rule |
+|---|---:|---|
+| Account matches the defined company profile | 20 | Size, sector, operating model, geography, or other hard criteria match |
+| Role belongs to the buying group | 10 | Economic buyer, champion, operational owner, or credible evaluator |
+| Webinar use case matches a current company need | 10 | Registration answer, question, or known account context confirms relevance |
+
+Do not award partial points because a company “looks interesting.” Record which criterion matched.
+
+## Engagement: 0–30
+
+Add signals, then cap at 30.
+
+| Signal | Points |
+|---|---:|
+| Registered only | 2 |
+| Attended less than 25% live | 5 |
+| Attended 25–49% live | 10 |
+| Attended at least 50% live | 15 |
+| Watched a meaningful replay segment | 10 |
+| Answered a substantive poll | 5 |
+| Asked a substantive question | 10 |
+| Clicked an event call to action or related resource | 10 |
+
+If watch depth is unavailable, use only verified attendance or replay state. Never estimate it from registration or email opens.
+
+## Buying intent: 0–30
+
+Add signals, then cap at 30.
+
+| Signal | Points |
+|---|---:|
+| Registration answer states a relevant operational problem | 8 |
+| Asks a workflow-fit or implementation question | 10 |
+| Asks a commercial, rollout, integration, compliance, or decision question | 15 |
+| Visits a verified high-intent product, pricing, or meeting page after the event | 15 |
+| Replies with a concrete problem, timing, stakeholder, or next-step request | 20 |
+| Requests or books a meeting | 30 |
+
+A meeting request becomes a sales handoff regardless of total score, but it still needs relationship and suppression checks.
+
+## Routing bands
+
+| Total | Default action |
+|---:|---|
+| 0–24 | Record only or low-frequency nurture |
+| 25–49 | Topic-specific nurture; no sales task |
+| 50–69 | Human sales review |
+| 70–100 | Priority sales review and handoff |
+
+Additional gates:
+
+- A scored handoff requires Fit of at least 20 and Buying Intent of at least 10.
+- Existing customers and active opportunities route to their owner, regardless of score.
+- Unsubscribed and disqualified contacts receive no external nurture.
+- An uncertain identity cannot become an automated handoff.
+
+## Calibration
+
+After three to five comparable webinars, inspect:
+
+- accepted versus rejected handoffs by score;
+- meetings and opportunities by each component score;
+- signals that added points but produced no commercial progression;
+- high-value records the score missed;
+- source and topic differences.
+
+Raise or lower one component at a time. Do not change the score and qualification definition together, or cohort comparisons become unreliable.

--- a/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/worked-webinar-case.md
+++ b/skills/gerrit-kesten/webinar-to-qualified-pipeline/references/worked-webinar-case.md
@@ -1,0 +1,71 @@
+# Worked webinar case
+
+This anonymised pattern comes from a recurring B2B software webinar. The example records use real question types observed in the webinar programme, with identifying details removed. The scores illustrate the rubric; they are not claimed revenue outcomes.
+
+## Context
+
+The webinar topic was broad enough to attract curiosity, but the most useful signals appeared in operational questions:
+
+- Can planned personnel hours for a quote later become an operational schedule?
+- Can fixed employees be planned against monthly target hours and utilisation?
+- Can relevant working-time rules be represented or checked?
+- Can annual or recurring plans be generated?
+
+Counting registrations alone would have hidden the difference between topic interest and an active buying problem.
+
+## Record A: operational buyer with a workflow question
+
+Evidence:
+
+- Account matched the target operating model: 20 Fit points.
+- Role was responsible for the workflow: 10 Fit points.
+- Question confirmed the use case: 10 Fit points.
+- Attended at least half of the session: 15 Engagement points.
+- Asked a substantive workflow question: 10 Engagement points.
+- The question described a concrete operational process: 10 Intent points.
+
+Score: **Fit 40, Engagement 25, Intent 10, Total 75.**
+
+Routing: priority human sales review. The handoff used the buyer's exact quote-to-schedule question and did not replace it with “interested in AI.” A named owner still had to check existing relationship and approve the message.
+
+## Record B: engaged learner from a poor-fit account
+
+Evidence:
+
+- Account did not meet the defined company profile: 0 Fit points.
+- Role was adjacent to the buying group: 5 Fit points was not available under the strict rubric, so no points were awarded.
+- Watched most of the session and answered a poll: 20 Engagement points.
+- Asked an educational question without a current company problem: 0 Intent points.
+
+Score: **Fit 0, Engagement 20, Intent 0, Total 20.**
+
+Routing: record only or permitted topic nurture. High engagement did not turn a poor-fit attendee into a sales task.
+
+## Record C: no-show who later viewed pricing
+
+Initial evidence:
+
+- Account matched: 20 Fit points.
+- Role matched: 10 Fit points.
+- Registered but did not attend: 2 Engagement points.
+- No stated problem: 0 Intent points.
+
+Initial score: **32.** The next action was a replay or summary, not a sales task.
+
+Later, a verified visit to a decision-stage pricing page added 15 Intent points. The record moved to **47**, still below review. If a concrete reply or meeting request arrived, it would be re-scored or handed directly to sales. The process did not inflate the score merely because the account looked valuable.
+
+## Failure pattern
+
+The first instinct was to treat every registrant as a lead and use the same post-event booking message. That would have:
+
+- sent sales pressure to educational and poor-fit contacts;
+- ignored the exact operational questions from the strongest records;
+- treated no-show and attendance as equal;
+- created conflicting follow-up for existing customers or opportunities;
+- counted tasks or registrations as pipeline.
+
+The corrected process separated lifecycle state, Fit, Engagement, and Intent. Sales received fewer records, but each handoff included the source, exact question, evidence, score components, existing relationship, and recommended next step.
+
+## Post-event learning
+
+The question cluster also changed the GTM backlog. The repeated operational questions became candidates for product-page clarification, sales-demo scenarios, and future webinar topics. The team could learn from all questions without pretending that every questioner had become a qualified opportunity.


### PR DESCRIPTION
## What this skill does

Turns webinar registrations and verified engagement into a controlled qualification and sales-handoff process. It separates lifecycle state, account fit, engagement, and buying intent; routes customers and active opportunities correctly; stops booking nurture after a confirmed meeting; and measures registrations, meetings, opportunities, and revenue as distinct funnel events.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/gerrit-kesten/webinar-to-qualified-pipeline/` only
- [x] `node tools/validate.mjs` passes locally
- [x] Gerrit Kesten's `author.md` is already supplied through his first contribution
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment
- [x] Includes a 100-point qualification rubric, lifecycle precedence, suppression rules, timing defaults, and worked examples
- [x] No lifecycle/operational frontmatter fields (`prefix`, `isDefault`, …)
- [x] No secrets, external data receivers, injection patterns, or ungated destructive actions
- [x] Individual sales messages, bulk sends, sequence enrolment, and ambiguous identity merges require human approval
- [x] Gerrit Kesten approved publication and MIT licensing with attribution via his creator profile

## Validation

```text
ok — 312 skills across 59 creators, all checks passed
security_pattern_check=pass
```
