### PR TITLE
update icp-builder by rutger-katz: fit scoring model, TAM list loop, cycle-time tier validation

### DIFF
--- a/skills/rutger-katz/icp-builder/SKILL.md
+++ b/skills/rutger-katz/icp-builder/SKILL.md
@@ -39,7 +39,7 @@ If you have no ICP at all, flag this immediately: that's the finding. Recommend 
 
 Score your ICP across seven dimensions. Each gets a rating: **Strong / Adequate / Weak / Missing.**
 
-**Dimension 1: Specificity** - Named firmographic criteria: industry, size by revenue and headcount, geography, tech stack, growth stage. Not "mid-market SaaS companies" but "B2B SaaS, EUR10-50M ARR, 100-500 employees, post-Series B, EU-based, using HubSpot or Salesforce." Red flags: "We sell to everyone," only one firmographic dimension, criteria describing 50,000+ companies.
+**Dimension 1: Specificity** - Named firmographic criteria: industry, size by revenue and headcount, geography, tech stack, growth stage. Not "mid-market SaaS companies" but "B2B SaaS, EUR10-50M ARR, 100-500 employees, post-Series B, EU-based, running a mid-market CRM and a subscription billing platform." Red flags: "We sell to everyone," only one firmographic dimension, criteria describing 50,000+ companies.
 
 **Dimension 2: Pain Clarity** - Specific problems in customer language, not vendor language. External problems (business issues), internal problems (how it feels), philosophical problems (why it feels wrong). Mapped by persona. Red flag: pain described as "they need better visibility" instead of "I can't answer simple revenue questions without pulling three spreadsheets."
 
@@ -209,6 +209,19 @@ Tiers say whether the account fits; gates say whether the deal is real. Once tie
 2. **Set per-stage minimums, per letter and in total.** With six letters (total out of 30): Inbound to Discovery 7, Discovery to Demo 14, Demo to Proposal 19, Proposal to Commit 23. One letter under its gate and the deal does not move. No rounding up. Go back, ask again, qualify or kill.
 3. **Install the critical-event forcing question:** "What breaks for this customer if they do nothing until next quarter?" No concrete answer scores Critical Event at 1, and the record is a conversation, not a deal.
 4. **Deploy in CRM:** letter scores as deal properties plus a computed deal-health field next to `icp_tier`; enforce via stage-transition validation or a weekly below-gate exception report. Expect two weeks of rep resistance, then adoption once the gate starts protecting calendars from deals that were never going to close.
+
+---
+
+## What good looks like
+
+- Any company in the universe can be scored 0-100 from enrichment data alone. Nobody needs a meeting to place it in a tier.
+- The model uses 5-8 attributes that separate your top 20% of customers from the rest, with one weight set per segment. A criterion that needs a discovery call lives in qualification, not in the fit score.
+- Tier 1 is narrow: a four-figure list from a six-figure universe, and 50 accounts rather than 5,000 at early stage. A Tier 1 that covers 40% of the universe describes the market, not your ideal customer.
+- Tier 1 beats Tier 2 on all five journey cycle times (MQL to SQL, SQL to Win, Win to Onboard, time to first impact, time to full impact). When it loses a column, one weight changes and the model gets a quarter to prove it.
+- The score is a CRM field that lead scoring, routing, and pipeline reports read from. A rep can say yes or no to an account in 30 seconds.
+- The evidence base includes the companies that never contacted you. A CRM-only ICP is a record of who found you.
+- The TAM list is refreshed quarterly: re-enriched, re-scored on new signals, topped up with new companies, purged of dead ones.
+- Below the customer-count threshold for your motion, the output is labeled an Early Customer Profile and iterated quarterly. Calling it an ICP is the first lie the forecast tells.
 
 ---
 

--- a/skills/rutger-katz/icp-builder/SKILL.md
+++ b/skills/rutger-katz/icp-builder/SKILL.md
@@ -1,43 +1,43 @@
 ---
 name: "icp-builder"
 title: ICP builder
-description: "Build, validate, or expand a client's ICP (Ideal Customer Profile) using the GAP method, SPICED framework, and customer interview pipeline. Triggers on 'build their ICP,' 'check their ICP,' 'ICP validation,' 'ICP quality,' 'they don't have an ICP,' 'ICP is too broad,' 'who should they sell to,' 'segment their market,' 'ICP workshop,' 'customer interviews for ICP,' 'GAP method,' 'ICP expansion,' 'Goldilocks zone,' 'tier their customers,' 'A/B/C segmentation,' 'are they targeting the right customers,' 'segmentation check,' 'ICP review,' 'who are they actually selling to,' or any client engagement where the ICP is missing, broken, or needs validation. This skill covers the full ICP lifecycle: validate what exists, build from scratch, refine with interviews, and plan expansion. BOUNDARY: For positioning/messaging (step AFTER ICP), see positioning-messaging-designer."
+description: "Build, validate, or expand your ICP (Ideal Customer Profile) using the GAP method, SPICED framework, and customer interview pipeline. Triggers on 'build your ICP,' 'check your ICP,' 'ICP validation,' 'ICP quality,' 'you don't have an ICP,' 'ICP is too broad,' 'who should we sell to,' 'segment our market,' 'ICP workshop,' 'customer interviews for ICP,' 'GAP method,' 'ICP expansion,' 'Goldilocks zone,' 'tier our customers,' 'A/B/C segmentation,' 'are we targeting the right customers,' 'segmentation check,' 'ICP review,' 'who are we actually selling to,' 'score our accounts,' 'ICP scoring,' 'fit score,' 'TAM list,' 'target list,' 'build our market list,' or any situation where your ICP is missing, broken, or needs validation. This skill covers the full ICP lifecycle: validate what exists, build from scratch, score every company 0-100 on fit, produce and maintain the TAM list, refine with interviews, and plan expansion. BOUNDARY: For positioning/messaging (step AFTER ICP), see positioning-messaging-designer."
 category: Prospecting
 ---
 
 # ICP Builder: Validate, Build & Expand
 
-You are helping work with a client's ICP. This is one of the highest-leverage activities in a revenue engagement : when the ICP is wrong, everything downstream (positioning, messaging, territory design, pipeline quality, CS segmentation) breaks.
+You are helping develop your company's ICP. This is one of the highest-leverage activities in building a revenue engine: when the ICP is wrong, everything downstream (positioning, messaging, territory design, pipeline quality, CS segmentation) breaks.
 
