### PR TITLE
add deal-blocker-maneuvers

### DIFF
--- a/skills/nikhil-mirza/author.md
+++ b/skills/nikhil-mirza/author.md
@@ -1,0 +1,9 @@
+---
+name: Nikhil Mirza
+title: Sr Director, Sales Operations, Taboola
+linkedinUrl: https://www.linkedin.com/in/nikhilmirza/
+companyDomain: taboola.com
+email: nikhil.m@taboola.com
+---
+
+Nikhil is Senior Director of Sales Operations at Taboola, where his focus is forecast accuracy, pipeline hygiene, and building the systems enterprise sellers actually use rather than the ones they route around. His skills encode the operator's half of revenue work: turning a qualification framework into something a rep runs on a Tuesday, and into a forecast a leader can defend.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/SKILL.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: deal-blocker-maneuvers
+title: Deal blocker maneuvers
+description: |
+  Use this skill after any meaningful interaction on a complex deal — a call, a stakeholder
+  meeting, a procurement exchange — when the question is not "what's missing" but "what do I
+  actually run next week." Takes a qualification assessment (supplied, or scored here from
+  primary evidence), reads it against what the deal's stage should already have proven rather
+  than against an absolute bar, and converts the single worst blocker into a two-cycle
+  maneuver the rep can save and execute: trigger conditions, a pre-mortem, a go/no-go
+  checklist, a verbatim opening, IF/THEN counter-moves, and explicit abort criteria. Covers
+  deal coaching, deal strategy, forecast defence, stalled and blocked deals, gone-dark
+  champions, procurement stalls, third-party and partner blockers, deal reviews, and "this
+  deal is stuck and I don't know why." Built for enterprise and complex deals; not for
+  transactional velocity motions.
+category: Deals
+tags: [Sales, RevOps]
+---
+
+# Deal blocker maneuvers
+
+Runs after every meaningful interaction on a complex deal. Produces one saved artifact: a stage-adjusted read of the deal's qualification, a named primary blocker, and a two-cycle maneuver with abort criteria — plus a missing-information report listing exactly what nobody has asked yet.
+
+This is the layer *after* diagnosis. Knowing that the economic buyer is unverified is not a plan; the plan is the specific move that verifies them, what you do when it backfires, and the condition under which you stop trying.
+
+## Scope — where this works and where it does not
+
+Built for **enterprise and complex deals**: multiple stakeholders, a real evaluation process, third parties or procurement in the path, months rather than days. That is where the eight dimensions all carry information and where a two-cycle maneuver is worth constructing.
+
+**On transactional and high-velocity deals, the economics invert.** A two-call deal has no buying committee to segment, no paper process to map, and rarely a blocker that survives a single well-aimed question — the diagnostic overhead exceeds what the deal returns, and the output reads as bureaucracy to the rep. Below `{{COMPLEX_DEAL_FLOOR}}`, use whatever lighter qualification standard your team already runs; the evidence rule below is still worth borrowing, but the rest of this is built for a different shape of deal.
+
+## Template placeholders
+
+Replace every `{{...}}` before enabling. Full setup list in **references/setup-customization-checklist.md**.
+
+- `{{TERMINOLOGY_MAP}}` — your org's labels for the eight dimensions, if they differ from textbook terms. Declare them here; the skill then uses **only** your labels in output.
+- `{{STAGE_NAMES}}` — your pipeline stage names, mapped onto the five bands in Step 3.
+- `{{CONTEXT_LAYER}}` — where primary evidence lives: call recordings and transcripts, email threads, meeting records, shared documents.
+- `{{COMPLEX_DEAL_FLOOR}}` — the deal size, cycle length, or segment below which this skill does not run (default: anything that closes in under 30 days or without a second stakeholder).
+- `{{FORECAST_OWNER}}` — who is told, same day, when a deal breaches an escalation condition.
+- `{{REVIEW_CADENCE}}` — default is after every meaningful interaction; weekly also works. Anything but "when the deal feels stuck."
+
+---
+
+## The evidence rule — read this before any step
+
+**Score only from primary evidence in `{{CONTEXT_LAYER}}`: what the buyer actually said or wrote.** Never from the rep's summary of what happened, their confidence, or their answer to "is the economic buyer engaged?"
+
+This is the failure mode that kills the whole framework. A rep who believes the deal is strong will report it as strong, the framework will faithfully convert that belief into a number, and the number will carry an authority the belief never earned. The output is a confident, wrong forecast — worse than no framework, because it launders optimism into arithmetic.
+
+If a dimension has no evidence in the context layer, it scores **0 (Unknown)**. Zero is an honest, useful state. A guess dressed as a score is neither.
+
+## Step 1 — Run the segmentation gate
+
+Test whether one assessment is even valid. If the definition of success, the identity of the decision-maker, or the risks in play differ across the parties in this deal, one blended assessment averages two realities into a third that describes neither.
+
+Three outcomes: **unified track**, **segmented track** (run the diagnostic separately per party), or **stop and ask** — when the deal plainly has divergent stakeholders but the evidence cannot tell you how they diverge. The stop is deliberate: guessing here corrupts every downstream step, and the question that resolves it takes one message. Variance test in **references/segmentation-and-lanes.md**.
+
+## Step 2 — Establish the assessment
+
+Eight dimensions: **metrics, economic buyer, decision criteria, decision process, third parties and paper process, implicated pain and initiative, champion, competition.**
+
+**If a current qualification assessment already exists** — from the deal record, a prior review, or a diagnostic pass someone else ran — prefer it over re-deriving one, but only per dimension and only where it passes the provenance test.
+
+**The provenance test.** A dimension in an incoming assessment is usable only if it carries the evidence behind it — a quote, a cited exchange, a named source in the context layer. **A qualification field on a deal record usually carries none, and an unsourced field is a rep's self-assessment wearing a score's clothing.** Accept the dimensions that cite evidence. Every dimension that does not is discarded — score it here from the context layer like any other, which will often mean 0, and will sometimes mean the field was right for reasons nobody had written down. Never accept an assessment wholesale because it exists.
+
+Where an accepted dimension conflicts with newer evidence in the context layer, say so explicitly and cite both sides rather than quietly replacing it.
+
+**For every dimension not accepted,** score here: **−1 (blocker)**, **0 (unknown)**, **+0.5 (friction)**, **+1 (accelerator)**, against evidence thresholds rather than impressions. Per-dimension criteria in **references/scoring-and-stage-bands.md**.
+
+Range is **−7 to +8**, because one asymmetry is deliberate: **the champion dimension has no −1.** A champion is proven, unproven, or absent — and "high-risk champion" is almost always a rep describing someone who was never a champion at all. Forcing that judgment into *unproven* or *absent* is more honest and points at a better next action.
+
+**Mapping a different rubric.** Incoming assessments often use a two-axis shape — how well evidenced a dimension is, and whether the answer favours you. Collapse it onto this scale in that order, never by feel:
+
+| Incoming | Maps to |
+|---|---|
+| Well evidenced, favourable | **+1** |
+| Well evidenced, neutral or merely adequate | **+0.5** |
+| Well evidenced, actively unfavourable — a condition that kills the deal unaddressed | **−1** |
+| Well evidenced, unfavourable but survivable | **+0.5** |
+| Asserted without evidence, any direction | **0** |
+| Explicitly flagged as a gap or an unknown | **0** |
+
+Three constraints on the table. **The per-dimension criteria govern wherever the incoming detail is specific enough to apply them** — the table is a fallback for assessments too coarse to map directly, not a shortcut past the thresholds. **The champion dimension never maps below 0**: a documented finding that a contact lacks influence or has misled you is *absent*, not a blocker. And a documented risk is an unfavourable finding, not an absence of information — it maps on the favourability rows, never to 0.
+
+The collapse is lossy — a documented "no budget confirmed" and an undocumented worry look similar in prose and land a point and a half apart here, which is enough to flip an escalation. Record the original label alongside the mapped score so the reconciliation is auditable, and where the incoming rubric cannot be resolved on the evidence axis, score **0** and re-derive.
+
+## Step 3 — Read the score against the stage, never in isolation
+
+A raw total means nothing on its own. **+3 is healthy in discovery and alarming in negotiation.** What matters is the gap between actual and what this stage should already have proven.
+
+| Band — map your `{{STAGE_NAMES}}` onto these | Expected | Hard floor | Additional gate |
+|---|---|---|---|
+| Discovery / qualification | ≥ 0 | −2 | Unknowns are normal — nobody has asked yet |
+| Validation | ≥ +2 | 0 | No unknowns on metrics, economic buyer, or champion |
+| Proposal / business case | ≥ +4 | +2 | No dimension sitting at −1 |
+| Negotiation | ≥ +5.5 | +4 | Any −1 triggers a forecast review |
+| Commit / close | ≥ +6.5 | +5 | Decision process and paper process both at +1 |
+
+Every threshold is a tunable default. Calibrate against your own closed-won and closed-lost history before letting any of it touch a forecast.
+
+**Escalate to `{{FORECAST_OWNER}}` the same day when either condition holds:** the total is more than 1.5 below its band expectation, or it is under the hard floor. Between those — up to 1.5 below expectation and above the floor — the deal is recoverable inside its stage: build a maneuver, leave the forecast alone.
+
+**The unknown-cluster override.** Regardless of total, if **three or more** dimensions score 0 *and* the missing evidence all sits behind a single stakeholder, **the deal does not hold its current stage.** Escalate regardless of the gap test, and recommend moving the opportunity back one stage until a second independent source exists inside the account — the close date and forecast category should follow the stage the deal can actually defend. The recommendation stands until the cluster clears; it does not compound into a further rollback on each run. You do not have a qualified deal; you have one relationship and a story, and a healthy-looking total is what makes it dangerous.
+
+**The stall rule.** No movement across two consecutive runs at validation-or-later is a stalled deal at any level — a live deal generates new information, and one that has stopped generating it has usually stopped moving inside the account. Flag the stall as a finding in its own right.
+
+**Band gates have consequences, not just descriptions.** A breached gate acts on its own, independent of the total — three of the four bind the plan, and one escalates:
+
+| Breached gate | Consequence |
+|---|---|
+| Validation — an unknown remains on metrics, economic buyer, or champion | The deal cannot advance past validation. Every one becomes a lane 3 item this cycle. |
+| Proposal — any dimension at −1 | Cycle 1 must target that dimension. A proposal does not go out, or is not pursued, while it stands. |
+| Negotiation — any dimension at −1 | Forecast review: `{{FORECAST_OWNER}}` decides that week whether the close date holds, recorded either way. |
+| Commit — decision process or paper process below +1 | The close date is not defensible. Treat it as a date estimate, not a commit, until both are +1. |
+
+## Step 4 — Codify and pick the target
+
+Sort the dimensions into blockers (−1), friction (+0.5), unknowns (0), accelerators (+1).
+
+**Cycle 1 targets the single worst blocker.** Not all of them — one. A rep executing one well-constructed move beats a rep holding a list of eight. **Cycle 2 either flanks that blocker or clears the highest-value unknown**, and does not begin until cycle 1 reaches a defined exit state.
+
+With no −1 anywhere, the target is the unknown that most constrains the stage gate above.
+
+## Step 5 — Construct the maneuver
+
+Each cycle gets trigger conditions, the strategic reframe it depends on, a pre-mortem, a go/no-go checklist, a verbatim opening, IF/THEN counter-moves, a named pitfall, and explicit success and abort criteria. Build it from **references/maneuver-construction.md**, which carries the full structure and two worked examples.
+
+**First, if the target blocker has already survived a straightforward attempt to clear it,** classify what kind of contest the deal actually is before writing the reframe — a hostile negotiation, a zero-sum resource fight, and the sale of a financial abstraction each demand a different response, and ordinary qualification logic prescribes the same wrong move for all three. On a first pass, or where the obvious move has not yet been tried properly, skip this. See **references/domain-model-retrieval.md**.
+
+## Step 6 — Assign lanes and publish the missing-information report
+
+Route each maneuver into a lane — third parties and procurement, client-direct, or targeted discovery — and ship discovery items as **literal questions addressed to a named person**, never as topics. A topic gets postponed; a written question gets asked. See **references/segmentation-and-lanes.md**.
+
+Every dimension scored 0 appears in the missing-information report as an unchecked item with the question that would close it. This is what makes the artifact usable in a deal review: it turns "we don't know" into an assignable task.
+
+## Step 7 — Persist the delta and re-run
+
+Mark every dimension **retained**, **upgraded**, **downgraded**, or **new**, against the previous assessment as baseline. Change a score only on clear new evidence; where new evidence contradicts an existing score, write the contradiction down and cite both sides. Where nothing new landed, retain and say so — silence is neither progress nor decay.
+
+Re-run at `{{REVIEW_CADENCE}}`.
+
+## What good looks like
+
+- **Every score traces to a quote.** Open the artifact, pick any dimension, and there is a line from a call or an email behind it. If a rep cannot produce the sentence, the score is not a score.
+- **The expert tell: unknowns clustered on one stakeholder.** Novices read the total. What predicts a loss is three or more zeros all sitting behind the same person — a single point of contact and a story you have been told rather than a process you have verified. The total can look respectable while this is true, which is exactly why it is the first thing to check.
+- **The mediocre version is a scorecard with no maneuver.** It grades the deal, hands the rep a list of gaps, and calls that coaching. Reps already know their gaps; what they lack is the move. If the artifact contains nothing the rep can say out loud on Tuesday, it has not done its job.
+- **The second mediocre version is eight simultaneous plays.** A plan addressing every dimension at once is a plan abandoned by Wednesday. One blocker, one maneuver, one exit condition.
+- **The forecast changes.** The test is not whether reps like the coaching — it is whether stage-adjusted scores start predicting outcomes, and whether deals leave the forecast earlier and more honestly than they used to.
+- **Reps run the abort.** When a rep stops a play at its stated failure condition instead of trying once more, the framework is operating rather than being filled in. It is the hardest behavior to establish and the clearest signal it is working.
+
+## Rules
+
+- **MUST** score only from primary evidence in `{{CONTEXT_LAYER}}`. **NEVER** score from a rep's self-reported summary, confidence level, or verbal assurance.
+- **MUST** score a dimension 0 when evidence is absent. **NEVER** infer a score to avoid an unknown.
+- **MUST** read every total against its stage band. **NEVER** report a raw score as healthy or unhealthy on its own.
+- **MUST** stop and ask when the segmentation gate is ambiguous. **NEVER** blend divergent stakeholders into one assessment to keep things moving.
+- **MUST** prefer an existing evidenced assessment over re-deriving one, and **MUST** state any conflict between it and new evidence rather than overwriting it.
+- **MUST** give every maneuver an explicit abort criterion before it is executed.
+- **MUST** run the pre-mortem before any move that goes around a stakeholder, and **NEVER** propose a move that bypasses a required approver without naming the political cost and its mitigation.
+- **MUST** use `{{TERMINOLOGY_MAP}}` labels in all output, and **NEVER** let borrowed external jargon reach the rep.
+- **MUST** explain any downgrade in writing. **NEVER** overwrite a prior score silently.
+- **NEVER** write to the deal record without explicit human approval, field by field.
+- **MUST** treat the stage bands as provisional until calibrated against your own closed-won and closed-lost history. **NEVER** let an uncalibrated band pull a deal from the forecast.
+- **NEVER** run the full framework on a deal below `{{COMPLEX_DEAL_FLOOR}}`.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/references/domain-model-retrieval.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/references/domain-model-retrieval.md
@@ -1,0 +1,58 @@
+---
+title: Identifying the game
+description: (reference) Classifying a stuck deal as a hostile negotiation, a resource fight, or a financial abstraction, and the counter-move each one implies.
+---
+
+# Identifying the game
+
+Some blockers are not qualification problems, and qualification logic prescribes the same wrong move for all of them: follow up harder, escalate, discount.
+
+**Run this only when a blocker has already survived a straightforward attempt to clear it.** First failure means do the obvious thing properly. Repeated failure usually means the deal is a different kind of contest than it appears.
+
+**Output:** one line at the top of the maneuver's orient phase — the game, and the reframe it implies. Nothing else from this page reaches the artifact.
+
+## The routing table
+
+| Signals in the context layer | The game | The reframe it forces | Cycle-1 shape |
+|---|---|---|---|
+| A stakeholder went dark after real engagement; procurement stonewalls; concessions extracted with no reciprocity; communication has gone one-directional | **Hostile negotiation** | From *chasing a decision* to *making it safe to say no* | Name their unspoken position for them, accurately and without defence, and let them correct you |
+| Budget freeze or reallocation; internal consolidation; your line item against another function's; a sponsor who wants it but cannot free funds | **Zero-sum resource fight** | From *convincing your sponsor* to *changing what the rival claimant gets* | Find the structure where the competing claimant gains from your winning — shared line, shared measure, or sequencing that serves them first |
+| Value is time-to-value, risk reduction, or optionality; the buyer agrees with the logic and does not act; "we'll revisit next quarter" with no objection attached | **Financial abstraction** | From *defending your price* to *pricing the delay* | Quantify the cost of the waiting period itself — what it forecloses, what it makes more expensive later |
+| None of the above | **Ordinary qualification gap** | — | Proceed with standard construction; skip this page |
+
+The last row is the common case. Most stuck deals are stuck because nobody asked a question, not because a mental model was missing.
+
+## What each game changes in practice
+
+**Hostile negotiation.** A stakeholder who has stopped responding is usually avoiding a conversation they expect to be unpleasant, not avoiding you. Stating their likely conclusion out loud — that you are too expensive, that this slipped down the list, that they have already chosen someone else — makes correcting you easier than continuing to avoid you. The counterintuitive part is that pressure produces more silence, so the move de-escalates and asks the other side to fill the gap.
+
+*Applied:* procurement silent for three weeks after a pricing exchange. Standard play is a fourth follow-up. Instead: "I expect you've concluded this is priced above what you can approve this quarter, and that it's easier not to reply than to say so. If that's right, tell me and I'll close the file." What comes back is frequently not the objection you assumed — often the budget moved, which is a different dimension entirely and a different play.
+
+**Zero-sum resource fight.** Two claimants on a fixed pool default to competing even where cooperation serves both. Arguing your case harder is playing the game as posed; the productive move changes the payoff so the rival claimant is not harmed by your winning.
+
+*Applied:* your project and another function are competing for the same budget line. Rather than strengthening your sponsor's case, find the outcome both functions are measured on, or sequence delivery so the rival's need is met first. The deal stops depending on your sponsor winning an internal argument, which is the part you cannot control.
+
+**Financial abstraction.** When the buyer's alternative is doing nothing, and nothing costs them nothing on paper, no amount of value articulation moves them. The object to quantify is the delay, not the solution — what a quarter of waiting costs, what it forecloses, and what it makes more expensive later.
+
+*Applied:* "we'll revisit next quarter" with no objection you can address. Price the quarter: the volume of the problem that accrues in it, the work that has to be redone if the decision lands later, the option that expires. The number under discussion becomes the wait rather than the price.
+
+## The terminology lock — non-negotiable
+
+**Borrowed vocabulary never reaches the rep, the artifact, or the deal review.** Map it back before anything is written down.
+
+| Borrowed concept | Write it as |
+|---|---|
+| Accusation audit, labelling | Risk mitigation discovery |
+| BATNA, walk-away alternative | Cost of inaction |
+| Payoff matrix, defection | Competing internal priorities |
+| Option value, carry cost | Cost of delay |
+
+Two reasons. A rep who repeats negotiation-theory vocabulary in front of a buyer sounds like they are running a technique, which destroys the effect the technique depends on. And an artifact that mixes vocabularies stops being reviewable — a manager cannot compare deals when each speaks a different language.
+
+## Compatibility check
+
+Before accepting a play derived this way:
+
+- Does it bypass a stakeholder whose validation the deal requires? Then it fails, however elegant.
+- Does it depend on a dimension currently scored 0? Close that unknown first — a borrowed model applied to unverified facts is confident and wrong.
+- Can this rep deliver it credibly? A move that only works when performed well is worse than a plain one performed badly. Where the answer is no, use the ordinary play and coach the technique separately.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/references/maneuver-construction.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/references/maneuver-construction.md
@@ -1,0 +1,152 @@
+---
+title: Maneuver construction
+description: (reference) The two-cycle observe/orient/decide/act structure — pre-mortem, go/no-go, verbatim opening, IF/THEN branches, and abort criteria — with worked examples.
+---
+
+# Maneuver construction
+
+How a codified blocker becomes something a rep can execute on Tuesday. Two cycles, four phases each: observe, orient, decide, act.
+
+A maneuver is not a task list. It specifies what to watch for before moving, the reframe the move depends on, what it costs if it fails, the words to open with, what to do when the buyer pushes back, and the condition under which you stop.
+
+## The two-cycle structure
+
+**Cycle 1 addresses the single worst blocker.** One. Not the three that scored −1 — the one that, if it stayed unresolved, would kill the deal first.
+
+**Cycle 2 either flanks that blocker or clears the highest-value unknown.** It does not begin until cycle 1 reaches a defined exit state, success or abort.
+
+Reps do not execute eight parallel plays. They execute one, and the second only exists so the artifact says what happens next rather than leaving them to improvise after the first move lands.
+
+---
+
+## Phase 1 — Observe
+
+**What to watch for before acting.** A maneuver launched on suspicion burns the move and teaches the buyer to expect it.
+
+- **Trigger conditions** — the specific, observable signals that confirm the blocker is real. Not "the champion seems less engaged" but "two consecutive meetings rescheduled by them, and the last two substantive questions went unanswered for more than four working days."
+- **Confirming evidence** — the lines in the context layer that established the −1.
+- **Hold condition** — the explicit instruction not to act until the triggers are confirmed.
+
+Write triggers so that two people reading the same context layer would agree on whether they have fired.
+
+## Phase 2 — Orient
+
+**Why this approach and not the obvious one.** Almost every blocker has an intuitive response that makes it worse: the champion goes quiet so you follow up harder; procurement stalls so you escalate; the buyer says you're expensive so you discount.
+
+State the **reframe** the maneuver depends on, in one line — the shift in how the rep is thinking about the situation. Examples of the shape:
+
+- From *asking for access* to *making the introduction serve the gatekeeper* — a contact deflecting a request to meet their boss is usually protecting their own position, not blocking yours.
+- From *proving value* to *removing risk* — a buyer who agrees with the case and still hesitates is not unconvinced; they are exposed, and the exposure is personal rather than commercial.
+- From *selling the outcome* to *selling the first ninety days* — where the objection is implementation capacity, the case has to be about their effort, not your result.
+
+Where the blocker has already survived a straightforward attempt and the deal was classified as a particular kind of contest, the reframe comes from that classification instead.
+
+If you cannot state the reframe, you have a follow-up, not a maneuver. Send the follow-up and skip the ceremony.
+
+## Phase 3 — Decide
+
+**What must be true before this is allowed to run.**
+
+### Why the rep should care
+
+One line, in the rep's interest, not the company's. "Stops you getting stuck presenting to someone who cannot approve this" beats "improves qualification hygiene." A maneuver a rep does not personally want to run does not get run.
+
+### Pre-mortem
+
+Assume the move has been made and it went badly. Answer two questions:
+
+- **What is the worst realistic outcome?** In complex deals the answer is almost always one of: a champion who feels bypassed and stops advocating, a stakeholder who feels their authority was violated, a premature "no" from someone who had not yet formed an opinion, or an internal politics problem the rep cannot see and now owns.
+- **What is the mitigation, and where does it sit in the act phase?** The mitigation must be *inside* the execution — a sentence in the script, a person told first, a sequencing choice. A mitigation written as a warning after the script is a warning, and warnings do not survive contact with a rep in a hurry.
+
+The most common backfire is going over a contact's head to reach the economic buyer. The mitigation is almost never "don't" — it is bringing the contact with you, framed so that the introduction makes them look prepared rather than circumvented.
+
+### Go/no-go checklist
+
+Four boxes, all of which must be checked:
+
+- [ ] The prerequisite fact this move depends on is confirmed (not assumed).
+- [ ] The stakeholder this targets is currently responsive.
+- [ ] The asset or material this move requires exists and is ready.
+- [ ] The political cost, priced by the pre-mortem, is smaller than the gain.
+
+Any unchecked box sends you back to targeted discovery. An unchecked fourth box means the maneuver is wrong, not early.
+
+## Phase 4 — Act
+
+### Persona check
+
+Before writing the script, check its register. It should read like someone diagnosing a business problem — direct, willing to name what is uncomfortable, focused on the buyer's outcome. It should not read like someone chasing a signature: no manufactured urgency, no gratitude for the buyer's time as an opening move, no stacked qualifiers.
+
+The practical test: **would a peer of the buyer's send this?** If it reads as written by someone junior to the recipient, rewrite it.
+
+### The verbatim opening
+
+Write the actual words — an opening line, a question, a short message. Not a description of what to communicate.
+
+A rep given "reframe the conversation around cost of inaction" will not do it. A rep given a sentence they can say will say it, or will edit it into their own voice, which is the point. Two to four sentences is usually right; a script long enough to need reading is long enough to sound read.
+
+Write one opening per maneuver, not per channel. If the channel changes the move materially, that is a different maneuver.
+
+### IF/THEN counter-moves
+
+Two to four branches covering the responses you can actually predict:
+
+- **IF** the buyer deflects to a subordinate → **THEN** accept, and use the subordinate to establish the approval path rather than re-presenting.
+- **IF** you get silence past the stated window → **THEN** switch to a closing-the-file message that makes non-response an answer, and stop.
+- **IF** the objection is price → **THEN** separate whether they cannot afford it from whether they do not believe the return, and handle only the second in this cycle.
+- **IF** the buyer confirms the blocker openly → **THEN** stop the maneuver as successful; the blocker is now a known condition with a different play.
+
+Branch on what the buyer does, never on what the rep hopes.
+
+### The pitfall
+
+One named warning specific to this maneuver — the thing that ruins it. "Do not run this before the economic impact is quantified; without a number this reads as pressure rather than analysis."
+
+### Exit criteria
+
+Both states, stated before execution:
+
+- **Success** — the observable outcome that means it worked, and the transition to cycle 2. Observable to a third party: a meeting booked, a name given, a written confirmation. Not "improved sentiment."
+- **Abort** — the outcome that means stop, and what replaces this cycle. Usually a bounded count or window: two attempts, or ten working days.
+
+**The abort criterion is the highest-value line in the artifact.** A rep who has already invested in a play will run it a fourth time rather than conclude it failed. Naming the failure condition in advance — before anyone is invested — is what makes stopping possible later.
+
+---
+
+## Worked example 1 — blocked access to the economic buyer
+
+**Situation.** Enterprise deal at validation. Metrics +1, economic buyer −1, decision criteria +0.5, decision process 0, third parties 0, initiative +1, champion +0.5, competition 0. **Total +2.0** against an expectation of +2.
+
+**Read.** The deal sits exactly at its band expectation, which is exactly why it is dangerous — the gap test alone would leave it alone. The economic buyer is identified and the main contact has twice deflected requests to meet her. Three dimensions sit at 0 — decision process, third parties, competition — and every one of them is unknown because that same contact is the only source. **The unknown-cluster override fires**: the deal does not hold validation, it escalates today regardless of the comfortable total, and the default recommendation is to move it back to discovery until there is a second source inside the account.
+
+**Cycle 1 — target the economic buyer blocker.**
+
+- *Observe* — two deflections in the context layer, both unprompted; no direct contact in eleven weeks of engagement.
+- *Orient* — reframe from *asking for access* to *making the introduction serve the contact*. Repeated asks read as going around them; the deflection is usually self-protection, not obstruction.
+- *Decide* — why the rep cares: without this they will build a case for someone who has never heard the problem stated. Pre-mortem: the contact feels bypassed and disengages — mitigated by making them the presenter rather than the gatekeeper. Go/no-go: economic buyer's identity confirmed ✓, contact responsive ✓, one-page case ready ✓, political cost low because nothing is being done behind them ✓.
+- *Act* — verbatim: "Before we go further I want to make sure what we build is what she'd actually approve — I'd rather find out now than in procurement. Could we get twenty minutes with the three of us, and you frame the business case? I'll send you the one-pager to present." IF they deflect again → THEN ask directly what the concern is; a second deflection with no stated reason is itself the answer. IF they agree but the meeting slips twice → THEN treat access as blocked and switch to a second entry point. Pitfall: do not send the one-pager to the economic buyer directly, even copied — it converts an unproven champion into an actively hostile one.
+- *Exit* — success: meeting held with the economic buyer present and speaking. Abort: two scheduling failures or a second unexplained deflection, at which point cycle 2 becomes finding an independent path in.
+
+**Cycle 2 — flank.** Clear the highest-value unknown, decision process, through a second stakeholder found via the initiative rather than the contact — which also tests whether the champion's influence is real, resolving the +0.5.
+
+---
+
+## Worked example 2 — the maneuver that should have been aborted
+
+Included because this is the failure mode the structure exists to prevent, and it is the one most teams recognise.
+
+**Situation.** Proposal stage, total +4 — at expectation. Third parties −1: an implementation partner has missed two consecutive working sessions and is not responding to scheduling requests. Everything else is healthy.
+
+**The gate, before anything else.** Proposal permits no dimension at −1. The gate is breached the moment the partner is scored, which means cycle 1 is *obliged* to target third parties and the proposal should not be pursued while the −1 stands. The comfortable total is irrelevant to that. Both facts were true here, and the second one was ignored.
+
+**The play that was run.** Cycle 1 correctly targeted the partner, with a straightforward escalation: a note to the partner's engagement lead restating the timeline and asking for a named owner. Reasonable, and it produced a reply promising attention.
+
+**What went wrong.** Nothing visible — which is the problem. The promise was not followed by a session. The rep ran the same escalation again, higher up. Another promise, no session. A third escalation went to the client to ask them to push their partner, which cost the champion credibility internally, because they had vouched for the partner relationship.
+
+**What the structure would have caught.** Two things.
+
+The **pre-mortem** asks what the worst realistic outcome is. Here it was foreseeable: escalating a partner to their own client makes the champion look like they mis-managed a vendor they chose. That cost belonged in the go/no-go's fourth box — political cost against gain — and it would have failed the check on the third attempt, if not the second.
+
+The **abort criterion** was never written, so nothing defined failure. With "two scheduling attempts, ten working days" stated up front, the first escalation ends after its second failure, and cycle 2 begins: not more pressure, but the incentive question — what does this partner actually gain from the integration? That is the reframe the situation needed, and it was available in week one.
+
+**The tell.** A maneuver that produces agreement without movement is failing, not progressing. Promises are not exit criteria. Where the success state is written as something observable to a third party — a session held, a name given in writing — a run of polite replies cannot be mistaken for progress.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/references/scoring-and-stage-bands.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/references/scoring-and-stage-bands.md
@@ -1,0 +1,188 @@
+---
+title: Scoring criteria and stage expectation bands
+description: (reference) Evidence thresholds per dimension, the stage bands that make a score meaningful, calibration procedure, worked scores, and edge cases.
+---
+
+# Scoring criteria and stage expectation bands
+
+The evidence thresholds behind every score, the stage bands that make a score mean something, how to calibrate both against your own history, and what to do at the edges.
+
+## The scale
+
+| Score | Label | What it means |
+|---|---|---|
+| **+1** | Accelerator | Strong, validated evidence. Someone with authority confirmed it in their own words. |
+| **+0.5** | Friction | Partial evidence. Known but unvalidated, or true but weak. Creates drag, not death. |
+| **0** | Unknown | No evidence either way. Nobody has asked, or nobody answered. |
+| **−1** | Blocker | Active evidence of a condition that kills the deal if unaddressed. |
+
+Eight dimensions. The champion dimension has no −1 (see below), so the range is **−7 to +8**.
+
+Note the asymmetry between steps: friction to accelerator is 0.5, but unknown to blocker is a full point. That is intentional — a confirmed blocker is a bigger event than a confirmed strength, because deals are lost by unaddressed blockers more often than they are won by stacked accelerators.
+
+## Per-dimension criteria
+
+Written in neutral terms — substitute your `{{TERMINOLOGY_MAP}}` labels and your own category of value.
+
+### Metrics — is there a quantified economic impact that justifies the spend?
+
+- **+1** — The economic decision-maker has confirmed that hitting a specific number achieves a business outcome they own. There is a jointly agreed case connecting your impact to their financials.
+- **+0.5** — A target number is known but treated as a nice-to-have. The metrics are operational rather than financial — real, measurable, and connected to nothing on the P&L.
+- **0** — No target numbers stated at all.
+- **−1** — The buyer cannot articulate what happens to the business if the target is missed, or the conversation is anchored on a pilot budget disconnected from any larger outcome.
+
+A frequent mis-score is +1 on an operational metric. A number the buyer is measured on is not the same as a number their business depends on. If missing it costs them nothing they can name, it is +0.5.
+
+### Economic buyer — is the person who owns the budget identified and engaged?
+
+- **+1** — Direct, substantive interaction with the person who ultimately releases the money, in which they articulated the priority this solves in their own words.
+- **+0.5** — You know who they are, but every interaction is filtered through a subordinate. Support is inferred from secondhand reports.
+- **0** — You cannot name the person who approves spend at this size.
+- **−1** — You have identified them and been actively blocked from reaching them, and your contact cannot or will not facilitate access.
+
+The line between +0.5 and −1 is whether the blocking is passive or active. "We haven't got to them yet" is friction. "You don't need to talk to her" is a blocker — and it is routinely recorded as friction, because it arrives politely.
+
+### Decision criteria — do you know what the buyer will actually judge on?
+
+- **+1** — The criteria are explicit and favour capabilities you hold and competitors do not.
+- **+0.5** — Criteria exist but are generic — the kind any credible vendor satisfies.
+- **0** — You do not know the formal or informal criteria.
+- **−1** — The criteria are written around a competitor's differentiators, or a constraint you cannot meet.
+
+Criteria you helped shape score +1. Criteria you merely learned score +0.5, however favourable they look. Discovering requirements is not the same as influencing them.
+
+### Decision process — do you know how the decision actually gets made?
+
+- **+1** — Every step, approval, and timeline is documented and confirmed by someone inside the account.
+- **+0.5** — You have a verbal outline nobody has validated, with assumed steps.
+- **0** — Not mapped.
+- **−1** — The process has stalled with no restart date, or you are being excluded from steps you should be in.
+
+### Third parties and paper process — is anyone outside the buying team in the path?
+
+Covers implementation partners, agencies, resellers, integrators, procurement, legal, and security review.
+
+- **+1** — Every external party is identified, their role is clear, and none blocks value delivery.
+- **+0.5** — There is involvement but the timelines or the incentives are unclear.
+- **0** — No visibility into whether third parties are involved at all.
+- **−1** — A third party is actively blocking — deprioritising the work, gating the timeline, or lacking any incentive to help you.
+
+Read incentives, not intentions. A partner who is friendly but earns nothing from your integration is a blocker with good manners, and reps score this +0.5 because the relationship feels fine.
+
+### Implicated pain and initiative — what is forcing action on a timeline?
+
+- **+1** — A funded, time-bound initiative with executive sponsorship is driving this, and slipping it has a named consequence.
+- **+0.5** — The pain is acknowledged but there is no deadline and no specific initiative creating urgency.
+- **0** — You do not know what prompted the evaluation.
+- **−1** — There is no real pain, or the pain is not big enough to displace anything else competing for the same budget.
+
+This is where no-decision losses are decided. A deal can score well everywhere else and die here, because the buyer's alternative — doing nothing for two more quarters — costs them nothing.
+
+### Champion — do you have an advocate who sells for you when you are not there?
+
+**This dimension has no −1.** Deliberately.
+
+- **+1** — Proven: they advocate internally without prompting, share information they were not asked for, and coach you on how to win. Their influence has been demonstrated at least once.
+- **+0.5** — Unproven: friendly, responsive, shares information — but has never demonstrated influence and has never sold on your behalf.
+- **0** — Absent: nobody identified.
+
+There is no "high-risk champion." A contact shown to have no influence, or who has misled you, was never a champion — they were a friendly contact who got mislabelled. Recording that as a blocker hides the real problem and points at the wrong action. Score them **0 — absent**, and the next action becomes finding one, which is correct.
+
+The +0.5 that sits at +1 for months is the quiet version of the same error, and it is worth re-testing every time this runs: what has this person actually done on your behalf since the last run?
+
+### Competition — where do you stand against the alternatives?
+
+Include the status quo. Doing nothing is the alternative that wins most often.
+
+- **+1** — Preferred or sole-sourced, with differentiation the buyer can articulate back to you.
+- **+0.5** — In a fair competitive evaluation with identified advantages.
+- **0** — You do not know who else is being considered.
+- **−1** — You are viewed as undifferentiated, a competitor is favoured, or the criteria are written against you.
+
+## Stage expectation bands
+
+| Band | Expected total | Hard floor | Additional gate |
+|---|---|---|---|
+| Discovery / qualification | ≥ 0 | −2 | Unknowns are normal — nobody has asked yet |
+| Validation | ≥ +2 | 0 | No unknowns on metrics, economic buyer, or champion |
+| Proposal / business case | ≥ +4 | +2 | No dimension at −1 |
+| Negotiation | ≥ +5.5 | +4 | Any −1 triggers a forecast review |
+| Commit / close | ≥ +6.5 | +5 | Decision process and paper process both at +1 |
+
+**Reading the gap** — actual minus expected:
+
+| Gap | Read | Action |
+|---|---|---|
+| At or above expectation | On track | Work the highest-value unknown |
+| Up to 1.5 below, and above the floor | Recoverable in stage | Build a maneuver; leave the forecast alone |
+| More than 1.5 below, **or** under the hard floor | Wrong stage, or something was scored on faith | Escalate to `{{FORECAST_OWNER}}` same day |
+
+**The unknown-cluster override.** Regardless of total, if **three or more** dimensions score 0 and the missing evidence all sits behind a single stakeholder, **the deal does not hold its current stage**: escalate regardless of the gap test, and recommend moving the opportunity back one stage until a second independent source exists inside the account.
+
+The override never softens a read. A deal that already fails the gap test and also clusters is not rescued by being re-read at an earlier stage — it fails both tests, and the earlier stage is the recommendation, not the excuse.
+
+**Band gate consequences.** A breached gate acts on its own, independent of the total — three bind the plan, one escalates. An unknown remaining on metrics, economic buyer, or champion blocks advancement past validation and becomes a lane 3 item that cycle; any −1 at proposal obliges cycle 1 to target it and holds the proposal; any −1 at negotiation triggers a forecast review that week; and a decision process or paper process below +1 at commit means the close date is an estimate, not a commit.
+
+**The stall rule.** No movement across two consecutive runs at validation-or-later is a stalled deal at any level — a live deal generates new information. Report it as a finding in its own right.
+
+## Worked scores
+
+### A deal that reads better than it is
+
+Proposal stage. Metrics +1, economic buyer +0.5, decision criteria +0.5, decision process 0, third parties 0, initiative +1, champion +0.5, competition 0. **Total +3.5.**
+
+Expected at proposal is +4, so the gap is −0.5: on the gap test alone, recoverable, no escalation. But three dimensions sit at 0 — decision process, third parties, competition — and every one traces to the same contact, the only person who has spoken about any of them. **The unknown-cluster override fires**, so the gap test does not govern: escalate today, and recommend the deal move back to validation. A business case is sitting with a buyer whose approval path nobody has verified, and the −0.5 gap is what makes that easy to miss.
+
+Target for cycle 1: the economic buyer's +0.5, because resolving it also produces an independent source for the three unknowns.
+
+### A deal that reads worse than it is
+
+Discovery. Metrics 0, economic buyer 0, decision criteria 0, decision process 0, third parties +0.5, initiative +1, champion +0.5, competition 0. **Total +2.**
+
+Five zeros looks alarming and is not. Expected at discovery is ≥ 0 and unknowns are the normal state — nobody has asked yet. The cluster override does not fire, because the zeros are not behind one stakeholder; they are behind nobody, which is what discovery looks like. Initiative at +1 with a funded, time-bound driver is the strongest possible thing to know this early. Correct action is lane 3 discovery, not a maneuver.
+
+### A −1 that should stop a forecast
+
+Negotiation. Metrics +1, economic buyer +1, decision criteria +0.5, decision process +1, third parties −1, initiative +1, champion +1, competition +0.5. **Total +5.0** — above the +4 floor, 0.5 below the +5.5 expectation, so the gap test alone says "recoverable, build a maneuver." But third parties sits at −1: procurement has gated the timeline with no restart date. At negotiation, **any −1 triggers a forecast review** regardless of total. `{{FORECAST_OWNER}}` decides that week whether the close date holds, and records the decision either way. The total is comfortable; the deal cannot close through a gate nobody has opened.
+
+## Edge cases
+
+**Segments in different stages.** On a segmented track, each party gets its own score, band, and stage read — and **the deal takes the weaker of the two**. A partner assessment sitting a full band behind the client assessment is the deal's real position, not an averaging problem. Never report a blended total.
+
+**The decisive call is missing from the context layer.** If the interaction everyone refers to was never recorded, the dimensions that depended on it score **0**, not the rep's recollection of it. Add a lane 3 item to re-establish the fact in writing — "confirming what you mentioned on the call, the sign-off sequence after you is…" — which both closes the gap and creates the evidence.
+
+**Renewals and expansions.** Metrics, initiative, and champion carry over from the existing relationship only where there is evidence they still hold; sponsors move and initiatives get defunded. Decision process and paper process reset to 0 by default — a renewal frequently takes a different approval path than the original purchase, and assuming otherwise is the most common way a renewal slips a quarter.
+
+**Multi-year or phased commitments.** Score the phase actually being decided now. A phase-two commitment that nobody has budgeted is not an accelerator on phase one; it is an unknown attached to a future deal.
+
+**A dimension genuinely does not apply.** Score it **+1** only where its absence is confirmed and favourable — no third parties in the path at all, verified — and record why. Where it is merely not visible, that is **0**. The difference between "no procurement involvement" and "nobody has mentioned procurement" is most of a quarter.
+
+## Calibrating the bands
+
+The numbers above are defaults, not findings. Calibrate before letting any of them touch a forecast.
+
+**1. Build a per-stage dataset.** Take your last 30–40 closed deals with a usable context layer, mixed won and lost. For each deal, score it **once per stage it passed through**, using only evidence available as of that stage's exit. One deal that reached negotiation yields four data points, not one. Score blind to the outcome — ideally have someone score deals whose results they do not know.
+
+**2. Set expectation from the winners.** At each stage, take the distribution of scores from deals that eventually closed won. Set the expectation near the **40th percentile** — most winners clear it, and the ones that do not are the genuinely scrappy wins you do not want the framework calling healthy. Setting it at the median guarantees half your winners read as behind, which trains everyone to ignore it.
+
+**3. Set the hard floor from the same distribution.** Put the floor near the **10th percentile of winners** at that stage: the level below which winning is rare enough that a same-day conversation is warranted.
+
+**4. Check the floor against the losers.** At each stage, what share of eventual losses were already below the floor? **Under a third** — the floor is too low to catch anything; raise it toward the 20th percentile of winners and re-check. **Over three quarters** — confirm you are not simply describing deals that had already visibly failed by that stage; if the breaches cluster in the last stage before the loss, the bands are recording death rather than predicting it, and the earlier stages are where the calibration effort belongs.
+
+**5. Small samples — count winners per stage, not deals.** Every percentile here is computed on *the winning deals that reached one particular stage*. A 40-deal set can still leave a dozen winners at negotiation, and a 10th percentile of twelve observations is a single data point wearing a statistic's clothing.
+
+Aim for **about 30 winners at the stage you are calibrating**. Below that: use the minimum and median of the winning set as floor and expectation, mark those bands provisional, and keep them out of forecast decisions until the sample fills in. Late stages fill slowest, so expect the commit band to stay provisional longest.
+
+Note also that a deal contributing four observations contributes four *correlated* ones — a strong deal tends to score well at every stage. Effective sample size is meaningfully smaller than the observation count, which is a reason to be conservative with the tails and to prefer the median-and-minimum fallback longer than the raw count suggests.
+
+Recalibrate when the motion changes — new segment, materially different price point, or a cycle length that shifts by more than about a third. Bands built on a six-month cycle mislead on a two-month one, because the same score had half the time to be earned.
+
+## Delta tracking on re-runs
+
+Every dimension carries a marker: **retained**, **upgraded**, **downgraded**, or **new**.
+
+- **Clear new evidence** → change the score.
+- **No new evidence** for that dimension → retain, and state that nothing new landed.
+- **New evidence contradicting the current score** → change it and write the contradiction down, citing both the earlier and later evidence.
+
+A written downgrade with its reason is the most useful line in a deal review. An unexplained one is noise, and a silent one is how a framework loses the trust of the people who have to act on it.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/references/segmentation-and-lanes.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/references/segmentation-and-lanes.md
@@ -1,0 +1,89 @@
+---
+title: Segmentation gate and execution lanes
+description: (reference) The variance test that decides whether one assessment is valid, the three-way logic gate, and how maneuvers route into partner, client-direct, and discovery lanes.
+---
+
+# Segmentation gate and execution lanes
+
+Whether one assessment is valid for this deal, and how finished maneuvers get routed into work.
+
+## Why segment at all
+
+Complex deals routinely contain parties whose interests do not align. An implementation partner and the client who hired them are not evaluating you on the same criteria. A business unit that wants the capability and a central procurement function that wants leverage are not measuring the same success.
+
+Score them together and you produce a blended assessment that describes neither. The blend is worse than either half, because it looks complete. A partner at −1 and a client at +1 average to a comfortable middle that hides the only thing that matters.
+
+## The variance test
+
+Three questions against the context layer. Any yes means variance.
+
+**1. Metric variance.** Do the parties define success in different units? An integrator measured on delivered hours and a client measured on business outcome are not solving the same problem, and a case built for one is inert to the other.
+
+**2. Persona variance.** Does the identity of the decision-maker or the advocate change by party? When the person who champions you inside the partner has no counterpart inside the client — or is a different function entirely — you have two campaigns.
+
+**3. Risk variance.** Does the evidence show different failure modes for different groups? Where one party's risk is technical delivery and another's is commercial exposure, one set of maneuvers cannot address both.
+
+## The logic gate
+
+**Unified track** — no variance. One assessment, one set of lanes. Most single-stakeholder-organisation deals.
+
+**Segmented track** — variance on any axis. Run the diagnostic **separately per party**, each with its own eight scores, its own total, and its own stage read. Then plan maneuvers per segment. Two segments is the normal case; three is rare and usually means the deal is not yet real.
+
+Report segment totals separately and never average them. If one segment sits below its floor, the deal sits below its floor — a deal does not close on the strength of its healthier half.
+
+**Stop and ask** — the deal plainly involves parties who could diverge, but the evidence cannot tell you how. Do not guess. State what is ambiguous and ask one question:
+
+> "The evidence shows both the partner and the client team involved, but not whether they're evaluating this on the same terms. Are we running one process here, or two?"
+
+Guessing corrupts every downstream step: wrong lanes, wrong maneuvers, a plan aimed at a stakeholder configuration that does not exist. The question costs one message. Stopping here is deliberate — the artifact will look equally authoritative whether or not this input was right, so an error made here is one nobody downstream can detect.
+
+---
+
+## The three lanes
+
+Every maneuver and every discovery item routes into exactly one lane. Lanes exist because these three kinds of work fail for different reasons and are often owned by different people.
+
+### Lane 1 — Third parties and procurement
+
+Partners, integrators, agencies, resellers, procurement, legal, security review.
+
+The recurring failure here is treating a third party as a communication problem when it is an incentive problem. A partner who is pleasant and unhurried is not confused about your timeline; your work simply does not advance anything they are measured on. Maneuvers in this lane should almost always change what the third party gets, not what they know — visibility with their own client, alignment with a target they already own, a delivery outcome they can claim.
+
+Each lane 1 item carries: the play, the gap it addresses, the specific ask, and the deliverable that proves it worked.
+
+### Lane 2 — Client-direct
+
+Economic buyer access, champion development, decision process mapping, competitive positioning.
+
+Every lane 2 item carries an IF/THEN contingency, because these maneuvers involve people whose reactions are not predictable and whose goodwill is the deal's main asset. A lane 2 play without a contingency is a coin flip with a champion on the table.
+
+### Lane 3 — Targeted discovery
+
+One item per dimension scored 0.
+
+**Discovery items ship as literal questions addressed to a named person.** Not "clarify the approval path" but:
+
+> Ask [name]: "Once you and I agree this is right, who else has to sign off before it's real — and has anything similar gone through that path this year?"
+
+A topic gets postponed. A written question gets asked. Most deal-coaching output fails right here: it names the gap and leaves the hard part — the words — to the rep, who is usually avoiding that exact conversation. Writing the question is doing the work; naming the gap is describing it.
+
+Where an unknown persists across two consecutive runs despite a lane 3 item, that is a finding. Either nobody asked, or somebody declined to answer. Both are more informative than the unknown itself, and the second is usually a blocker in disguise.
+
+---
+
+## Phasing
+
+Maneuvers group into two phases, and phase 1 completes before phase 2 begins.
+
+**Phase 1 — gap closure.** Clear blockers and resolve the unknowns that gate the current stage. The objective is not to advance the deal; it is to make the assessment trustworthy enough to advance on. Reps skip this phase constantly, because closing gaps feels like preparation rather than selling.
+
+**Phase 2 — alignment and advancement.** Move friction to accelerator, build the case, work the paper process. Only meaningful once phase 1 has produced real answers — a business case built on unverified assumptions is elaborate guessing, and the more polished it is, the longer it takes anyone to notice.
+
+## The missing-information report
+
+Published with every run, as a checklist:
+
+- **Unchecked** — missing or unknown. States the gap and carries its lane 3 question.
+- **Checked** — validated. States what evidence validated it.
+
+All eight dimensions appear every time, including the validated ones. The checked items are what lets a manager see the deal was actually worked rather than partially scored, and the ratio of checked to unchecked across a rep's pipeline is a better read on their qualification discipline than any individual deal score.

