### PR TITLE
Ariel Cohen: handle-demo-request

### DIFF
--- a/skills/ariel-cohen/handle-demo-request/SKILL.md
+++ b/skills/ariel-cohen/handle-demo-request/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: handle-demo-request
+title: Handle a demo request
+description: |
+  Use this skill when someone requests a demo through your website — a "Book a demo" form,
+  a webhook carrying little more than a work email — and the question is what happens in the
+  next sixty seconds. Enriches the person and company, decides fit and buyer persona
+  separately, and routes the request down one of three paths: the qualified hand-raise that
+  gets a booking email, the right company with the wrong person, and the account that should
+  be sent to a free trial rather than a calendar. Covers inbound demo requests, form-fill
+  routing, hand-raise qualification, MQL hygiene, and self-serve versus sales-assisted
+  triage.
+category: Signals
+tags: [Sales, RevOps, Demand Gen]
+---
+
+# Handle a demo request
+
+Runs on every inbound demo request. Produces a CRM record, a fit-and-persona verdict, exactly one outbound email (or none), and a single alert to the team — with the request routed by whether the company is a fit and whether the person is a buyer, never by a tier number alone.
+
+The default handling — route every demo request to a rep and book the meeting — is wrong in both directions. It sends your team into meetings with companies that were never going to buy, and it treats a junior analyst at a perfect-fit account as if they were the CRO.
+
+## Template placeholders
+
+Replace every `{{...}}` before enabling. Full setup list in **references/setup-customization-checklist.md**.
+
+- `{{CRM}}` — where contacts and companies live (e.g. HubSpot, Salesforce, Attio).
+- `{{ALERT_CHANNEL}}` — the single channel every demo request posts to, whatever the outcome.
+- `{{MQL_CHANNEL}}` — where qualified leads surface. Owned by your scoring pass, never posted to from here.
+- `{{SALES_SENDER}}` — the person booking emails come from.
+- `{{BOOKING_LINK}}` — their calendar link.
+- `{{TRIAL_LINK}}` — your self-serve entry point.
+- `{{SELF_SERVE_FLOOR}}` — the company size below which an account is self-serve, not sales-assisted (default: under 50 employees).
+- `{{FUNDED_OVERRIDE}}` — the funding-and-size combination that pulls an account back onto the sales-assisted path regardless (default: more than 30 employees **and** more than $10M raised).
+- `{{TOP_TIERS}}` — the tiers that justify an MQL stage rather than an awareness stage.
+- `{{DECISION_MAKER_TITLES}}` — the titles that count as buying authority in your market.
+
+---
+
+## Step 1 — Gate the email before spending anything
+
+Extract the work email. **Stop when there is no email, or when it is a consumer domain** — gmail, outlook, hotmail, yahoo, icloud, proton, and the rest.
+
+Post a low-priority note to `{{ALERT_CHANNEL}}` saying a demo request arrived that could not be processed, include the raw address if there was one, and end. Do not enrich, do not write to `{{CRM}}`, do not send anything.
+
+This gate exists because enrichment costs money and CRM pollution costs more. A personal address on a demo form is usually a student, a competitor, or a bot, and the cost of finding out is not zero.
+
+## Step 2 — Enrich, then write to the CRM
+
+Resolve the person (name, title, profile URL) and the company from the email domain (employee count, funding, industry, description, target market).
+
+**If no real company resolves from the domain, that is a non-fit answer, not a missing one** — route to Step 5's non-fit path and say the domain could not be resolved.
+
+Create or update the contact and company, associated to each other, with a note recording the source, the date, and the submitted address. CRM writes need no approval; they are reversible and they are the audit trail.
+
+## Step 3 — Decide persona *before* you score
+
+Classify the submitter as a decision-maker or not, from their title, using `{{DECISION_MAKER_TITLES}}`. Everyone else — individual contributors, junior titles, non-GTM functions, and any title that would not resolve — is not a decision-maker.
+
+**The order matters.** Persona is an input to scoring, not a read of its output. Score first and you get a tier that has already blended "good company" and "good person" into one number, and you can no longer tell which one you are looking at.
+
+## Step 4 — Score the account, with three directives
+
+Run your normal account scoring pass in full: tier, deal-size band, ICP and target-market flags, and every hard stop it already enforces (competitor, investor, partner, government, self-serve). Do not re-implement any of that here.
+
+Pass it three directives:
+
+**1. Suppress the MQL alert for non-decision-makers.** If the submitter is not a decision-maker, the scoring pass does everything *except* announce. No `{{MQL_CHANNEL}}` post, no direct message, no briefing. Tier, tags, and CRM state all still happen. This keeps the MQL channel clean of accounts where no buyer has actually raised a hand — the alternative is a channel full of good logos that nobody can act on.
+
+**2. Self-serve is not a full stop here.** Let the self-serve gate apply its tags and stage as normal, then keep going — this workflow still sends the free-trial email. A small company asking for a demo is the ideal free-trial audience, and silence is a worse answer than the wrong door.
+
+**3. The funding override — don't cancel the demo.** Before scoring, resolve employee count (take the lower of enrichment and the profile) and total funding. If the company clears `{{FUNDED_OVERRIDE}}`, do not self-serve-gate it: score it on the sales-assisted path, do **not** suppress the MQL alert even for a non-decision-maker, and route it to Branch A. A funded company that asks for a demo gets a demo, not a self-serve brush-off.
+
+## Step 5 — Route on fit × persona, never on tier
+
+| Outcome | Path |
+|---|---|
+| **Competitor** | Post nothing, anywhere. Send nothing. End silently — the competitor gate forbids surfacing them, and scoring has already logged it. |
+| **Investor, partner/vendor, or government** | One low-priority note naming the reason. No email. End. |
+| **Self-serve, or out of ICP** | **Branch C** — free trial. |
+| **Fit + decision-maker** | **Branch A** — booking email. |
+| **Fit + not a decision-maker** | **Branch B** — surface, don't send. |
+
+A fit account is one your scoring places in a target market with real sales-assisted deal size. **It is not the tier number.** A persona gate can cap a genuinely good company at a middling tier because a junior person was the only signal — that account is still a fit, and it belongs in Branch B, not Branch C.
+
+### Branch A — the qualified hand-raise
+
+1. Set the funnel stage by tier: `{{TOP_TIERS}}` → MQL stage; everything else → an awareness stage. A decision-maker demo request is real, but only the top tiers belong in MQL.
+2. Send a booking email from `{{SALES_SENDER}}`. Subject names the company. Three short paragraphs, casual and specific: confirm what you do maps to their situation, referencing something concrete about their company. **Never write "I saw you filled out a form."** Close by inviting them onto `{{BOOKING_LINK}}` as a plain-text URL.
+3. Post a high-priority alert to `{{ALERT_CHANNEL}}` — who, where, title, tier, why they qualify, that the email went out, and CRM links. Format in **references/alerting-and-channel-model.md**.
+
+The MQL-channel post is not yours. Your scoring pass already made it. Do not rebuild it.
+
+### Branch B — right company, wrong person
+
+The account is real. The person is not a buyer. This is the case every inbound motion handles badly, and it is reached by fit, not tier.
+
+1. Leave the CRM stage where scoring put it. Do not force an MQL stage from here.
+2. **Send nothing.** No booking email — they cannot book. No free-trial email either — this is a fit account, not a self-serve one.
+3. Confirm the MQL alert was suppressed (Step 4, directive 1). Do not post one now.
+4. Post a medium-priority alert to `{{ALERT_CHANNEL}}` flagging explicitly that this is a fit account whose demo request came from a non-buyer, so a human can decide whether to route to the real buyer. Include the likely decision-makers at that account if your scoring surfaced them. **This alert is the only surfacing this case gets** — which is exactly why it has to carry enough for someone to act on.
+
+### Branch C — not a sales-assisted fit
+
+Covers both the out-of-ICP company and the self-serve one below `{{SELF_SERVE_FLOOR}}`.
+
+1. Send a short free-trial email from `{{SALES_SENDER}}` — three or four sentences. Name the specific thing they would want to try, and invite them to `{{TRIAL_LINK}}` to try that exact use case. No calendar link.
+2. Post a low-priority note to `{{ALERT_CHANNEL}}` with the reason they are not sales-assisted and that the trial email went out. Bump to medium for a recognizable brand or a large company — size that your own scoring under-reads is worth a human glance.
+
+**Never send both emails.** One branch, one message.
+
+## Step 6 — Keep the two channels separate
+
+`{{ALERT_CHANNEL}}` is this workflow's channel and every outcome posts there exactly once. `{{MQL_CHANNEL}}` belongs to your scoring pass, with its own suppression and gating. Posting to it from here produces duplicates that quietly train the team to ignore both. Full model, priorities, and alert format in **references/alerting-and-channel-model.md**.
+
+## What good looks like
+
+- **Persona and fit are separately legible in the record.** Someone reading the account can tell whether it was the company or the person that failed, because those were decided in different steps.
+- **The expert tell: the MQL channel stays boring.** Novices measure the inbound motion by how many leads it surfaces. What predicts a working motion is that everything surfaced is actionable — a channel where a good logo appears with nobody to call is a channel people stop opening.
+- **Branch B produces action, not filing.** The test is whether anyone actually reached the real buyer. If those alerts are consistently read and dropped, the alert lacks the buying-committee detail, and that is a fixable defect rather than a fact of life.
+- **The mediocre version routes on tier.** It sends a top-tier junior analyst to a rep and pushes a mid-tier CRO to a free trial, and it looks defensible in a dashboard the whole time.
+- **The second mediocre version answers everything with a calendar link.** Self-serve companies do not book, do not show, and do not come back — the free-trial nudge exists because the wrong door is worse than a smaller one.
+- **Nobody is surprised by an email.** Every send traces to a branch, and no account ever received two.
+
+## Rules
+
+- **MUST** gate consumer email domains before enriching or writing to the CRM. **NEVER** spend enrichment on an ungated address.
+- **MUST** decide persona before scoring, and pass it in as a directive.
+- **MUST** route on fit and persona together. **NEVER** route on the tier number alone.
+- **MUST** send at most one email per request. **NEVER** send both the booking and the trial email.
+- **MUST** treat an unresolvable company domain as non-fit, not as missing data.
+- **MUST** leave the `{{MQL_CHANNEL}}` post to the scoring pass. **NEVER** rebuild or re-post it from here.
+- **MUST** post competitor outcomes nowhere at all — no channel, no email.
+- **MUST** queue outbound for human approval by default; flip to auto-send only once a team has decided a demo request is explicit enough consent, and only for these single acknowledgement emails.
+- **NEVER** send a booking email to someone with no buying authority; surface them to a human instead.
+- **MUST** treat every threshold here — `{{SELF_SERVE_FLOOR}}`, `{{FUNDED_OVERRIDE}}`, `{{TOP_TIERS}}` — as a tunable default, calibrated against your own closed-won history before it routes real requests.