-Your role is to guide the process, not lecture the client. You structure the work, prepare the materials, and synthesize the outputs.
+Your role is to guide the process, not lecture your team. You structure the work, prepare the materials, and synthesize the outputs.
 
 ---
 
 ## Mode Selection
 
-Every ICP engagement starts with the same question: **does the client already have an ICP?**
+Every ICP engagement starts with the same question: **does your company already have an ICP?**
 
-- **If YES** → Start with **Mode 1: Validate** to assess what they have. The validation tells you whether they need refinements or a full rebuild.
-- **If NO** → Go straight to **Mode 2: Build** : there's nothing to validate.
-- **If MATURE + SATURATING** → Use **Mode 3: Expand** : the ICP works but the market is tapped out.
+- **If YES** → Start with **Mode 1: Validate** to assess what you have. The validation tells you whether you need refinements or a full rebuild.
+- **If NO** → Go straight to **Mode 2: Build**: there's nothing to validate.
+- **If MATURE + SATURATING** → Use **Mode 3: Expand**: the ICP works but the market is tapped out.
 
-If an ICP definition, call notes, or transcript where a client describes their customers is shared, default to Mode 1 first.
+If an ICP definition, call notes, or transcript where someone describes your customers is shared, default to Mode 1 first.
 
 ---
 
 ## Mode 1: Validate an Existing ICP
 
-This is a quality check : take the client's existing ICP as input and produce a gap assessment with specific recommendations.
+This is a quality check: take your existing ICP as input and produce a gap assessment with specific recommendations.
 
 ### Input
 
-Accept any combination of: client's ICP document, verbal description from call notes, transcript, CRM deal distribution data, win/loss data, or notes from a diagnostic.
+Accept any combination of: your ICP document, verbal description from call notes, transcript, CRM deal distribution data, win/loss data, or notes from a diagnostic.
 
-If the client has no ICP at all, flag this immediately : that's the finding. Recommend Mode 2.
+If you have no ICP at all, flag this immediately: that's the finding. Recommend Mode 2.
 
 ### The Seven-Dimension Validation Framework
 
-Score the client's ICP across seven dimensions. Each gets a rating: **Strong / Adequate / Weak / Missing.**
+Score your ICP across seven dimensions. Each gets a rating: **Strong / Adequate / Weak / Missing.**
 
 **Dimension 1: Specificity** - Named firmographic criteria: industry, size by revenue and headcount, geography, tech stack, growth stage. Not "mid-market SaaS companies" but "B2B SaaS, EUR10-50M ARR, 100-500 employees, post-Series B, EU-based, using HubSpot or Salesforce." Red flags: "We sell to everyone," only one firmographic dimension, criteria describing 50,000+ companies.
 
@@ -50,11 +50,11 @@ Score the client's ICP across seven dimensions. Each gets a rating: **Strong / A
 - 8-30: Real ICP emerging, motion-specific confidence varies
 - 30-50: Patterns validatable across segments
 - 50+: High-confidence, scalable ICP
-Red flag: ICP defined in a strategy offsite without customer input, never validated against win/loss data.
+Red flag: ICP defined in a strategy offsite without customer input, never validated against win/loss data. Second red flag: the evidence base is CRM-only. A CRM is an archive of whoever found you (inbound, referrals, event scans), not a sample of the market; an ICP derived purely from it inherits that survivorship bias.
 
 **Dimension 5: Segmentation & Motions** : ICP broken into segments with different GTM motions, buying processes, DMUs, value props, and success metrics. Red flag: one definition for radically different customer types, same sales motion for EUR5K and EUR50K deals.
 
-**Dimension 6: CRM Operationalisation** : ICP criteria exist as filterable, reportable CRM fields. Lead scoring reflects ICP fit. Pipeline reports filterable by segment. Red flag: ICP lives in a slide deck but not in the CRM.
+**Dimension 6: CRM Operationalization** : ICP criteria exist as filterable, reportable CRM fields. Lead scoring reflects ICP fit. Pipeline reports filterable by segment. The blunt test: can the team score any company 0-100 on fit from data alone, without a meeting? If not, the ICP is an opinion, however well-documented. Red flag: ICP lives in a slide deck but not in the CRM; tiers assigned by feel.
 
 **Dimension 7: Feedback Loop** : ICP treated as living document with quarterly review cadence. Win/loss analysis by segment feeds back. CS health data informs definition. Red flag: defined once, never revisited.
 
@@ -64,7 +64,7 @@ Produce:
 
 **1. Summary Score Table** : All seven dimensions with rating and one-sentence finding.
 
-**2. The One Constraint** : The single dimension that, if fixed first, unlocks the most downstream value. Connect to the revenue system: a broken ICP sits at the centre of the customer value loops.
+**2. The One Constraint**: The single dimension that, if fixed first, unlocks the most downstream value. Connect to the revenue system: a broken ICP sits at the center of the customer value loops.
 
 **3. Three Recommendations** : Maximum three, in priority order. Each: what to do, why it matters, how long it takes, who owns it.
 
@@ -78,7 +78,7 @@ Produce:
 
 ### Step 0: Assess ICP Maturity
 
-Before building, determine where the client stands using customer count thresholds:
+Before building, determine where your company stands using customer count thresholds:
 
 | Motion Type | Customers Needed for Real ICP | Confidence |
 |---|---|---|
@@ -92,7 +92,7 @@ Before building, determine where the client stands using customer count threshol
 
 **At or above threshold = real ICP territory.** Enough data to identify repeatable patterns.
 
-For the full maturity framework, read `references/icp-building-reference.md` Sections 1-2. For AI-native techniques, see Section 4.5.
+For the full maturity framework, read `references/icp-building-operational-reference.md` Sections 1-2. For AI-native techniques, see Section 4.5.
 
 ### Step 1: Gather Data (GAP Phase G)
 
@@ -106,15 +106,15 @@ Collect from four sources:
 
 **Conversation Data** : Customer interviews (the gold), sales recordings, support tickets, win/loss reviews. If none exist, move to Step 3 (Interview Pipeline).
 
-For detailed collection guidance, read `references/icp-building-reference.md` Section 3 (Phase G).
+For detailed collection guidance, read `references/icp-building-operational-reference.md` Section 3 (Phase G).
 
