### PR TITLE
Intake cleanup: Nikhil avatar, bio house style, unsourced stats, internal consistency

### DIFF
--- a/skills/amit-rotstein/author.md
+++ b/skills/amit-rotstein/author.md
@@ -1,9 +1,9 @@
 ---
 name: Amit Rotstein
-title: Head of Product @Spotlight.ai
+title: Head of Product, Spotlight.ai
 linkedinUrl: https://www.linkedin.com/in/amitrotstein/
 companyDomain: https://www.spotlight.ai
 email: amit.rotstein@spotlight.ai
 ---
 
-Amit is Head of Product at Spotlight.ai, an autonomous deal execution platform, with 20+ years of experience building software and product organizations, including deep CRM platform expertise. At Spotlight.ai, he builds the product for AI-driven deal execution, covering value-selling and forecasting workflows powered by Spotlight.ai's proprietary Knowledge Graph.
+Amit is Head of Product at Spotlight.ai, an autonomous deal execution platform, with 20+ years of experience building software and product organizations, including deep CRM platform expertise. At Spotlight.ai, he builds the product for AI-driven deal execution, covering value-selling and forecasting workflows.

--- a/skills/nikhil-mirza/author.md
+++ b/skills/nikhil-mirza/author.md
@@ -1,5 +1,6 @@
 ---
 name: Nikhil Mirza
+avatarUrl: https://www.gtmskills.com/authors/nikhil-mirza.jpg
 title: Sr Director, Sales Operations, Taboola
 linkedinUrl: https://www.linkedin.com/in/nikhilmirza/
 companyDomain: taboola.com

--- a/skills/rutger-katz/icp-builder/references/icp-building-operational-reference.md
+++ b/skills/rutger-katz/icp-builder/references/icp-building-operational-reference.md
@@ -54,7 +54,7 @@ The way you build an ICP depends on how you go to market. Here are motion-specif
 
 | Motion | ICP Building Challenge | Strategic Response |
 |--------|---|---|
-| **No Touch / PLG** | Behavioral signals are sparse; no sales conversations to mine | Build behavioral ICP from product analytics. Use event tracking in Mixpanel, Amplitude, or Segment; analyze feature adoption depth, cohort retention curves, and expansion velocity. Hybrid PLG+sales-assist (sales-assisted PQLs 25-35% conversion, CAC payback under 12 months) outperforms pure self-serve on NRR (67% vs 58%) (OpenView Benchmarks, 2024-2025). ACV framework: self-serve under $10K; hybrid $10K-$25K; sales-led above $25K. |
+| **No Touch / PLG** | Behavioral signals are sparse; no sales conversations to mine | Build behavioral ICP from product analytics. Use whatever product analytics you already run; analyze feature adoption depth, cohort retention curves, and expansion velocity. A hybrid motion — self-serve with sales assist on product-qualified accounts — typically retains and expands better than pure self-serve, so treat the PQL threshold as the real ICP boundary: below it the product sells itself, above it a human should. Where that line sits is a function of your ACV and cost to serve, not a published number. |
 | **Low Touch / 1-Stage** | Many tire-kickers; lightweight sales process means limited depth | Cluster by role, use case, retention curves. Identify micro-segments with 70%+ 12-mo retention. Double-down there. |
 | **Medium Touch / 2-Stage** | Balancing limited data against depth of signal | Blend 8-15 SPICED interviews with win/loss reviews. Surface patterns across competitive wins + expansion. |
 | **High Touch / Sales** | Few closed deals; each customer is precious data | Treat every deal as a test case. Iterate ICP quarterly. Build from pilot customers + expansion proof. |
@@ -285,7 +285,7 @@ LLM-assisted and AI-driven tools now complement traditional analysis. Key techni
 Run customer interview transcripts through Claude or similar LLM with a SPICED extraction prompt. LLM picks out Situation, Pain, Implementation, Critical Event, Decision lines faster than manual review. Works best when combined with domain context (your product, market).
 
 **Intent-Based Scoring**
-Intent data platforms (6sense, ZoomInfo, Demandbase) track in-market buying signals: job postings (hiring), tech stack changes, funding announcements, executive moves. Roughly 5% of TAM is in-market at any time (Gartner, cited 2026). Use intent signals to identify which ICP segments are in-market NOW, then prioritize outreach. Single vendors contacted first win roughly 80% of deals, so speed matters.
+Intent data platforms (6sense, ZoomInfo, Demandbase) track in-market buying signals: job postings (hiring), tech stack changes, funding announcements, executive moves. Only a small fraction of any TAM is in-market in a given quarter, which is the whole argument for intent data: it tells you which ICP segments are live now so outreach goes there first. Speed compounds — the vendor who reaches an in-market account first shapes the decision criteria the rest get measured against.
 
 **AI-Assisted Account Clustering**
 Feed your best customer data (firmographic, technographic, SPICED language, revenue, retention) into an embedding model or clustering algorithm. LLM can surface micro-clusters (sub-ICPs) you might miss manually. Example: "Mid-market SaaS in EU" clusters into "Series B fintech in DE/AT" vs "Series B B2B SaaS in NL/BE" with different SPICED patterns.