--- a/skills/ariel-cohen/handle-demo-request/references/alerting-and-channel-model.md
+++ b/skills/ariel-cohen/handle-demo-request/references/alerting-and-channel-model.md
@@ -1,0 +1,66 @@
+---
+title: Alerting and the two-channel model
+description: (reference) Why demo requests and qualified leads go to different channels, the alert format every branch shares, and the priority ladder.
+---
+
+# Alerting and the two-channel model
+
+Every demo request produces exactly one alert. Which channel it lands in, and how loud it is, is decided before anything is written.
+
+## Two channels, two owners
+
+| Channel | Owner | Posts |
+|---|---|---|
+| `{{ALERT_CHANNEL}}` | this workflow | Every outcome — all three branches, plus investor / partner / government notes |
+| `{{MQL_CHANNEL}}` | your account scoring pass | Only qualified leads, with its own gating and suppression |
+
+**The separation is the point.** The workflow channel answers "what came in and what did we do about it" — it is a log, and it is complete. The MQL channel answers "who should someone call today" — it is a queue, and it is short. Merge them and you get a queue nobody trusts, because most of what is in it is not a lead.
+
+The failure this prevents is duplicate announcement. When two systems both post the qualified case, the team learns that every item appears twice, then stops reading whichever one they see second — usually the one that mattered.
+
+**Net effect, so the routing is auditable:**
+
+| Case | Workflow channel | MQL channel |
+|---|---|---|
+| Branch A, top tier | ✓ | ✓ (from scoring) |
+| Branch A, lower tier | ✓ | — (scoring does not surface sub-tier) |
+| Branch B (fit, non-buyer) | ✓ | — (suppressed at Step 4) |
+| Branch C (non-fit / self-serve) | ✓ | — |
+| Investor / partner / government | ✓ low note | — |
+| Competitor | — | — |
+
+Competitors get nothing anywhere. A competitor appearing in a channel invites a reply from someone who has not read the whole thread, and the scoring pass has already logged them where they belong.
+
+## Priority ladder
+
+- **High** — Branch A. A buyer at a fit account asked for a demo. This is the only case that should interrupt someone.
+- **Medium** — Branch B, and Branch C when the company is a recognizable brand or unusually large. Both mean "a human should look at this today", not "right now".
+- **Low** — Branch C in the ordinary case, and every hard-stop note. These are read in a batch, or not at all, and that is fine.
+
+If everything is high priority, nothing is. The ladder is only doing its job when most posts are low.
+
+## Alert format
+
+Every post carries the same shape, so the channel can be skimmed vertically:
+
+```text
+WHO       — name, title, company
+WHAT      — which branch fired, and what was sent (or that nothing was)
+CONTEXT   — how they arrived, and when
+ICP MATCH — fit verdict and tier, with the one line that decided it
+INSIGHT   — the single most useful thing about this account
+ACTIONS   — what the workflow already did, so nobody repeats it
+LINKS     — CRM records
+```
+
+Two rules about the body:
+
+**Say what was already done.** An alert that reports a lead without reporting the email already sent produces a second, near-identical email from a helpful human. The "actions taken" line is not a courtesy; it is a deduplication mechanism.
+
+**Include the account profile in the body, not behind a link.** Size, maturity, and growth stage decide whether anyone acts, and an alert that requires opening the CRM to learn them will be triaged as "later" by whoever is on their phone.
+
+## Branch B carries more
+
+Branch B's alert is the only surfacing that case ever gets, so it needs everything a person requires to act without going back to the source: the fit verdict, why the submitter was not treated as a buyer, and the likely decision-makers at that account if scoring surfaced them.
+
+An alert that says "fit account, wrong person" and stops has moved the work to a human without giving them the means to do it. Where these get read and dropped consistently, that is the defect to fix — not evidence that the case does not matter.