-### Step 2: Analyse Patterns (GAP Phase A)
+### Step 2: Analyze Patterns (GAP Phase A)
 
-Analyse across 8 dimensions: Industry/Vertical, Company Size, Tech Stack, Revenue Model, SPICED Patterns, Product Usage, Enrichment Signals, Pipeline Behaviour.
+Analyze across 8 dimensions: Industry/Vertical, Company Size, Tech Stack, Revenue Model, SPICED Patterns, Product Usage, Enrichment Signals, Pipeline Behavior.
 
 Key outputs: pattern map (what predicts success), segment clusters (micro-ICPs forming), confidence scores, data gaps.
 
-For the full framework, read `references/icp-building-reference.md` Section 3 (Phase A).
+For the full framework, read `references/icp-building-operational-reference.md` Section 3 (Phase A).
 
 ### Step 3: Customer Interview Pipeline (If Needed)
 
@@ -128,7 +128,7 @@ When conversation data is missing or shallow, run the 7-step pipeline:
 6. **Build Case Studies** : Problem-focused 1-2 pagers (with consent)
 7. **Feed Back** : Add language to SPICED library, update personas, sharpen positioning
 
-For the complete interview guide, read `references/icp-building-reference.md` Section 5.
+For the complete interview guide, read `references/icp-building-operational-reference.md` Section 5.
 
 **Pain language enrichment:** Reference your own collection of raw customer pain quotes.
 
@@ -136,29 +136,37 @@ For the complete interview guide, read `references/icp-building-reference.md` Se
 
 Synthesize into 4 deliverables:
 
-**Output 1: ICP Definition** : Firmographic + technographic + behavioural criteria. Include exclusions (who is NOT ICP). Specific enough for a rep to say "yes" or "no" in 30 seconds.
+**Output 1: ICP Definition**: Firmographic + technographic + behavioral criteria. Include exclusions (who is NOT ICP). Specific enough for a rep to say "yes" or "no" in 30 seconds.
 
-**Output 2: SPICED Tiers** : A/B/C segmentation:
-- **T1 (Perfect Fit):** All ICP criteria, high SPICED match. Win rate target: 60-80%.
-- **T2 (Good Fit):** 70% of criteria. Win rate target: 30-50%.
-- **T3 (Opportunistic):** 40-70%. Win rate target: 10-30%. Don't chase.
+**Output 2: SPICED Tiers** : A/B/C segmentation driven by the 0-100 fit scoring model (5-8 weighted attributes across the firmographic, technographic, and signal pillars; one weight set per segment). Tiers come from score bands, never from feel:
+- **T1 (Perfect Fit):** Score 80-100. All ICP criteria, high SPICED match. Win rate target: 60-80%.
+- **T2 (Good Fit):** Score 50-79. Most criteria. Win rate target: 30-50%.
+- **T3 (Opportunistic):** Score below 50. Win rate target: 10-30%. Don't chase.
+
+For the model build (best-customer scorecard, attribute extraction, weighting, banding), read `references/icp-building-operational-reference.md` Section 3, Phase P, Output 2a. Validate tiers with journey cycle times (Output 2b) every quarter.
 
 **Output 3: Buyer Personas** : Role-level profiles with goals, pains, decision criteria, buying committee, proof needed. Tied to SPICED.
 
 **Output 4: Informational Needs per Buying Phase** : Content/proof needed at Awareness, Consideration, Decision, Onboarding.
 
-For detailed templates, read `references/icp-building-reference.md` Section 3 (Phase P).
+For detailed templates, read `references/icp-building-operational-reference.md` Section 3 (Phase P).
 
 ### Step 5: Goldilocks Zone Check
 
-Before finalizing, validate ICP size matches client's stage:
+Before finalizing, validate ICP size matches your company's stage:
 - ACV sustainable with sales model? (>=20K for Medium Touch; >=50K for High Touch)
 - Deals closing in 2-4 months? (6+ months = ICP too big for stage)
 - 5+ reference customers? (Fewer = ICP too new for scale)
 - Cost-to-serve proportional to ACV? (>30% = ICP too small)
 - 100+ addressable targets? (Fewer = TAM too small)
 
-For the full Goldilocks framework, read `references/icp-building-reference.md` Section 7.
+For the full Goldilocks framework, read `references/icp-building-operational-reference.md` Section 7.
+
+### Step 6: Produce the TAM List
+
+An ICP that only ever filters inbound is an opinion about whoever showed up. Convert it into a working market list: define the universe (industry, size, geography) from the source that matches where your buyers show up, enrich in bulk (contact data plus the free website-quality signal), score every company 0-100, select tiers to activate against real campaign capacity, and keep the list alive quarterly (re-enrich, re-score on new signals, add new companies, remove dead ones).
+
+For the full seven-step loop and the funnel shape to expect, read `references/icp-building-operational-reference.md` Section 7.5.
 
 ---
 
@@ -173,17 +181,17 @@ Only relevant when the current ICP is mature and showing saturation signals. Fou
 
 **Expansion triggers:** Win rate plateaus, pipeline saturates, NRR signals expansion, competitive pressure, TAM exhaustion, product expansion.
 
-For the full framework, read `references/icp-building-reference.md` Section 6.
+For the full framework, read `references/icp-building-operational-reference.md` Section 6.
 
 ---
 
-## Delivery Formats
+## How to Pace the Work
 
-**Within a short diagnostic engagement (1-2 days):** Quick validation (Mode 1) + gap identification. Flag whether full build needed.
+**Quick check (1-2 days):** Run validation (Mode 1) against your existing customer data and flag the gaps. Enough to tell you whether a full build is worth the investment.
 
-**Within a 90-Day Programme (full build):** Complete GAP method over 2-3 weeks. Customer interviews weeks 2-4. Profile deliverables by week 6. Expansion if relevant.
+**Full build (4-6 weeks):** Complete GAP analysis in the first 2-3 weeks. Customer interviews in weeks 2-4. Finished profiles and tiering by week 6. Add expansion analysis if you're evaluating new segments.
 
-**Standalone ICP Workshop (half-day):** Compressed : gather data in advance, analyse together, build initial profiles. Follow up with interview pipeline recommendation.
+**Team working session (half-day):** Compressed version: gather the data in advance, analyze it together with sales and marketing in the room, and leave with initial profiles. Follow up with an interview pipeline to validate what the session produced.
 
 ---
 