--- a/skills/nikhil-mirza/deal-blocker-maneuvers/references/setup-customization-checklist.md
+++ b/skills/nikhil-mirza/deal-blocker-maneuvers/references/setup-customization-checklist.md
@@ -1,0 +1,88 @@
+---
+title: Setup and customization checklist
+description: (reference) Placeholders to fill, stage mapping, calibration and observation-mode rollout, write-back rules, and the enablement failures that matter.
+---
+
+# Setup and customization checklist
+
+What to configure before running this on live deals, and how to roll it out without losing the reps in week one.
+
+## 1. Fill the placeholders
+
+| Placeholder | What to put there | Default if unsure |
+|---|---|---|
+| `{{TERMINOLOGY_MAP}}` | Your org's labels for the eight dimensions, where they differ from textbook terms | Textbook terms |
+| `{{STAGE_NAMES}}` | Your pipeline stages mapped onto the five bands | See mapping below |
+| `{{CONTEXT_LAYER}}` | Where primary evidence lives — call recordings and transcripts, email threads, meeting records, shared docs | Whatever is reliably captured |
+| `{{COMPLEX_DEAL_FLOOR}}` | Size, cycle length, or segment below which this does not run | Closes in under 30 days, or has one stakeholder |
+| `{{FORECAST_OWNER}}` | Who is told, same day, when a deal escalates — more than 1.5 below expectation, under the hard floor, an unknown cluster, or a breached band gate | The rep's direct manager |
+| `{{REVIEW_CADENCE}}` | When it runs | After every meaningful interaction |
+
+### The terminology map
+
+Many orgs rename dimensions to match how they sell. Whatever you choose, declare it once and enforce it everywhere — mixed vocabulary across a pipeline makes deals uncomparable, which is most of the value of scoring them.
+
+Common renames worth considering: *economic buyer* → executive sponsor, when the approver is a sponsor rather than a budget holder. *Implicated pain* → initiative, when purchases are driven by funded programs rather than problems. *Paper process* → partners, when third parties matter more than legal review. Each of these changes what reps look for, which is the point of renaming.
+
+### Mapping your stages
+
+Five bands, however many stages you run:
+
+| Band | Maps to any stage where… |
+|---|---|
+| Discovery / qualification | You are establishing whether a deal exists |
+| Validation | The buyer has confirmed intent; you are proving fit |
+| Proposal / business case | A formal case, quote, or proposal is with the buyer |
+| Negotiation | Commercial terms are being worked |
+| Commit / close | Signature and paperwork |
+
+More than five stages: map several to one band. Fewer: leave bands unused rather than compressing them — an unused band is harmless, a compressed one moves the floor to the wrong place.
+
+## 2. Calibrate the bands before trusting them
+
+Do not adopt the default numbers on faith. The full procedure — building a per-stage dataset from closed deals, setting expectation and floor from the distribution of winners, and checking the floor against losses — is in the scoring reference. Note that the binding constraint is **winners at the stage being calibrated**, not total deals: a set large enough overall can still leave too few late-stage winners to support a percentile, and those bands stay provisional until it fills in. Budget half a day.
+
+Skipping calibration is survivable for coaching output but not for forecast decisions. Do not let an uncalibrated score pull a deal from the forecast in the first quarter of use.
+
+## 3. Run in observation mode first
+
+For the first two to four weeks, run everything except the consequences:
+
+- Score deals, build maneuvers, publish artifacts.
+- **Do not** write to the deal record.
+- **Do not** move anything in or out of the forecast on the strength of a score.
+- Include the exact values that *would* have been written, so reps can see what the framework wanted to do.
+
+Ask two questions in review: where did the score disagree with the rep's read, and who was right? Every disagreement is calibration data, and the ones where the rep was right are the more valuable half.
+
+## 4. Check the context layer honestly
+
+The framework is only as good as the evidence it reads. Before rollout, confirm:
+
+- Calls are recorded and transcribed with enough coverage that a typical deal has real material — not one call in six.
+- Email with buyers is captured somewhere the analysis can reach.
+- Meeting records exist for stakeholder interactions that happen outside calls.
+
+**If coverage is thin, fix that before rolling this out.** A framework starved of primary evidence will be fed the rep's summary instead, which is the exact failure this skill is built to prevent: it converts a rep's optimism into a number that looks like analysis. Thin coverage is not a reason to lower the evidence standard; it is a reason to delay.
+
+## 5. Write-back rules
+
+If scores or next steps sync to the deal record:
+
+- Field by field, with explicit human approval each time. Never a bulk write.
+- Never write on a schedule or from an automated run without a human in the loop.
+- Preserve the prior value and the delta marker, so a downgrade is auditable.
+- Where the record has a length limit on a next-step or summary field, write to it rather than truncating mid-sentence — a cut-off instruction is worse than a short one.
+
+## 6. Enablement — where this actually fails
+
+The framework does not fail on logic. It fails when reps treat it as a form.
+
+- **Train on the evidence rule first, not the scoring.** The single behavior that determines whether this works is a rep declining to score a dimension they cannot evidence. Everything else is secondary.
+- **Make 0 safe.** If unknowns are treated as a rep failing to do their job, unknowns will disappear from the data and the framework becomes decorative within a month. Unknowns are the product working.
+- **Review the maneuver, not the score, in one-to-ones.** "What did you run and what happened" builds the habit. "Why is this a +3" builds score inflation.
+- **Celebrate an abort.** The first time a rep stops a play at its stated failure condition instead of trying once more, say so publicly. It is the hardest behavior to establish and the clearest sign the framework is being used rather than filled in.
+
+## 7. Recalibrate when the motion changes
+
+Re-run the calibration when you enter a new segment, change price point materially, or see cycle length shift by more than about a third. Bands built on a six-month cycle mislead on a two-month one — the same score means something different when there was half the time to earn it.