--- a/skills/ariel-cohen/handle-demo-request/references/setup-customization-checklist.md
+++ b/skills/ariel-cohen/handle-demo-request/references/setup-customization-checklist.md
@@ -1,0 +1,70 @@
+---
+title: Setup and customization checklist
+description: (reference) Placeholders to fill, the policy decisions to make before enabling, calibration, and the invariants that must survive any customization.
+---
+
+# Setup and customization checklist
+
+What to decide before this runs on live inbound.
+
+## 1. Fill the placeholders
+
+| Placeholder | What to put there | Default if unsure |
+|---|---|---|
+| `{{CRM}}` | Where contacts and companies live | Whatever your reps already work in |
+| `{{ALERT_CHANNEL}}` | One channel, every demo request | A new channel — do not reuse an MQL channel |
+| `{{MQL_CHANNEL}}` | Where your scoring pass surfaces qualified leads | Your existing one; this skill never posts there |
+| `{{SALES_SENDER}}` | Who booking and trial emails come from | The person whose calendar the link opens |
+| `{{BOOKING_LINK}}` | Their calendar link | A 30-minute meeting type |
+| `{{TRIAL_LINK}}` | Self-serve entry point | Your signup URL, no campaign parameters |
+| `{{SELF_SERVE_FLOOR}}` | Size below which an account is self-serve | Under 50 employees |
+| `{{FUNDED_OVERRIDE}}` | The exception that pulls an account back to sales-assisted | More than 30 employees **and** more than $10M raised |
+| `{{TOP_TIERS}}` | Tiers justifying an MQL stage | Your top two |
+| `{{DECISION_MAKER_TITLES}}` | Titles with buying authority in your market | See below |
+
+### Decision-maker titles
+
+The default list is GTM leadership with budget: CRO, VP or Head of Sales, VP or Head of Marketing, CMO, CEO, founder or co-founder, RevOps lead, GTM engineer, growth lead, head of demand generation, agency owner.
+
+Adjust for how your market actually buys. In a developer product the buyer may be a staff engineer; in mid-market the CEO signs everything. **The list is not a seniority ranking — it is a list of people who can say yes.** A director who owns the budget belongs on it; a VP who does not, does not.
+
+## 2. Decide the auto-send policy first
+
+This skill defaults to **queueing outbound for human approval**, which is the right starting posture.
+
+Teams that treat a demo request as explicit consent flip Branch A and Branch C to auto-send, on the reasoning that someone who asked for a demo has asked to be contacted, and a reply an hour later beats a reply tomorrow. That is a defensible call and a common one.
+
+Two conditions before you make it:
+
+- **The flip covers these acknowledgement emails only.** It is not a general auto-send permission for the sender, and it must not silently become one for outbound sequences.
+- **Read the first twenty out loud.** Auto-send makes every drafting weakness public at speed. If any of the twenty makes you wince, the voice guidance needs work before the volume does.
+
+Branch B is never auto-send, because Branch B never sends.
+
+## 3. Calibrate the thresholds against your own history
+
+The numbers here are starting points, not findings.
+
+- **`{{SELF_SERVE_FLOOR}}`** — take your closed-won accounts and find the size below which sales-assisted deals stopped being worth the touch. If you have never won below a size, that is your floor.
+- **`{{FUNDED_OVERRIDE}}`** — this exists because size alone under-reads a funded company: thirty people with real money behind them buys like a much larger org. Check it against the funded accounts you have actually won.
+- **`{{TOP_TIERS}}`** — should be narrow enough that the MQL channel stays short. If more than a small fraction of demo requests reach it, the bar is too low and the channel will be ignored within a month.
+
+Re-check after a quarter of real volume, and change one threshold at a time — moving two at once makes the result unreadable.
+
+## 4. Invariants — do not customize these away
+
+These carry the judgment. Everything else is tunable.
+
+- **Persona is decided before scoring**, and passed in. Reversing the order collapses "good company" and "good person" into one number.
+- **Routing is fit × persona, never tier alone.** A capped tier on a genuinely good company is exactly the case this exists to catch.
+- **One email per request, maximum.** The booking email and the trial email are mutually exclusive, always.
+- **The MQL channel has one owner.** This workflow never posts there.
+- **Competitors surface nowhere.**
+- **Branch B sends nothing and surfaces everything.** The temptation is to send the junior person something friendly; that trains them to think they are the contact, and it is harder to route to the real buyer afterwards.
+
+## 5. What to watch in the first month
+
+- **The share of requests reaching Branch B.** Consistently high means your form is collecting the wrong person — a "what's your role" field will do more than any routing change.
+- **Whether Branch B alerts get acted on.** If not, the alert is missing buying-committee detail.
+- **Trial starts from Branch C.** Zero means the email is not landing, or the trial link is wrong. This is the cheapest branch to fix and the easiest to leave broken, because nobody complains about it.
+- **Consumer-domain stops.** A sudden rise usually means a bot found your form, not that your market changed.