@@ -193,14 +201,22 @@ For the full framework, read `references/icp-building-reference.md` Section 6.
 
 Hand off to `positioning-messaging-designer` to translate ICP insights into positioning framework and messaging architecture. The SPICED language becomes the raw material for messaging.
 
+**ICP → Qualification Gates (pipeline enforcement)**
+
+Tiers say whether the account fits; gates say whether the deal is real. Once tiers exist, install the qualification-gate layer so the ICP governs pipeline movement instead of living in a slide (built on the SPICED qualification framework). Gates, not fields: more CRM fields will not fix a forecast; minimum scores per stage will.
+
+1. **Score evidence quality per SPICED letter, 1 to 5:** 1 Unknown (not asked), 2 Weak (surface mention), 3 Confirmed (said and logged), 4 Quantified (numbers behind it), 5 Validated (third party or system data). The scale grades evidence, not rep enthusiasm.
+2. **Set per-stage minimums, per letter and in total.** With six letters (total out of 30): Inbound to Discovery 7, Discovery to Demo 14, Demo to Proposal 19, Proposal to Commit 23. One letter under its gate and the deal does not move. No rounding up. Go back, ask again, qualify or kill.
+3. **Install the critical-event forcing question:** "What breaks for this customer if they do nothing until next quarter?" No concrete answer scores Critical Event at 1, and the record is a conversation, not a deal.
+4. **Deploy in CRM:** letter scores as deal properties plus a computed deal-health field next to `icp_tier`; enforce via stage-transition validation or a weekly below-gate exception report. Expect two weeks of rep resistance, then adoption once the gate starts protecting calendars from deals that were never going to close.
+
 ---
 
 ## Voice Rules
 
-- System first, blame never : "your ICP isn't broken because someone failed; it's broken because nobody installed a feedback loop"
-- Concrete over abstract : use specific examples of what good looks like
-- British spelling
-- Short, direct assessments : CROs don't have time for padding
+- System first, blame never: "your ICP isn't broken because someone failed; it's broken because nobody installed a feedback loop"
+- Concrete over abstract: use specific examples of what good looks like
+- Short, direct assessments: CROs don't have time for padding
 
 ---
 
@@ -208,7 +224,7 @@ Hand off to `positioning-messaging-designer` to translate ICP insights into posi
 
 | File | When to read | What's inside |
 |------|-------------|---------------|
-| `references/icp-building-reference.md` | Always for Mode 2 : full methodology | GAP method, 8-dimension analysis, interview pipeline, expansion, Goldilocks zone, thresholds |
+| `references/icp-building-operational-reference.md` | Always for Mode 2 : full methodology | GAP method, 8-dimension analysis, fit scoring model (0-100, Output 2a), cycle-time tier validation (Output 2b), interview pipeline, expansion, Goldilocks zone, TAM list production (Section 7.5), thresholds |
 
 ## Related Skills
 
@@ -218,7 +234,7 @@ Hand off to `positioning-messaging-designer` to translate ICP insights into posi
 
 ## Cross-References
 
-- **positioning-messaging-designer** : The NEXT skill: ICP → Positioning → Messaging
-- **sales-methodology** : Discovery calls produce SPICED data that feeds ICP work
+- **positioning-messaging-designer**: The NEXT skill: ICP → Positioning → Messaging
+- **sales-methodology**: Discovery calls produce SPICED data that feeds ICP work
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/icp-builder/references/icp-building-operational-reference.md
+++ b/skills/rutger-katz/icp-builder/references/icp-building-operational-reference.md
@@ -1,10 +1,5 @@
 ---
 title: ICP Building Operational Reference
-description: (reference)
----
-
----
-title: ICP Building Operational Reference
 source: "ICP methodology + industry best practices"
 category: Frameworks
 tags: [ICP, GTM, customer-insights, go-to-market, reference]
@@ -37,22 +32,15 @@ Not all customer profiles are ICPs. Early customers often represent **initial tr
 
 **You need at least 8 comparable great customers to claim a real ICP.**
 
-Beyond that baseline, customer count thresholds vary by **motion type** (how you sell):
+Beyond that baseline, customer count thresholds vary by **motion type** (how you sell). The thresholds below reflect data quality and signal noise across selling motions (practice-based):
 
-| Motion Type | Customer Count Threshold | Confidence Level | Core ICP Variability |
+| Motion Type | Customer Count Threshold | Pattern Variability | Why This Number |
 |---|---|---|---|
-| **No Touch / Product-Led** | ±160 customers | 95% confidence | ±5% |
-| **Low Touch / 1-Stage** | ±80 customers | 90% confidence | ±10% |
-| **Medium Touch / 2-Stage** | ±40 customers | 85% confidence | ±20% |
-| **High Touch / Field Sales** | ±27 customers | 80% confidence | ±30% |
-| **Dedicated / Named Accounts** | ±20 customers | 75% confidence | ±40% |
-
-**Why the difference?**
-- **No Touch** = qualitative depth problem. Self-serve hides decision criteria; hard to collect SPICED data.
-- **Low Touch** = signal noise. Many light-fit buyers muddy the pattern; need volume to cluster signal.
-- **Medium Touch** = pattern clarity emerges. Conversations are richer; clearer fit signals in 8-15 customers.
-- **High Touch** = sample scarcity. Fewer deals close; each one is diagnostic. Iterate quarterly.
-- **Dedicated** = diversity risk. Each named account is unique. Shift toward **Ideal Account Profile (IAP)** instead (org traits, not personas).
+| **No Touch / Product-Led** | ±160 customers | ±5% | Self-serve hides decision criteria; need large volume to extract SPICED signals from analytics alone. |
+| **Low Touch / 1-Stage** | ±80 customers | ±10% | Signal noise is high (many light-fit buyers); volume needed to cluster true fit signals. |
+| **Medium Touch / 2-Stage** | ±40 customers | ±20% | Sales conversations richer; clearer fit signals emerge in 8-15 customers, validatable in 40+. |
+| **High Touch / Field Sales** | ±27 customers | ±30% | Fewer deals close overall; each deal is diagnostic. Patterns form quickly, but iterate quarterly as sample is small. |
+| **Dedicated / Named Accounts** | ±20 customers | ±40% | Each named account is unique. Shift toward **Ideal Account Profile (IAP)** (org traits, not buyer personas) instead of traditional ICP. |
 
 ### Implication for ICP Maturity
 
