### PR TITLE
reach-out: ban the "worth a…" close, stop opening with the trigger event

### DIFF
--- a/skills/ido-goldberg/reach-out/SKILL.md
+++ b/skills/ido-goldberg/reach-out/SKILL.md
@@ -22,7 +22,7 @@ This table is the org's motion library. It starts seeded and is meant to be edit
 | Someone engaged with a post or profile on LinkedIn | `references/linkedin-engagement.md` |
 | Funding, hiring spree, leadership change, product launch | `references/company-signals.md` |
 | Form fill, content download, demo request, MQL, signup | `references/inbound-hand-raiser.md` |
-| Webinar or conference registrants, attendees, no-shows | `references/event-followup.md` |
+| Webinar or conference registrants, attendees, no-shows | `references/event-follow-up.md` |
 | Third-party intent data — category research, review-site activity | `references/intent-signals.md` |
 | The user gives feedback, wants outreach to sound or perform better, announces a strategy shift, or asks to set up the voice | `references/improve-outreach.md` |
 
@@ -38,7 +38,7 @@ Nothing recorded yet. Org-wide rules from user feedback live here, one do/don't 
 
 Every message needs a reason it goes to this person now. Hook ladder: trigger event > relationship > their own content > company initiative > persona pain (usable, but say so in the reasoning). No hook → push back before drafting. NEVER invent a signal.
 
-The hook informs the angle; it rarely appears in the copy. Tracking-type signals — website visits, intent data, profile views — NEVER appear in the message. Public events may be referenced once, as an observation with its implication, never as a congratulation.
+The hook informs the angle; it rarely appears in the copy. Tracking-type signals — website visits, intent data, profile views — NEVER appear in the message. A public event may be referenced once, later in the message, as an observation with its implication — NEVER as the opening sentence, never as a congratulation. Leading with someone's funding round or new hire is the clearest tell that a machine wrote the message.
 
 ### Voice
 
@@ -46,9 +46,10 @@ Approved sends accumulate automatically as style examples. Examples carry the vo
 
 ### Draft
 
-- Opener: the hook's implication, in the contact's frame. One sentence.
-- Body: one researched detail max, reacted to rather than exhibited. One proof point max — attributed, sized to the company. Never a feature list, never an invented customer or stat.
-- CTA: one ask. Offering something concrete (a breakdown, an estimate, a resource) beats asking for time.
+- Opener, email: the hook's implication, in the contact's frame. One sentence. The event or signal itself never opens the message.
+- Opener, LinkedIn: say who you are and what you want in the first line. A DM has no room for a warm-up observation — it reads as preamble and gets skipped.
+- Body: one researched detail max, reacted to rather than exhibited. One proof point max — attributed, sized to the company. Never a feature list, never an invented customer or stat. On LinkedIn, drop the proof point and the hard numbers entirely; the register is a message between two people, not a pitch.
+- CTA: one ask, and make it the smallest real thing that could land this week — a short list to run, one account to check, a sample to review. Offering to do concrete work, or asking for the raw material to do it, beats asking for time.
 - Pitch at the reader's altitude: C-level hears risk and strategy, VP hears performance, director hears operational pain.
 - Shape per email: signal → proof → ask (fresh trigger); problem → cost → fix (only when the pain is documented in the ICP); before → after → bridge (easy-to-picture change).
 - Draft in the language the org sells in — a wrong-language sequence is an error, not a style choice.
@@ -62,10 +63,12 @@ The org's recorded cadence always wins; default: 3–5 steps, days ~0/3/7/14, si
 Run on every message before staging; a failed check means rewrite, not tweak:
 
 1. Delete the opener — still makes sense? The personalization is decoration; rebuild around the hook.
-2. Could this go to anyone else this week? Then it's a blast in costume.
-3. One CTA. 60–110 words, follow-ups shorter. Subject 2–5 words, lowercase, internal-looking. More "you" than "I/we".
-4. Is the proof a number or a name? "Helps teams like yours" is not proof.
-5. Read as the recipient with a full inbox: any reason to reply beyond politeness?
+2. Does the close contain the word "worth"? Rewrite it. "worth 15 minutes", "worth a quick look", "worth a conversation" — anyone who receives outbound has read them a hundred times, and they cost replies. Ask for the thing itself instead.
+3. Does sentence one name a funding round, a launch, a hire, or any other event? Rewrite — open with what it means for them, not with the news.
+4. Could this go to anyone else this week? Then it's a blast in costume.
+5. One CTA. 60–110 words, follow-ups shorter. Subject 2–5 words, lowercase, internal-looking. More "you" than "I/we".
+6. Email: is the proof a number or a name? "Helps teams like yours" is not proof.
+7. Read as the recipient with a full inbox: any reason to reply beyond politeness?
 
 ### Stage
 

