### PR TITLE
add closed-lost-revival by rutger-katz

### DIFF
--- a/skills/rutger-katz/closed-lost-revival/SKILL.md
+++ b/skills/rutger-katz/closed-lost-revival/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: "closed-lost-revival"
+title: Closed-lost revival
+description: "Run a quarterly revival sweep over the pipeline you already paid for: closed-lost deals, proposals that went quiet, champions who changed jobs, and engaged contacts who went silent. Triggers on 'closed-lost,' 'win-back,' 'revive dead deals,' 'they ghosted us,' 'gone quiet,' 'lost the deal, what now,' 'reactivation campaign,' 're-engage old pipeline,' 'proposal never answered,' 'dormant accounts,' or any situation where a team is buying new leads while a warehouse of once-interested accounts sits untouched. The skill gates hard: it revives accounts that engaged and then went quiet, never cold contacts that ignored you from day one. BOUNDARY: the won side of the same idea (turning wins into lookalike prospecting) is a separate play; a standing champion-move monitor detects movers continuously, while this skill only consumes verified moves inside a quarterly campaign; live threads still inside an active cadence (under 60 days of silence) are patience, not revival."
+category: Outreach
+---
+
+# Closed-Lost Revival: The Pipeline You Already Paid For
+
+Average B2B win rates run 20-21%, and the 2025 Ebsta x Pavilion benchmark measured 19%, down from 29% the year before. Read that from the other side: roughly four of five opportunities you worked end closed-lost. That pool compounds every year, it already knows you, and in most CRMs nobody owns it. Revival is not a heroic save. It is working an asset you already paid to create.
+
+One practitioner data point for what disciplined revival produces: Swan AI publicly documented $250K of pipeline in seven days from a pool of 566 closed-lost deals, after adding one step, loss categorization, to a re-engagement agent (public LinkedIn post, August 2026). The step that made the difference is built into this skill as the loss-pattern library.
+
+**The prime rule: revive engaged-then-quiet, never cold-never-replied.** A contact who never engaged is not dormant pipeline, they are a stranger with your logo in their inbox. Revival applies only to accounts that showed real interest and then disengaged. Everything else routes back to normal prospecting.
+
+---
+
+## The Three Revival Lanes
+
+Every sweep audits three lanes. Each lane has hard gates (skip immediately), evidence requirements (before any draft), and an opener posture.
+
+### Lane A: Closed-Lost Deals and Proposal-Gone-Quiet
+
+The highest-value lane. Post-proposal win rates run 31-50% (Norwest, 2024): a buyer who reached proposal stage was more likely to buy than not. When that thread dies silently, more value evaporates than anywhere else in the funnel.
+
+**Hard gates:**
+- Marked Do Not Contact or equivalent: skip entirely.
+- Peers, advisors, partners, or friendly industry contacts: skip. They never ride a sales cadence.
+- Cold-never-replied: not revival material. Dead is dead.
+- Lost to a fundamental mismatch (wrong ICP, product genuinely cannot do the job): skip. Revival cannot fix a fit problem.
+
+**Evidence required before drafting:**
+- Closed-lost: the deal closed 6-18 months ago (the reactivation sweet spot; objections resolve, budgets reset, sponsors rotate). Pull the original objection, the last contact date, and who owned the relationship.
+- Proposal-gone-quiet: demo or proposal sent 60-120 days ago, no response, contact still at the same company. Pull the exact date and what the proposal promised.
+
+**Opener posture:**
+- Lead with the specific objection from the first cycle, never generic win-back language: "When we last spoke, you flagged [exact objection]. Since then, [concrete change]."
+- Never "just checking in," never "touching base," and no reassurance hedges ("no pressure," "no agenda," "either way"). Sophisticated buyers know you are selling; hedging reads as weakness.
+- Ask for a specific outcome, not permission: "Worth 15 minutes to see if the landscape changed?" beats "Would you be open to reconnecting?"
+
+### Lane B: Champion Job Changes
+
+Roughly 20% of your past champions change jobs in any given year (industry estimates from job-change tracking vendors; Swan AI cites the same rate in production, 2026). Each verified move is a warm door into an account you have never touched.
+
+**Hard gates:**
+- The champion must have realized value at the origin account: the deal closed won, or they were a materially active user who drove workflows. A named contact on a lost deal is warm familiarity, not a champion. Skip.
+- Origin company declined you within the last 90 days: the champion is leaving a company that just said no. Not a buying signal. Skip.
+- New company is a competitor or a standing exclusion: log it, no outreach.
+- New company is below your minimum viable size: a personal note from the old relationship owner at most, never a sales motion.
+- Moved into advisor, fractional, or board roles: classify as a partner conversation, not a deal.
+
+**Evidence required before drafting:**
+- Live verification of current employment. Cached enrichment data lags exactly where movers happen. Read the full profile, not the headline.
+- Wrong-person guard (hard rule): the destination profile's own work history must contain the origin company. A name-and-company match alone is never sufficient.
+- Capture the move month. The outreach window is days 14-45 in the new role. Day 2 they are drowning; month 4 the "new broom" energy is spent.
+
+**Opener posture:**
+- Reference the prior relationship in terms of what THEY did with your product, not what you did for them.
+- No diagnosis in the first message ("I bet you're dealing with...") and no stock congratulations. Name the specific reason their move makes this relevant.
+
+### Lane C: Engaged-Then-Quiet Threads
+
+**Hard gates:**
+- Last real exchange 60+ days ago. Under 60 days is an active cadence problem, not revival.
+- Real engagement happened: a substantive reply, an attended meeting, a genuine conversation. One-way sends do not count.
+- Contact still at the same company (if moved, re-route to Lane B) and account still fits ICP.
+
+**Evidence required before drafting:**
+- Pull the last message, its date, and the last open question in the thread.
+- Classify the silence: GHOSTED (interest then disappearance), OBJECTION-PENDING ("let us think" then nothing), TIMING-MISS ("circle back after [event]" that never happened), or CHANGED-LANDSCAPE (reorg, freeze, role change mid-conversation). The class determines the opener.
+
+**Opener posture:**
+- Acknowledge the gap briefly, never apologize for it, and anchor on their last question: "You asked about [specific thing]. Here is what changed since."
+
+---
+
+## The Loss-Pattern Library
+
+The step that turns revival from a one-off campaign into a compounding system. Before drafting anything for a Lane A account, name the loss pattern:
+
+1. Match the account against your existing loss categories (examples that recur across B2B: budget-cycle timing, champion departed mid-deal, chose competitor on one capability, trial launched at the wrong moment, sponsor lacked authority, price-to-value gap at the proposed scope).
+2. If it matches, pull the revival play that already worked for that category.
+3. If it matches nothing, create a new category, define its play, and file this account as the first worked example.
+
+Treating 500 losses as 500 unique investigations gives you zero leverage; account #10 learns nothing from the nine before it. With a library, most losses drop into a shape you have already solved, and only genuinely new patterns need original thought.
+
+---
+
+## Campaign Compression Rules
+
+A sweep produces ONE campaign package per quarter, not a drip of ad-hoc sends.
+
+1. Audit all three lanes with the hard gates. Only survivors advance.
+2. De-duplicate across lanes: the same human appearing twice (a champion mover from a closed-lost account) gets one thread, not two.
+3. Rank by signal strength and freshness: champion movers first, then proposal-gone-quiet, then engaged-then-quiet, then old closed-lost. Apply recency decay within each lane.
+4. **Cap at 5-15 accounts.** If 20+ survive, take the top 15. If fewer than 5 survive, ship fewer. Never pad with weak accounts: quality per touch is the entire economics of revival, because each account gets exactly one credible re-open per cycle.
+5. Every account carries a one-line premise anchored in dated evidence: "Closed-lost Nov 2024, objection was integration depth; they posted an integration-engineer opening last week." If the premise cannot cite a date, it does not ship.
+
+**The current-offer rule.** Revival reaches people who went quiet months or years ago. Whatever they were offered then is often retired. Every draft converges on what you are CURRENTLY selling or sharing, and where the old asset was superseded, bridge it explicitly ("that assessment became something sharper") rather than re-pitching the dead version or pretending the first cycle never happened. The dated trigger opens the message; the current offer carries the ask.
+
+**Quarterly cadence is intentional.** Monthly sweeps drain the pool and catch movers too early (the best movers have been in role long enough to hit a real problem). Quarterly spacing also lets budgets reset and objections age out. Resist the urge to accelerate just because candidates accumulate.
+
+---
+
+## Human Approval Contract
+
+Revival touches people with history, where a clumsy message burns the one re-open you get.
+
+- Every draft goes to a human review queue with its lane, premise, evidence, and a NEXT-TOUCH date. Nothing sends autonomously.
+- NEXT-TOUCH discipline: closed-lost 7 days, champion movers 10 days (they are busy, give them room), engaged-then-quiet 14 days. One follow-up. No reply by then: the account moves to passive nurture until a fresh signal fires. Revival is one knock, not a new cadence.
+- Log every shipped cohort and its outcomes. Quarter-over-quarter reply and conversion rates per lane are how you learn which lanes deserve more of the 15 slots.
+
+---
+
+## What good looks like
+
+- Every shipped account carries a one-line premise anchored in a dated trigger. If the premise cannot cite a date, it does not ship, and nobody argues about this anymore.
+- The quarterly package is 5-15 accounts, deduplicated across lanes and ranked by signal freshness. The kill list is longer than the send list; that ratio is the health check.
+- Lane B movers are verified live against the destination profile's own work history, and contacted in the day 14-45 window, not the week the alert fired.
+- Openers name the original objection or the last open question. Zero "just checking in", zero reassurance hedges, and the CURRENT offer carries the ask, never the retired one.
+- One knock, one follow-up on its NEXT-TOUCH date, then passive nurture. Revival never quietly becomes a new cadence.
+- The loss-pattern library compounds: by the third sweep, most Lane A accounts match an existing category and inherit a play that already worked.
+- Reply and conversion rates per lane, quarter over quarter, decide how next quarter's 15 slots are allocated.
+
+## Diagnostic Questions
+
+Run these before the first sweep; they usually expose the opportunity in minutes.
+
+1. How many closed-lost deals sit in the CRM from 6-18 months ago, and does anyone own them today?
+2. What percentage of your proposals from the last two quarters received a final answer, even a no?
+3. Can you name the last three champions who left customer accounts, and where they work now?
+4. What are your top five loss reasons as WRITTEN IN THE CRM, and do you believe them? (Loss-reason fields are usually fiction; transcripts and email threads are the evidence.)
+5. When someone re-engages a dead account today, do they know the original objection, or are they opening cold with worse odds?
+
+
+## Benchmarks Referenced
+
+Full provenance, vintages, and the list of practice-based rules: read `references/revival-benchmarks.md`.
+
+- Average B2B win rate 20-21%; 19% measured for 2025 (Ebsta x Pavilion benchmark, 2025; prior year 29%). The complement is the size of the closed-lost pool.
+- Post-proposal win rates 31-50% (Norwest, 2024): the case for the proposal-gone-quiet lane.
+- ~20% of champions change jobs per year (job-change vendor estimates, 2023-2026, consistent with Swan AI's published production rate, 2026).
+- $250K pipeline in 7 days from 566 closed-lost deals once loss categorization was added (Swan AI, public post, August 2026). A practitioner anecdote, not a controlled benchmark; treat as an existence proof.

--- a/skills/rutger-katz/closed-lost-revival/references/revival-benchmarks.md
+++ b/skills/rutger-katz/closed-lost-revival/references/revival-benchmarks.md
@@ -1,0 +1,27 @@
+# Revival Benchmarks: Provenance and How the Skill Uses Them
+
+Every number in the skill carries a source and a vintage. Win rates moved sharply between 2024 and 2025, so vintage is load-bearing; recalibrate against current-year data where you have it.
+
+## Win rates and the size of the closed-lost pool
+
+- Average B2B win rate 20-21%; the 2025 Ebsta x Pavilion benchmark measured 19%, down from 29% in 2024 (Ebsta x Pavilion B2B Sales Benchmarks, 2025 edition; prior-year figure from the 2024 edition). The skill uses the complement, roughly four of five worked opportunities ending closed-lost, to size the revival pool. It does not predict revival conversion; it establishes that the pool exists and compounds.
+
+## The proposal-gone-quiet lane
+
+- Post-proposal win rates run 31-50% (Norwest Venture Partners benchmark data, 2024). The skill uses this to rank proposal-gone-quiet as the highest-value lane: a buyer at proposal stage was more likely to buy than not, so silent death there loses more expected value than anywhere else in the funnel.
+
+## Champion job changes
+
+- Roughly 20% of past champions change jobs in a given year (estimates published by job-change tracking vendors, 2023-2026; Swan AI cites the same rate for its production sweep, 2026). Used only to size Lane B. The skill deliberately does NOT carry a "champion-sourced deals close at X%" claim: a widely circulated known-contact win-rate statistic failed source verification during drafting and was dropped rather than repeated.
+
+## Practitioner existence proofs (not controlled benchmarks)
+
+- $250K of pipeline in 7 days from 566 closed-lost deals, after adding loss categorization to a re-engagement agent (Swan AI, public LinkedIn post, August 2026). Treat as an existence proof for the loss-pattern library step, not an expected return.
+
+## Practice-based rules (no external study)
+
+Flagged in the skill as practice-based defaults, to be replaced by your own cohort data after two sweeps:
+
+- The 6-18 month closed-lost reactivation window (objections resolve, budgets reset, sponsors rotate).
+- The days-14-45 outreach window for champion movers.
+- The 5-15 account cap per quarterly campaign and the one-knock NEXT-TOUCH discipline (7/10/14 days by lane).


### PR DESCRIPTION
## What this skill does

Quarterly revival sweep over the pipeline you already paid for: closed-lost deals, gone-quiet proposals, champion job changes, and engaged-then-quiet threads, with hard gates, a loss-pattern library, and a 5-15 account campaign cap.

**Test prompt:** We lost about 40 deals last year and our proposals keep going unanswered. Two of our old champions moved companies recently. Build our first quarterly revival sweep: what do we pull from the CRM, which accounts qualify, and what does the campaign package look like?

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally (no problems in `skills/rutger-katz/`; the two pre-existing errors in other folders are untouched)
- [x] First contribution: `author.md` exists from prior PRs, unchanged here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