@@ -66,7 +54,7 @@ The way you build an ICP depends on how you go to market. Here are motion-specif
 
 | Motion | ICP Building Challenge | Strategic Response |
 |--------|---|---|
-| **No Touch / PLG** | Behavioral signals are sparse; no sales conversations to mine | Build behavioral ICP from product analytics (feature adoption, cohort retention, expansion velocity). Use event tracking and cohort analysis. |
+| **No Touch / PLG** | Behavioral signals are sparse; no sales conversations to mine | Build behavioral ICP from product analytics. Use event tracking in Mixpanel, Amplitude, or Segment; analyze feature adoption depth, cohort retention curves, and expansion velocity. Hybrid PLG+sales-assist (sales-assisted PQLs 25-35% conversion, CAC payback under 12 months) outperforms pure self-serve on NRR (67% vs 58%) (OpenView Benchmarks, 2024-2025). ACV framework: self-serve under $10K; hybrid $10K-$25K; sales-led above $25K. |
 | **Low Touch / 1-Stage** | Many tire-kickers; lightweight sales process means limited depth | Cluster by role, use case, retention curves. Identify micro-segments with 70%+ 12-mo retention. Double-down there. |
 | **Medium Touch / 2-Stage** | Balancing limited data against depth of signal | Blend 8-15 SPICED interviews with win/loss reviews. Surface patterns across competitive wins + expansion. |
 | **High Touch / Sales** | Few closed deals; each customer is precious data | Treat every deal as a test case. Iterate ICP quarterly. Build from pilot customers + expansion proof. |
@@ -74,7 +62,7 @@ The way you build an ICP depends on how you go to market. Here are motion-specif
 
 ---
 
-## 3. The GAP Method — How to Build an ICP
+## 3. The GAP Method : How to Build an ICP
 
 The **GAP Method** is a structured 3-phase process for ICP creation:
 
@@ -96,6 +84,7 @@ The **GAP Method** is a structured 3-phase process for ICP creation:
    - Firmographic: company size, revenue, funding, hiring
    - Technographic: software stack, cloud adoption, legacy systems
    - Intent signals: website visitor behavior, job postings, news mentions
+   - Website quality: does the company run a real, maintained website? Site depth and freshness predict buying behavior; a company with a real site behaves differently from one without. Free signal, widely ignored.
    - Source: Clearbit, ZoomInfo, Apollo, 6sense, etc.
 
 4. **Conversation Data**
@@ -104,18 +93,18 @@ The **GAP Method** is a structured 3-phase process for ICP creation:
    - Support tickets (feature requests, pain points)
    - Win/loss interviews with non-customers
 
-### Phase A: Analyse Across 8 Dimensions
+### Phase A: Analyze Across 8 Dimensions
 
-After gathering, systematically analyse patterns:
+After gathering, systematically analyze patterns:
 