@@ -293,7 +293,7 @@ Feed your best customer data (firmographic, technographic, SPICED language, reve
 **Generative Agents for Candidate Evaluation**
 AI agents can screen and score inbound leads or prospect lists against ICP criteria at scale. Ensure training data is clean (small sample of known good/bad ICPs) and review agent decisions on high-value prospects before routing.
 
-**Critical caution:** AI-driven ICP building is a tool, not a replacement. Validate AI output against real customer data and sales experience. 60% of AI projects fail when deployed against non-agent-ready data (Gartner, 2026); data quality is prerequisite.
+**Critical caution:** AI-driven ICP building is a tool, not a replacement. Validate AI output against real customer data and sales experience. These techniques fail on messy data far more often than on bad models — data quality is the prerequisite, not the optimization.
 
 ---
 
@@ -532,18 +532,18 @@ Once you have defined your ICP, encode it operationally in your CRM and enable a
 - Use Data 360 (formerly Data Cloud; released 2024) to unify customer data and create a unified profile per account
 - Deploy Agentforce agents (General purpose or role-specific) to score leads and accounts against ICP criteria at scale
 - Agentforce can read unstructured data (emails, Slack, call notes) via Intelligent Context and surface ICP fit signals automatically
-- Recommended architecture: Agentforce Revenue Management (end-of-sale on CPQ means this is the forward path) for deal scoring and orchestration
-- Workflow automation: Flow (Process Builder and Workflow Rules reached end of support 31 December 2025; Flow is the only path forward)
+- Build deal scoring and orchestration on the platform's current agent and revenue-management layer rather than a legacy CPQ path
+- Use the platform's current workflow-automation engine; older rules-based builders are being retired
 
 **HubSpot + Breeze:**
 - Encode ICP criteria as Lead Scoring (standard or custom) and Account Scoring properties
-- Breeze Prospecting Agent ($1.00 per recommended lead) can score inbound leads and prospects against ICP fit
-- Breeze Customer Agent ($0.50 per resolved conversation) supports customer interviews and can help extract SPICED language from transcripts when configured with domain knowledge
-- Operations Hub (rebranded to Data Hub in October 2025) provides data management, automation, and governance
+- The prospecting agent can score inbound leads and prospects against ICP fit; these are consumption-priced, so check the current per-unit rate before turning them loose on a large list
+- The customer-facing agent supports customer interviews and can extract SPICED language from transcripts when configured with domain knowledge
+- The data-operations hub provides data management, automation, and governance
 - Recommend Agentic Automation Builder (workflows + agents together) as the architecture for ICP-powered routing and nurture
 
 **Common pattern (both platforms):**
-Define ICP as a scoring model, then use platform agents or automation to route prospects and leads based on fit. Quality data is prerequisite: 60% of AI projects abandoned over non-agent-ready data (Gartner, 2026).
+Define ICP as a scoring model, then use platform agents or automation to route prospects and leads based on fit. Quality data is the prerequisite: agent-driven routing fails on incomplete records long before it fails on scoring logic.
 
 ---
 

--- a/skills/vesselin-malev/content-de-slop-ai/SKILL.md
+++ b/skills/vesselin-malev/content-de-slop-ai/SKILL.md
@@ -34,7 +34,7 @@ The order is the method. Reversing it produces a draft that has been word-swappe
 
 6. **Calibrate for the channel.** Feed posts, cold email, long-form, and proof content each punish different tells.
 
-7. **Prove it clean.** Run the full detection battery. A draft ships when it passes all seven tests, and never before.
+7. **Prove it clean.** Run the full detection battery. A draft ships when it passes every applicable test, and never before — the correlation check is the one exception, since it only applies to teams running several accounts.
 
 ## The reference pages
 
@@ -42,7 +42,7 @@ The order is the method. Reversing it produces a draft that has been word-swappe
 - `references/channel-calibration.md` covers feed posts, cold email, newsletters and long-form, and case studies and proof content.
 - `references/detection-tests.md` carries the seven tests, what each one catches, and what a repeated failure means.
 - `references/voice-fingerprint.md` covers building the author document that overrides the tell list.
-- `references/worked-examples.md` walks four passes end to end, including one where a flagged construction was correct and stayed.
+- `references/worked-examples.md` walks three passes end to end, plus one case where a flagged construction was correct and stayed.
 
 ## The rule underneath the lexicon
 
@@ -62,7 +62,7 @@ When a draft keeps failing the lineup or the x-ray after repeated passes, the pr
 
 - MUST rewrite structure before touching word choice.
 - MUST trace every number and name to source material, or cut it.
-- MUST run all seven detection tests before anything ships.
+- MUST run every applicable detection test before anything ships (the correlation check applies only to multi-account teams).
 - NEVER compensate with slang, forced edge, or manufactured casualness.
 - NEVER treat paraphrase alone as humanizing. It preserves the structure that gives the draft away.
 - NEVER override an author's real voice with the tell list.

--- a/skills/vesselin-malev/content-de-slop-ai/references/channel-calibration.md
+++ b/skills/vesselin-malev/content-de-slop-ai/references/channel-calibration.md
@@ -1,6 +1,6 @@
 # Channel calibration
 
-The four passes are constant. What changes by channel is which tells do the most damage and where the specificity has to land.
+The seven steps of the pass are constant. What changes by channel is which tells do the most damage and where the specificity has to land.
 
 ## Feed posts
 

--- a/skills/vesselin-malev/content-de-slop-ai/references/detection-tests.md
+++ b/skills/vesselin-malev/content-de-slop-ai/references/detection-tests.md
@@ -1,6 +1,6 @@
 # Detection tests
 
-Run all seven. Each catches a failure the others miss. A draft that fails any test goes back through the pass, and the pass repeats until the battery comes back clean.
+Run every one that applies — all seven for a team running several accounts, the first six for a single author publishing alone. Each catches a failure the others miss. A draft that fails any test goes back through the pass, and the pass repeats until the battery comes back clean.
 
 ## 1. The squint test
 

--- a/skills/vesselin-malev/content-de-slop-ai/references/worked-examples.md
+++ b/skills/vesselin-malev/content-de-slop-ai/references/worked-examples.md
@@ -100,7 +100,7 @@ The rhetorical question opener is on the inventory. The pass flagged it and the 
 
 The author's fingerprint documents that 9 of their last 15 posts open with a question, and those posts outperform their others on engagement. This is a real habit, visible in genuine samples predating any AI use, and their audience recognizes it.
 
-**Resolution:** the opener stays. The rest of the piece still gets all four passes.
+**Resolution:** the opener stays. The rest of the piece still gets the full pass.
 
 This is the fingerprint overriding the tell list, and it is the most common way a careless pass damages a draft. The tell list describes the average machine draft. It does not describe this person. When a flagged construction appears repeatedly in the author's genuine, pre-AI work, it is voice, and removing it makes the piece less like them, not more.
 


### PR DESCRIPTION
Follow-ups to the eight contributor PRs merged today (#75, #109, #111, #112, #120, #124, #125, #126). Kept out of the contributor branches deliberately — pushing to a branch dismisses its approval, and these were all maintainer-side edits rather than things to hold a contributor for.

**nikhil-mirza (#125)** — add `avatarUrl`. His author.md shipped without one, and the site's fallback is a stock human photo, so a missing avatar renders a stranger's face on his profile. LinkedIn photo, rehosted to `www.gtmskills.com/authors/nikhil-mirza.jpg` (image already pushed to gtm-skills-web, along with his author-links entry).

**amit-rotstein (#120)** — the two house-style points from the review, applied here rather than held: title back to `Head of Product, Spotlight.ai` (the site already renders the Spotlight.ai mark from `companyDomain`, so the `@` suffix doubled up), and the closing "powered by Spotlight.ai's proprietary Knowledge Graph" clause trimmed. His rewrite was otherwise an improvement and is kept.

**rutger-katz (#126)** — removed four statistics whose named attributions don't hold up:

| Claim | Problem |
|---|---|
| NRR 67% vs 58%, cited to "OpenView Benchmarks, 2024-2025" | OpenView stopped investing in Dec 2023; High Alpha took over the benchmarks report. No such edition exists. |
| "Roughly 5% of TAM is in-market (Gartner, cited 2026)" | No locatable source |
| "Single vendors contacted first win roughly 80% of deals" | No locatable source |
| "60% of AI projects fail... (Gartner, 2026)" — twice | No locatable source |

In each case the surrounding judgment is sound and survives without the number, so the prose stays and the false precision goes. Also de-priced section 8 — per-lead and per-conversation agent rates and platform end-of-support dates are the fastest-rotting content a skill can carry.

**vesselin-malev (#75)** — the three internal contradictions from the review:
- Ship gate demanded "all seven detection tests" while test 7 exempts a single author publishing alone. Now "every applicable test" in both files.
- "The four passes" in two references contradicted the seven-step pass defined in SKILL.md.
- SKILL.md said worked-examples walks "four passes"; the file itself says three plus an edge case.

`node tools/validate.mjs` → ok, 330 skills across 62 creators.

@idogoldd — needs your approve, since it's my PR.