### PR DESCRIPTION
Repo copy of `handle-demo-request`, published to the library today and live at [gtmskills.com/skill/handle-demo-request](https://www.gtmskills.com/skill/handle-demo-request). This PR just brings the repo in line so the profile's download commands and GitHub link resolve.

**Source and attribution.** Generalized from Swan's production "Handle Demo Request" org skill — 18 versions, Ariel 14 edits to Amos's 4, and those four were a single alert-format change that this version generalizes away.

**What it carries.** Persona decided *before* scoring and passed in as a directive, so "good company" and "good person" never collapse into one number. Routing on fit × persona rather than tier — which is what catches the fit account whose tier got capped because a junior person was the only signal. The "right company, wrong person" branch that sends nothing and surfaces everything. MQL-alert suppression for non-buyers. Self-serve still gets the trial nudge. And the funding override: a funded company that asks for a demo gets a demo, not a self-serve brush-off.

**Generalization.** Ten placeholders, all declared and all used (checked mechanically). Gone: channel IDs, stage IDs, `${skill:...}` references, tool names, employee names, the Gold/Silver/Bronze tier names, the trial URL, and the dated "Ariel, Aug 2026" attributions — the rules stayed, the datestamps didn't. Thresholds survive as tunable defaults (`{{SELF_SERVE_FLOOR}}` under 50 employees, `{{FUNDED_OVERRIDE}}` 30 + $10M) with a calibration section in the checklist.

**One deliberate behavior change.** The org original auto-sends both emails. This version defaults to queued-for-approval, with the checklist covering when and how to flip it — the marketplace rail for anything that sends.

`node tools/validate.mjs` → ok, 334 skills across 66 creators.

@idogoldd — my PR, so it needs your approve.