-1. **Industry / Vertical** — Which verticals convert best? Which have highest LTV?
-2. **Company Size** — Employees? Revenue? ARR? Growth rate? What's the sweet spot for your motion?
-3. **Tech Stack** — What adjacent tools matter? Cloud vs on-prem? Legacy debt signals?
-4. **Revenue Model** — B2B SaaS? Marketplace? Services? Agency? (Business model fit = proxy for buyer sophistication)
-5. **SPICED Patterns** — What do best customers say about Situation, Pain, Implementation, Critical Event, Decision?
-6. **Product Usage** — Which features do high-ACV customers use most? At what frequency?
-7. **Enrichment Signals** — Growth signals (hiring, funding, M&A)? Expansion risk (losing headcount)? Technical readiness (cloud-first)?
-8. **Pipeline Behavior** — Sales cycle length by segment? Conversion rates? Objection patterns? Champion level (end-user vs IT vs C-suite)?
+1. **Industry / Vertical** : Which verticals convert best? Which have highest LTV?
+2. **Company Size** : Employees? Revenue? ARR? Growth rate? What's the sweet spot for your motion?
+3. **Tech Stack** : What adjacent tools matter? Cloud vs on-prem? Legacy debt signals?
+4. **Revenue Model** : B2B SaaS? Marketplace? Services? Agency? (Business model fit = proxy for buyer sophistication)
+5. **SPICED Patterns** : What do best customers say about Situation, Pain, Implementation, Critical Event, Decision?
+6. **Product Usage** : Which features do high-ACV customers use most? At what frequency?
+7. **Enrichment Signals** : Growth signals (hiring, funding, M&A)? Expansion risk (losing headcount)? Technical readiness (cloud-first)?
+8. **Pipeline Behavior** : Sales cycle length by segment? Conversion rates? Objection patterns? Champion level (end-user vs IT vs C-suite)?
 
 **Output of Analysis Phase:**
 - Pattern map (what's correlated with high LTV / retention?)
@@ -123,7 +112,7 @@ After gathering, systematically analyse patterns:
 - Confidence scores (how many customers validate this pattern?)
 - Gaps (what's missing from the data?)
 
-### Phase P: Profile — Create 4 Outputs
+### Phase P: Profile : Create 4 Outputs
 
 Once patterns are clear, synthesize into **4 actionable outputs**:
 
@@ -134,18 +123,70 @@ A firmographic + technographic + behavioral criteria list.
 - **Firmographic:** $10-50M ARR, Series B-D, 100-500 employees, US/EU
 - **Technographic:** Cloud-native stack (AWS/GCP/Azure), 3+ microservices, Kubernetes-adjacent
 - **Behavioral:** Enterprise Security SOC team, 3+ ITSM tool integrations, >40% cloud infrastructure spend
-- **Exclusions:** Startups <$2M ARR, legacy mainframe-only, heavily regulated (healthcare/finance — separate segment)
+- **Exclusions:** Startups <$2M ARR, legacy mainframe-only, heavily regulated (healthcare/finance : separate segment)
 
 #### Output 2: SPICED Tiers
 Categorize ICPs into fit tiers:
 
-| Tier | Definition | Sales Effort | Win Rate | Example |
-|---|---|---|---|---|
-| **T1: Perfect Fit** | Hits all ICP criteria; high SPICED match | Low | 60-80% | Mid-market SaaS, multi-cloud, growth-stage |
-| **T2: Good Fit** | Hits 70% of ICP criteria; some SPICED variance | Medium | 30-50% | Enterprise SaaS, single-cloud, slower-moving |
-| **T3: Opportunistic** | Hits 40-70% of ICP criteria; niche fit | High | 10-30% | SMB, specific vertical, high-touch champion |
+| Tier | Definition | Fit Score | Sales Effort | Win Rate | Example |
+|---|---|---|---|---|---|
+| **T1: Perfect Fit** | Hits all ICP criteria; high SPICED match | 80-100 | Low | 60-80% | Mid-market SaaS, multi-cloud, growth-stage |
+| **T2: Good Fit** | Hits most ICP criteria; some SPICED variance | 50-79 | Medium | 30-50% | Enterprise SaaS, single-cloud, slower-moving |
+| **T3: Opportunistic** | Partial criteria match; niche fit | Below 50 | High | 10-30% | SMB, specific vertical, high-touch champion |
 
-**Use:** Marketing targets T1 + T2; Sales uses T3 as "if we close one, great; don't chase."
+**Use:** Marketing targets T1 + T2; Sales uses T3 as "if we close one, great; don't chase." Tier assignment comes from the fit scoring model below, never from feel.
+
+#### Output 2a: The Fit Scoring Model (0-100)
+
+The test of an ICP is blunt: can you score any company 0-100 on fit, from data alone, without a meeting? If you can't, you have an opinion, not an ICP. Opinions get expensive: wrong-fit customers close at worse margins and then drag the roadmap toward requests your real ICP never asked for. Tiers assigned by feel drift with whoever assigned them; tiers assigned by a scored model can be audited, automated, and improved.
+
+Build the model in four steps:
+
+**1. Scorecard your best customers.** Take your top 20 accounts by behavior, not by logo size. Rate each 1-5 on five dimensions: revenue quality, sales velocity, time to impact, product depth (how much of the product they actually use), and ease of working together. Multiply the five ratings instead of averaging them: a 5/4/5/4/5 account scores 2,000 while a 4/3/4/3/4 account scores 576. Multiplication separates what averaging hides. Sort. The top 20% is your working definition of ideal; everything else in the model derives from it.
+
+**2. Extract 5-8 discriminating attributes.** Run the 8-dimension pattern analysis (Phase A) over that top 20% and keep only the attributes that separate them from the rest of your customer base. An attribute the whole market shares describes the market, not your ideal customer. Group the survivors under the three pillars: firmographic (who they are on paper), technographic (what they run), signals (what happened before they bought).
+
+**3. Weight out of 100.** Not every attribute matters equally. Example distribution:
+
+| Pillar | Attribute | Weight |
+|---|---|---|
+| Firmographic | Industry match | 25 |
+| Firmographic | Employee range | 15 |
+| Firmographic | Revenue range | 10 |
+| Firmographic | Geography | 5 |
+| Technographic | Tech stack match | 15 |
+| Technographic | Website / digital maturity | 5 |
+| Signals | Hiring in relevant roles | 10 |
+| Signals | Funding or growth event | 5 |
+| Signals | System or leadership change | 10 |
+
+The weights are hypotheses, tuned quarterly through the cycle-time validation below (Output 2b). Two rules:
+
+- **One weight model per segment.** An attribute that predicts buying in one segment can mean nothing in another: a review-site rating predicts behavior for an independent restaurant and says nothing about a PE-backed chain. Radically different customer types get separate weight sets, each validated against its own cycle times.
+- **Scoreable from data you can actually get.** Any criterion that needs a discovery call to evaluate belongs in the qualification-gate layer, not in the fit score. The fit score runs on enrichment data at list scale.
+
+**4. Band into tiers.** T1 = 80 and up, T2 = 50-79, T3 = below 50. The bands feed the tier table above and the CRM: store the score as a field next to `icp_tier` and let lead scoring read from it (Section 8).
+
+#### Output 2b: Tier Validation via Journey Cycle Times
+
+A tier model is a hypothesis until cycle-time data proves it. The model only "works" when T1 accounts demonstrably move faster through the whole journey, not just the funnel top.
+
+Map five cycle times per tier, from CRM plus onboarding data:
+
+| Cycle | Measures | T1 should be |
+|---|---|---|
+| MQL to SQL | Time + conversion | Fastest, highest conversion |
+| SQL to Win | Time + win rate | Fastest, highest win rate |
+| Win to Onboard | Time to live | Smoothest, fewest escalations |
+| Time to first impact | First measurable value | Shortest |
+| Time to full impact | Full recurring value | Shortest, highest expansion |
+
+Reading the result:
+- **T1 wins every column:** the model is validated. Leave the weights alone.
+- **T1 loses a column to T2:** the weights are wrong for whatever that column measures. Adjust one weight, wait a quarter, re-measure. Never adjust on a single read.
+- **Tiers barely separate:** the criteria describe the market, not the ideal customer. Return to pattern analysis and find sharper discriminating attributes.
+
+Cadence is quarterly. Small-base rule: with 15 customers rather than 500 the model is more hypothesis than proof; that is fine. Start with 10 scored accounts, keep Tier 1 deliberately narrow (at early stage you need 50 Tier 1 accounts, not 5,000), and iterate every quarter. Different segments need different weight models: an attribute that predicts buying for one segment can mean nothing for another, and each weight set is validated separately against its own cycle times.
 
 #### Output 3: Buyer Personas
 Role-level profiles (not accounts) with goals, pains, decision criteria.
@@ -170,7 +211,7 @@ What content/proof does the ICP need at each stage?
 
 ---
 
-## 4. SPICED ICP Creation — 6-Level Process
+## 4. SPICED ICP Creation : 6-Level Process
 
 The **SPICED** framework (Situation, Pain, Implementation, Critical Event, Decision) is your core GTM language. Build your ICP SPICED in 6 steps:
 
@@ -181,7 +222,7 @@ The **SPICED** framework (Situation, Pain, Implementation, Critical Event, Decis
 
 ### Step 2: Dream Customer Analysis
 - Identify best customers' "look-alikes" using firmographic + technographic data
-- Look for "TierUppers" — customers one scale tier up (mid-market → enterprise, or SMB → mid-market)
+- Look for "TierUppers" : customers one scale tier up (mid-market → enterprise, or SMB → mid-market)
 - Find proof signals: press mentions, funding announcements, hiring sprees, tech migrations
 - Answer: *If we cloned our top customers and scaled them up, what would they look like?*
 
@@ -233,6 +274,26 @@ Persona: [Role] (VP Eng, VP Finance, CISO, etc.)
 - Decision: [what matters to them?]
 - Proof Needed: [what do they trust?]
 ```
+
+---
+
+## 4.5. AI-Native ICP Building (2026)
+
+LLM-assisted and AI-driven tools now complement traditional analysis. Key techniques:
+
+**Transcript Analysis & SPICED Extraction**
+Run customer interview transcripts through Claude or similar LLM with a SPICED extraction prompt. LLM picks out Situation, Pain, Implementation, Critical Event, Decision lines faster than manual review. Works best when combined with domain context (your product, market).
+
+**Intent-Based Scoring**
+Intent data platforms (6sense, ZoomInfo, Demandbase) track in-market buying signals: job postings (hiring), tech stack changes, funding announcements, executive moves. Roughly 5% of TAM is in-market at any time (Gartner, cited 2026). Use intent signals to identify which ICP segments are in-market NOW, then prioritize outreach. Single vendors contacted first win roughly 80% of deals, so speed matters.
+
+**AI-Assisted Account Clustering**
+Feed your best customer data (firmographic, technographic, SPICED language, revenue, retention) into an embedding model or clustering algorithm. LLM can surface micro-clusters (sub-ICPs) you might miss manually. Example: "Mid-market SaaS in EU" clusters into "Series B fintech in DE/AT" vs "Series B B2B SaaS in NL/BE" with different SPICED patterns.
+
+**Generative Agents for Candidate Evaluation**
+AI agents can screen and score inbound leads or prospect lists against ICP criteria at scale. Ensure training data is clean (small sample of known good/bad ICPs) and review agent decisions on high-value prospects before routing.
+
+**Critical caution:** AI-driven ICP building is a tool, not a replacement. Validate AI output against real customer data and sales experience. 60% of AI projects fail when deployed against non-agent-ready data (Gartner, 2026); data quality is prerequisite.
 
 ---
 
@@ -309,15 +370,20 @@ Extract powerful "working with us feels like..." quotes directly in or right aft
 - "If you had to describe working with us in one sentence, what would you say?"
 - Goal: 1-2 powerful quotes per customer
 
-### Step 5: Quotes
-Run the interview transcript through an LLM with the prompt:
+### Step 5: Quotes & SPICED Extraction
+Run the interview transcript through Claude or similar LLM. Use two prompts:
+
+**Prompt 1 (Quotes):**
 > "Extract the 5-10 most quotable lines from this customer interview. Focus on lines that illustrate the Situation, Pain, Implementation, Critical Event, or Impact. Format as direct quotes with context."
 
-Use these for:
-- Website testimonials
-- Sales decks
-- Blog posts
-- Social proof
+**Prompt 2 (SPICED Extraction):**
+> "Extract and summarize the SPICED framework from this transcript: Situation (their business context when they bought), Pain (specific problem they faced, quantified if possible), Implementation (how they rolled out the solution), Critical Event (what triggered the decision), Decision (why they chose us vs. alternatives). Format as bullet points under each letter."
+
+Use the output for:
+- Website testimonials and social proof
+- Sales decks and positioning language
+- Sharpening your SPICED library with real customer language
+- Feeding back into ICP definition and buyer persona refinement
 
 ### Step 6: Case Study
 If the customer is willing, develop a 1-2 page case study:
@@ -341,7 +407,7 @@ If the customer is willing, develop a 1-2 page case study:
 
 ---
 
-## 6. ICP Expansion Strategy — When & How to Grow
+## 6. ICP Expansion Strategy : When & How to Grow
 
 Starting with **one focused ICP** is strategic. Expansion happens in 4 phases:
 
@@ -369,7 +435,7 @@ Starting with **one focused ICP** is strategic. Expansion happens in 4 phases:
 **Trigger for success:** Win rate 40%+; expansion opportunity clear; can reference customers in the vertical.
 
 ### Phase 4: Tier-Up (Larger Account Sizes)
-- **Shift from ICP to Ideal Account Profile (IAP)** — emphasis shifts from buyer personas to org-level traits
+- **Shift from ICP to Ideal Account Profile (IAP)** : emphasis shifts from buyer personas to org-level traits
 - **Example:** ICP = "VP Eng at $20M ARR SaaS" → IAP = "Enterprise software company, $500M+ revenue, 50%+ cloud adoption"
 - **Requires:** Enterprise sales motion, longer cycle, higher price point, deeper integration
 
@@ -386,7 +452,7 @@ Starting with **one focused ICP** is strategic. Expansion happens in 4 phases:
 
 ---
 
-## 7. The Goldilocks Zone — Right-Sizing Your ICP
+## 7. The Goldilocks Zone : Right-Sizing Your ICP
 
 The ICP size (by ACV, company size, buyer sophistication) has to match your **stage** and **motion type**.
 
@@ -431,15 +497,65 @@ When below $350K ARR, sell slightly smaller companies than you'd ideally want. W
 
 ---
 
-## 8. Usage Guide
+## 7.5. TAM List Production: From ICP to Working Market List
+
+A CRM is an archive of whoever already found you: inbound, referrals, the conference scan from three years ago. It is not the market. An ICP that only ever filters the CRM degenerates into a ranking of whoever showed up, and the scoring model never touches the companies that never contacted you. The TAM list is the inversion: every company in your universe that could match the ICP, enriched, scored, tiered, and maintained. Most "pipeline problems" diagnosed as volume problems (fill the funnel, book more meetings, raise activity) are list problems wearing a disguise.
+
+Seven steps, run as a standing loop:
+
+**1. Define the universe.** Industry, company size, geography. Stop there; everything else comes later from enrichment and scoring. Pick the source that matches where your buyers show up: buyers who sit behind a desk live in LinkedIn Sales Navigator; restaurants, contractors, and local businesses live in Google Maps, chamber-of-commerce registries, and trade directories. Rule of thumb: one well-chosen source covers roughly 60% of the universe, a second takes you to roughly 80%. Chasing the last 20% costs weeks for marginal names. Stop at 80 and move.
+
+**2. Enrich.** Company names without contact data are a directory, not a working list. Bulk-enrich emails, phone numbers, and domains (Apollo, Clay, Clearbit, Databar-class tools), then capture website quality (see Phase G): a company with a real, maintained site behaves differently from one without, and it costs nothing to check.
+
+**3. Score.** Apply the 0-100 fit model (Output 2a) to the whole list before anyone touches it. A big unscored list invites blasting, and blasting teaches you nothing except your unsubscribe rate.
+
+**4. Select tiers to activate.** Pick Tier 1 plus as much of Tier 2 as this quarter's actual campaign capacity can work. Focus beats coverage; the rest of the list is patient.
+
+**5. Activate known-fit only.** Whatever the channel mix (search, social, email, phone, direct mail), every unit of spend goes to companies you already know fit. Activation mechanics belong to the campaign and outbound skills; the list's job is to make sure they aim at scored targets.
+
+**6. Validate.** Per-tier journey cycle times (Output 2b). If Tier 1 does not move faster and retain better than Tier 2, fix the weights, not the list size.
+
+**7. Keep the list alive.** Quarterly, always running: re-enrich (emails bounce, people move), re-score on new signals (hiring, funding, system change), add newly founded or newly qualifying companies from feeds and directories, remove dead ones (closed, merged, inactive). A TAM list nobody refreshes converges back into a directory.
+
+**The funnel shape to expect:** a defined universe of, say, 100,000 companies typically enriches down to roughly 60,000 alive and reachable, scores down to a five-figure group above the floor, and yields a four-figure Tier 1 (illustrative shape, not a benchmark). If Tier 1 comes out at 40% of the universe, the model is describing the market instead of discriminating within it: go back to Output 2a step 2 and find sharper attributes.
+
+**The first step takes an hour, not a month:** pick one source and export every company in your geography matching industry and size. Don't enrich, don't score, just capture it. That raw export is TAM v1, and every later step operates on it.
+
+---
+
+## 8. Platform Implementation: ICP in CRM & Automation
+
+Once you have defined your ICP, encode it operationally in your CRM and enable automation.
+
+**Salesforce + Agentforce:**
+- Store ICP criteria as custom fields and validation rules in Salesforce
+- Use Data 360 (formerly Data Cloud; released 2024) to unify customer data and create a unified profile per account
+- Deploy Agentforce agents (General purpose or role-specific) to score leads and accounts against ICP criteria at scale
+- Agentforce can read unstructured data (emails, Slack, call notes) via Intelligent Context and surface ICP fit signals automatically
+- Recommended architecture: Agentforce Revenue Management (end-of-sale on CPQ means this is the forward path) for deal scoring and orchestration
+- Workflow automation: Flow (Process Builder and Workflow Rules reached end of support 31 December 2025; Flow is the only path forward)
+
+**HubSpot + Breeze:**
+- Encode ICP criteria as Lead Scoring (standard or custom) and Account Scoring properties
+- Breeze Prospecting Agent ($1.00 per recommended lead) can score inbound leads and prospects against ICP fit
+- Breeze Customer Agent ($0.50 per resolved conversation) supports customer interviews and can help extract SPICED language from transcripts when configured with domain knowledge
+- Operations Hub (rebranded to Data Hub in October 2025) provides data management, automation, and governance
+- Recommend Agentic Automation Builder (workflows + agents together) as the architecture for ICP-powered routing and nurture
+
+**Common pattern (both platforms):**
+Define ICP as a scoring model, then use platform agents or automation to route prospects and leads based on fit. Quality data is prerequisite: 60% of AI projects abandoned over non-agent-ready data (Gartner, 2026).
+
+---
+
+## 9. Usage Guide
 
 This reference is designed as a **before & after** to your SPICED ICP library:
 
 1. **Before:** Use this file to **build** your ICP (Sections 3-6: GAP Method, SPICED Process, Interview Pipeline)
-2. **During:** Use the customer count thresholds (Section 1) to assess **ICP maturity** — if your customer count is below threshold for your motion, cap maturity at Level 2
+2. **During:** Use the customer count thresholds (Section 1) to assess **ICP maturity** : if your customer count is below threshold for your motion, cap maturity at Level 2
 3. **Output:** Feed SPICED language into your SPICED ICP library
 4. **Next Step:** Use the positioning-messaging-reference to translate ICP into positioning and messaging
-5. **Expansion:** Use Section 6 (Expansion Strategy) when clients ask "where do we grow next?"
+5. **Expansion:** Use Section 6 (Expansion Strategy) when your team asks "where do we grow next?"
 
 ### Common Questions This Reference Answers
 
@@ -450,10 +566,12 @@ This reference is designed as a **before & after** to your SPICED ICP library:
 | "What's the quickest way to extract ICP from customers?" | Section 5: Customer Interview Pipeline |
 | "We're in Low Touch / Product-Led; how do we do ICP?" | Section 2: Motion-Specific Tactics |
 | "Are we targeting the right company size?" | Section 7: Goldilocks Zone |
+| "How do we score companies 0-100 on fit?" | Section 3, Phase P, Output 2a: Fit Scoring Model |
+| "How do we turn the ICP into a target list?" | Section 7.5: TAM List Production |
 | "We're saturating the current ICP; where do we expand?" | Section 6: Expansion Strategy |
 
 ---
 
-**Version:** 1.0
-**Last Updated:** 2026-03-06
+**Version:** 1.2
+**Last Updated:** 2026-08-21
 **Review Cadence:** Quarterly (after expansion trigger assessments)


### PR DESCRIPTION
## What this skill does

Builds, validates, scores, and expands an Ideal Customer Profile: a 0-100 weighted fit score per company, tiering validated against journey cycle times, a maintained TAM list, and a qualification-gate layer so the ICP governs pipeline movement instead of living in a slide. This PR updates the existing `icp-builder` skill (same slug, same folder) and refreshes its reference page in place.

What changed in this update:
- New fit scoring model (Output 2a): best-customer scorecard, 5-8 discriminating attributes across firmographic / technographic / signal pillars, weights out of 100 with one weight set per segment, score-band tiering.
- New TAM list production loop (Section 7.5): define the universe, enrich, score before activation, select tiers against capacity, activate known-fit only, validate, quarterly keep-alive.
- Tier validation via five journey cycle times (Output 2b) and the qualification-gate layer.
- New `## What good looks like` section; user-first framing throughout; vendor-free body.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally (icp-builder reports no problems; the two pre-existing errors in other folders are untouched by this PR)
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn (existing profile, unchanged)
- [x] Body speaks in GTM verbs — zero vendor tool names (the reference page names enrichment sources as examples in its list-building section)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
