### PR TITLE
author.md template: drop the hedge on the email field

### DIFF
--- a/templates/author.md
+++ b/templates/author.md
@@ -4,7 +4,7 @@ avatarUrl: https://…            # optional: a real PHOTO OF YOU — headshot, 
 title: Role, Company            # e.g. "Head of Growth, Acme"
 linkedinUrl: https://www.linkedin.com/in/…   # YOUR OWN profile — required. Not a company or product page. This is how maintainers verify you.
 companyDomain: example.com
-email: you@company.com          # required — how maintainers reach you about your skills; use a work address you're OK having public (this repo is open)
+email: you@company.com          # required — how maintainers reach you about your skills
 ---
 
 Two to four sentences about who you are and what kind of GTM work your skills encode, written person-first ("I built…" / "Jane built…", not "Acme is…"). Claims should be verifiable on your site, LinkedIn, or press — maintainers check. This is your public bio. (The file lives at skills/<your-slug>/author.md — the directory name is your permanent creator slug; there is no slug field.)


### PR DESCRIPTION
Narrowed. The validator work this PR originally carried duplicates **#69**, which has been open since 7 August, is still MERGEABLE, and does strictly more (requires `linkedinUrl` as a personal profile, plus `companyDomain` and a category whitelist, and backfills the five author files that were missing fields). **Merge #69 for the enforcement**; this PR is now only a one-line template wording change so the two do not conflict in `validate.mjs`.

Removes "use a work address you're OK having public (this repo is open)" from the `email:` line. A personal address is fine, and the caveat only invited people to skip the field.

`node tools/validate.mjs`: 333 skills across 66 creators, passing.