### PR TITLE
add qbr-ebr-builder by rutger-katz

### DIFF
--- a/skills/rutger-katz/qbr-ebr-builder/SKILL.md
+++ b/skills/rutger-katz/qbr-ebr-builder/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: "qbr-ebr-builder"
+title: QBR and EBR builder
+description: "Design and build customer business reviews that buyers actually attend: QBR (operational cadence) and EBR (executive cadence), with the value recap in the customer's own numbers as the load-bearing artifact. Triggers on 'QBR,' 'EBR,' 'business review,' 'executive business review,' 'quarterly review deck,' 'prove value to the customer,' 'renewal conversation prep,' 'customer stopped attending reviews,' 'our QBRs are a feature parade,' 'success plan review,' or any situation where post-sale value needs to be demonstrated to the people who pay, not just the people who use. BOUNDARY: account-health scanners produce the internal diagnostic BEFORE the review; this skill builds the customer-facing instrument itself and starts from their output. renewal-save-motion owns the intervention when a review surfaces risk; expansion-revenue-architect owns the motion when it surfaces headroom; this skill hands off to both and runs neither. revenue-operating-cadence owns INTERNAL meeting architecture; a business review is a customer-facing meeting and follows different rules: their agenda, their numbers, their next quarter."
+category: RevOps
+---
+
+# QBR / EBR Builder: Reviews Buyers Attend
+
+Most business reviews die the same death: a slideware feature parade delivered to the daily users while the economic buyer, the person who will decide the renewal, has stopped attending. Then renewal season arrives and the value case gets built in a panic, from scratch, for an audience that has not heard it all year.
+
+A business review exists to do one job: keep the people who PAY convinced of value, in their numbers, on a rhythm, so the renewal is a formality and the expansion conversation has a natural venue. Median gross revenue retention for private SaaS sits around 90% with top quartile above 95% (industry surveys, 2025); the review cadence is one of the few controllable instruments that moves an account from the first group's trajectory to the second's.
+
+**Entry condition:** an internal health read already exists (from an account health audit or health scan). A review built without one is theater; you are presenting to the customer what you have not verified yourself.
+
+---
+
+## QBR vs EBR: Two Instruments, Not One
+
+The single blended "QBR" is where most programs go wrong. Separate the two:
+
+| | QBR (operational) | EBR (executive) |
+|---|---|---|
+| Audience | Daily users, program owner | Economic buyer, executive sponsor |
+| Rhythm | Quarterly (or async for small accounts) | 1-2 per year, anchored 90-120 days before renewal |
+| Question it answers | Is the thing working and used well? | Was this worth the money, and what should it do next? |
+| Content center | Adoption, blockers, roadmap of USE | Value recap in their numbers, strategic alignment, roadmap of OUTCOMES |
+| Failure mode | Feature parade | Skipping it because "the users are happy" |
+
+The EBR anchored ahead of renewal matters because by the time a renewal conversation starts, an unengaged economic buyer has already formed their view from hallway signal. The EBR is where you form it instead.
+
+## Segmentation: Who Gets What
+
+Review effort is a budget; spend it where revenue concentrates.
+
+- **Top tier (largest ARR, expansion headroom, strategic logos):** quarterly QBR + 1-2 EBRs per year, live.
+- **Middle tier:** semi-annual QBR, EBR only when a trigger fires (renewal inside 120 days, risk flag, expansion signal, sponsor change).
+- **Long tail:** no live reviews. A quarterly async value summary (one page, auto-assembled from usage and outcome data, human-reviewed) replaces the meeting. A calendar full of small-account QBRs is how CS teams burn out while GRR falls anyway.
+
+An AI-agent note that changes the old math: assembling the review pack used to be the expensive part, which justified skipping reviews for smaller accounts. When an agent assembles the data pack from usage, CRM, and conversation history, the constraint moves to CUSTOMER attention, not your capacity. Spend the freed capacity on better meetings for the top tier, not more meetings everywhere.
+
+## The Review Architecture: Three Panels
+
+Every review, QBR or EBR, runs the same three-panel spine. Depth differs by audience.
+
+**Panel 1: Look back, in their numbers.** The value recap is the load-bearing artifact of the entire review. Rules:
+- Built from THEIR system data and THEIR baseline, agreed at onboarding or the previous review. If no baseline exists, the first review's job is to install one.
+- Outcomes, not activity: "reduced X by Y since March" beats "487 workflows run" in every room that matters.
+- Quantify honestly, including what did NOT improve. One acknowledged miss buys credibility for every claimed win; a review with no misses reads as marketing.
+- If the value recap cannot be built, that is a finding, not an inconvenience: either instrumentation is missing (fix that) or value is absent (route to the save motion now, not at renewal).
+
+**Panel 2: Current state, honestly.** Adoption depth against plan, open issues with owners and dates, health verdict shared plainly. Do not launder the internal health read into a greener customer-facing version; sophisticated buyers keep their own scorecard, and the gap between yours and theirs is trust lost.
+
+**Panel 3: Look forward, jointly owned.** Next quarter's success plan with the customer's name on half the actions: goals, owners, dates, and the one metric the next review will be judged on. A review that ends without the customer owning actions was a presentation. This panel is also where expansion surfaces naturally: unmet goals plus adjacent problems, raised as THEIR roadmap, not your quota.
+
+## Stakeholder Rules
+
+- The economic buyer attends the EBR, or the EBR moves. Running it without them is rehearsal, not review. Getting them there is the sponsor's job, agreed as part of the success plan, not a calendar surprise.
+- Map attendance drift as a signal: a sponsor who attended two reviews and skips the third just told you something the health score has not caught yet. Feed it to the risk triage.
+- New stakeholder in the room (reorg, new exec): the review restarts at their zero, with a compressed look-back. Assume inherited context of nothing; see the champion-loss pattern in renewal-save-motion.
+
+## Outputs and Routing
+
+A review is upstream instrumentation for the rest of the post-sale system. Every review produces:
+
+1. An updated success plan (Panel 3), dated and shared.
+2. A refreshed baseline for the next value recap.
+3. Routed flags: risk signals to the save motion, expansion signals to the expansion motion, product blockers to product with a feedback loop the customer can see.
+4. A one-paragraph internal verdict on the account: trajectory, sponsor state, one thing to fix before next review.
+
+## Anti-Patterns
+
+- **The feature parade:** roadmap-heavy decks answer a question nobody asked. Roadmap earns 10 minutes of Panel 3, framed by their goals.
+- **The NPS theater:** a survey score is not a value recap. Scores decorate; outcomes convince.
+- **The annual ambush:** the first value conversation happening at renewal is the most expensive scheduling failure in CS. The EBR 90-120 days ahead exists to make renewal week boring.
+- **The unchanged deck:** if the review could be last quarter's deck with new dates, cancel it and send the async summary; you are spending customer attention with no news.
+- **The solo review:** vendor presents, customer receives. Jointly built agendas (send Panel 1 in advance, ask what they want contested) double as engagement signal: an account that will not co-build an agenda is telling you where you stand.
+
+## What good looks like
+
+- QBR and EBR are two instruments with two audiences. The EBR sits 90-120 days before renewal with the economic buyer in the room, or the meeting moves until they are.
+- The value recap is built from the customer's system data against a baseline agreed in advance. No baseline yet: installing one is the first review's whole job. A recap that cannot be built routes the account to the save motion now, not at renewal.
+- Reviews admit misses. The internal health verdict and the customer-facing one are the same verdict, and buyers notice.
+- Every review ends with the customer owning half the actions, dated. A review without customer-owned actions was a presentation, and it gets counted as one.
+- The long tail gets a one-page async value summary instead of a meeting, and the freed capacity buys better top-tier reviews, not more meetings.
+- Attendance drift feeds risk triage: a sponsor who skips their third review has said something no health score caught yet.
+
+## Diagnostic Questions
+
+1. For your top ten accounts: when did the economic buyer last hear the value case, from you, in their numbers? Not the users, the buyer.
+2. Can you produce a value recap with an agreed baseline for your largest renewal due in the next two quarters, today, without a data archaeology project?
+3. What percentage of your last quarter's reviews ended with customer-owned actions that got done?
+4. Which accounts had sponsors stop attending reviews in the last year, and what happened at their renewals? (This one usually settles the argument for the program.)
+5. How many hours does one review pack take to assemble, and is that number the reason your long tail gets no reviews at all?
+
+## Benchmarks and Provenance
+
+GRR median ~90% / top quartile 95%+ (industry surveys, 2025; provenance detail shared with renewal-save-motion's `references/retention-benchmarks.md`). The 90-120 day EBR-before-renewal anchor, the three-panel spine, and the segmentation tiers are practice-based operating rules, labeled as such; validate against your own renewal cohort once two quarters of review discipline exist. Full notes: `references/business-review-practices.md`.

--- a/skills/rutger-katz/qbr-ebr-builder/references/business-review-practices.md
+++ b/skills/rutger-katz/qbr-ebr-builder/references/business-review-practices.md
@@ -1,0 +1,22 @@
+# Business Review Practices: Provenance and Practice-Based Rules
+
+This skill is deliberately light on external benchmarks, because the business-review literature is dominated by vendor content with unverifiable numbers. Rather than launder those, the skill marks its operating rules as practice-based and anchors only retention economics to surveyed data.
+
+## Externally sourced
+
+- Gross revenue retention median ~90% for private B2B SaaS, top quartile above 95% (SaaS industry surveys, 2025). Used to size the stakes of a review program, not to promise its effect. Shared provenance with renewal-save-motion's `references/retention-benchmarks.md`.
+
+## Practice-based rules (no external study; validate against your own cohort)
+
+- The QBR/EBR split by audience and question, and the failure mode of blending them.
+- The EBR anchor 90-120 days before renewal (early enough to act on what surfaces, late enough that the look-forward covers the renewal term).
+- The three-panel spine (look back in their numbers / current state honestly / look forward jointly owned).
+- Segmentation tiers and the async-summary substitution for the long tail.
+- Attendance drift as a leading risk signal ahead of health-score movement.
+- The "one acknowledged miss" credibility rule in value recaps.
+
+How to convert these to measured rules: after two quarters of running the program, compare renewal outcomes and expansion attach for accounts with economic-buyer EBR attendance versus without, and replace the practice-based framing with your own numbers.
+
+## Deliberate non-claims
+
+The skill makes no claim of the form "companies running QBRs retain X% more"; circulating figures of that shape trace to vendor marketing without published methodology, and were excluded under this library's benchmark standard (every number carries a source and a vintage, or it is labeled practice-based, or it is dropped).


### PR DESCRIPTION
## What this skill does

Customer business reviews buyers actually attend: QBR and EBR as separate instruments, a three-panel spine with the value recap in the customer's own numbers as the load-bearing artifact, and segmentation that gives the long tail async summaries instead of meetings.

**Test prompt:** Our QBRs are feature parades, the economic buyers stopped showing up, and our biggest renewal is in five months. Rebuild the review program: split QBR from EBR, design the value recap for that big account, and tell me which of our 60 accounts should get live reviews at all.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally (no problems in `skills/rutger-katz/`; the two pre-existing errors in other folders are untouched)
- [x] First contribution: `author.md` exists from prior PRs, unchanged here
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