--- a/skills/ido-goldberg/reach-out/references/company-signals.md
+++ b/skills/ido-goldberg/reach-out/references/company-signals.md
@@ -23,7 +23,7 @@ The event is public; everyone selling to this company saw it. And "congrats on t
 ## Don't
 
 - Don't congratulate. At most one clause of acknowledgment; the message is about the consequence.
-- Don't open with "I noticed" or "I saw that" — state the observation directly, or skip to its implication.
+- Don't open with the event. Not "I noticed", not "I saw that", and not the event stated plainly either — sentence one is the consequence. An event-led opening line is the single most reliable way to get ignored.
 - Don't stack events. A company that raised, hired, and launched gets one consequence — the sharpest.
 - Don't recycle the same event-template across a list; the market hears every "congrats on the Series B" template within a quarter.
 - Don't use an event as a costume for a pitch that was going out anyway — if the consequence doesn't connect to what the org actually solves, the signal isn't a hook.


### PR DESCRIPTION
Three copy rules in `reach-out`, changed off measured reply data rather than instinct.

## Where the numbers come from

63,372 cold agent-written first touches over 90 days (active paid orgs, email + LinkedIn), with all 4,149 replies read and scored for sentiment. **Every comparison is within-org** — an org only counts when it sent both versions — so this measures the copy, not which customers happen to be good at outbound. That control mattered: it killed one of the three findings I started with.

| Change | Effect | p | orgs | direction |
|---|---|---|---|---|
| Drop `"worth…"` from the close — email | OR **1.49** | .010 | 58 | better in 27/58 |
| Drop `"worth…"` from the close — LinkedIn | OR **1.57** | .008 | 14 | better in 9/14 |
| Don't open with the trigger event — email | OR **0.28** | .003 | 30 | worse in **30/30** |
| Self-intro over observation opener — LinkedIn | OR **1.66** | .004 | 5 | better in 4/5 |
| Self-intro over observation opener — email | OR 1.05 | .87 | 36 | no effect |
| Named customer proof — LinkedIn | OR **0.36** | .009 | 6 | worse in 5/6 |
| Numbers in the body — LinkedIn | OR **0.44** | .006 | 4 | worse in 4/4 |

## What changed

**1. `"worth"` is now a hard fail in the final gate.** "worth 15 minutes", "worth a quick look", "worth a conversation" — we ship these ~20,000 times a quarter across a handful of interchangeable variants, and they measurably cost replies on both channels. It isn't that asking for a meeting is wrong; a plain "does it make sense to talk this week?" does fine. It's this phrasing. The gate now sends it back with a replacement rule: ask for the smallest real thing that could arrive this week — a short list to run, one account to check, a sample to review.

**2. The trigger event never opens the message.** The skill already said the hook informs the angle and rarely appears in the copy. This makes it check #3 in the gate, and tightens `references/company-signals.md`, which previously said "state the observation directly" — that permitted exactly the losing pattern. This is the most robust result in the set: not one org out of 30 does better with an event-led opener.

**3. Opener guidance splits by channel.** On LinkedIn, say who you are and what you want in the first line, and drop the proof point and hard numbers — all three measured positive-to-strongly-positive there. On email, an observation opener is fine; the raw advantage for self-intro on email turned out to be entirely org confounding, so that rule stays where it was.

Also fixes a dead pointer in the motion table — `references/event-followup.md` → `references/event-follow-up.md`, the actual filename.

## Not changed, deliberately

- The **micro-ask** ("want to send me a short contact list?") is the most promising shape in the data — OR 1.70 over a `"worth…"` close — but p=.20 on only 316 sends out of 63,372. Encouraged in the CTA rule, not mandated, until there's volume behind it.
- **Length.** A previous analysis called brevity a decisive lever; once org-controlled it's OR 1.20 email (p=.47) and 1.03 LinkedIn (p=.97). The word limits stay because they're free, but they aren't where the leverage is.

## Caveats

Observational, not causal. Email positives are rare (1.1% baseline), so email findings rest on a few hundred positives; several LinkedIn results lean on 5–6 orgs. Features are regex-derived and reply sentiment is model-scored without a human audit. The clean way to settle the `"worth"` question is a two-week holdout.

`node tools/validate.mjs` → ok, 333 skills across 66 creators, all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)