### PR DESCRIPTION
## What this skill does

Takes a qualification assessment on a complex deal — supplied, or scored here from primary evidence — reads it against what the deal's stage should already have proven rather than against an absolute bar, and converts the single worst blocker into a two-cycle maneuver a rep can execute: trigger conditions, a pre-mortem, a go/no-go checklist, a verbatim opening, IF/THEN counter-moves, and explicit abort criteria.

It deliberately sits *after* diagnosis rather than repeating it. Where a current assessment already exists, the skill accepts it per dimension — but only for dimensions that carry their evidence, since an unsourced qualification field is a rep's self-assessment wearing a score's clothing. Everything else is re-derived from the context layer. There's an explicit mapping table for assessments that arrive on a different rubric.

Five reference pages carry the depth: per-dimension evidence thresholds and stage expectation bands with a calibration procedure, the maneuver construction structure with two worked examples (one of them a failure case), the segmentation gate and lane routing, the borrowed-models routing table, and a setup checklist.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/nikhil-mirza/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name and LinkedIn — **no `avatarUrl` supplied.** Per AGENTS.md I'm happy for maintainers to re-host my LinkedIn profile photo at gtmskills.com; glad to provide a durable URL or attach an image instead if you'd prefer.
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

## Notes for reviewers

The stage bands (expectations ≥0 / +2 / +4 / +5.5 / +6.5, floors −2 / 0 / +2 / +4 / +5) are defaults, labelled tunable throughout, and the skill ships a full calibration procedure against your own closed deals rather than asking anyone to adopt the numbers on faith.

`SKILL.md` carries six `{{...}}` template placeholders (terminology map, stage names, context layer, complex-deal floor, forecast owner, review cadence). These are intentional customization points, documented in a `## Template placeholders` section with defaults for every one, and expanded in `references/setup-customization-checklist.md` — not unfilled drafting artifacts.
