### PR TITLE
rutger-katz: listing repositioning for 10 skills (stacked on #131)

### DIFF
--- a/skills/rutger-katz/abm-engagement-scoring/SKILL.md
+++ b/skills/rutger-katz/abm-engagement-scoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "abm-engagement-scoring"
-title: ABM engagement scoring
-description: "Account-level engagement scoring, buying group/DMU measurement, and marketing-to-sales handover triggers for account-based marketing programs (50-500 named accounts). Use when the user mentions account engagement score, ABM measurement, buying committee, DMU coverage, account stage progression, engagement triggering sales handover, multiple stakeholder tracking, account qualification, or ABM program measurement. Also trigger on 'how do we measure ABM success,' 'which accounts are hot,' 'do we have the buying group,' 'when do we hand this to sales,' 'account engagement scoring model,' or 'we run ABM but can't prove ROI.' BOUNDARY: Covers account-level engagement scoring, buying group measurement, and handover-to-sales triggers in ABM contexts. For lead-level scoring (fit + engagement dual-axis), see marketing-operations. For account selection and ICP methodology, see icp-builder. For sales speed-to-lead and routing, see lead-routing."
+title: Measure ABM engagement and hand accounts to sales
+description: "Use this skill when an ABM program cannot prove engagement matters, accounts get handed to sales on gut feel, or nobody knows which activity moves buying groups forward. Builds an account engagement score (weighted signals plus decay), maps buying group coverage across the decision-making unit, and defines explicit handover gates so marketing and sales agree on readiness. Produces a scoring model, a buying group tracker template, and a handover decision rule. Rule: without buying group visibility a high engagement score is a false positive; handover requires both the score and the coverage threshold met. Trigger phrases: ABM measurement, which accounts are hot, buying committee coverage, when do we hand this to sales, account engagement score, ABM ROI."
 category: ABM
 ---
 
@@ -578,5 +578,12 @@ For ABM measurement buildout:
 Use in: ABM program inception, measurement system buildout, monthly cadence reporting.
 
 Original source: Practitioner scenario documented for 200-account enterprise ABM TAM (2026).
+
+## What good looks like
+
+- Engagement is scored at account level with signal weights and decay, not summed lead activity.
+- Buying group coverage is tracked per account against a target per role.
+- Handover to sales fires on an explicit gate combining score and coverage, and sales accepts the definition.
+- The program reports account movement, not activity volume.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/cs-operations/SKILL.md
+++ b/skills/rutger-katz/cs-operations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cs-operations"
-title: Customer success operations
-description: "Customer success operations for B2B SaaS. The post-sale revenue engine that prevents churn, drives expansion, and compounds customer value. Use when the user mentions customer success, CS ops, health scoring, renewal management, churn prevention, expansion playbook, expansion signals, onboarding orchestration, time to first value, QBR, customer segmentation, coverage model, high-touch, low-touch, tech-touch, CSM ratios, NPS, CSAT, save plays, red accounts, CS-Sales handoff, churn autopsy, renewal discount governance, discount sunset, renewal pricing, or save plays with pricing components. Also trigger when someone says 'we keep losing customers' or 'our CS team is reactive' or 'we have no idea which accounts will churn' or 'discounts are expiring and customers are pushing back' or 'renewal price increase resistance.'"
+title: Red account rescue
+description: "Save churning customers through proactive health scoring and recovery plays. Use when red accounts pile up unpredictably, renewal conversations turn contentious, or expansion-ready accounts slip away. Builds a 5-dimension health score (product usage, relationship quality, support friction, commercial trends, outcomes) updated weekly, triages red accounts into rescue mode or renewal-risk mode, and activates save plays with executive sponsorship, backed by the full post-sale operating model (onboarding, QBRs, CS-Sales handoffs, renewal governance). Produces a weekly red-account triage list and recovery playbooks by churn cause. Rule: a customer does not turn red on one signal; red means 3 or more health dimensions breaking at once. Trigger phrases: we keep losing customers, red accounts, health scoring, save play, churn autopsy, renewal price increase resistance."
 category: RevOps
 ---
 
@@ -394,5 +394,12 @@ QBRs are the highest-leverage CS touchpoint for T1 accounts and most fail by loo
 ## Operator Templates: Forecasting Worksheet (Renewals Tab)
 
 Use a forecasting worksheet with dedicated renewal modeling tabs to model: renewal cohort sizing, churn impact on ARR, expansion uplift scenarios.
+
+## What good looks like
+
+- Every account carries a health score across five dimensions, refreshed weekly.
+- Red accounts surface on a triage list with an owner and a named recovery play before the renewal window opens.
+- Renewal conversations start from documented value evidence, not a pricing surprise.
+- Churn postmortems feed a playbook per churn cause instead of anecdotes.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/data-enrichment/SKILL.md
+++ b/skills/rutger-katz/data-enrichment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "data-enrichment"
-title: Data enrichment
-description: "B2B data enrichment strategy, provider evaluation, integration patterns, and quality management for revenue operations teams. Use when the user mentions data enrichment, lead enrichment, account enrichment, contact enrichment, ZoomInfo, HubSpot Data Platform, Apollo, Clay, Cognism, Lusha, enrichment automation, enrichment workflows, firmographic data, technographic data, intent data, data append, enrichment API, enrichment coverage, data freshness, enrichment quality, or third-party data providers. Also trigger on 'our data is incomplete,' 'leads come in with no company info,' 'we need better data on our accounts,' 'enrichment isn't working,' or 'which enrichment tool should we use.' BOUNDARY: Covers enrichment STRATEGY, PROVIDER SELECTION, and INTEGRATION. For CRM-specific implementation, see revops-hubspot or revops-salesforce. For data governance, see revops-data-governance. For lead scoring that uses enriched data, see marketing-operations."
+title: Choose an enrichment provider and build a waterfall
+description: "Use this skill when inbound leads arrive incomplete (missing company size, industry, revenue), the TAM list lacks data for scoring, or the CRM cannot route and segment without enrichment. Maps coverage gaps, compares single-source and waterfall provider strategies, and builds an integration roadmap with cost guardrails and quality gates. Produces a provider recommendation matrix, a waterfall architecture, and a go or no-go checklist. Rule: no single provider has full coverage; a waterfall across two or more providers in sequence beats any one source on match rate. Trigger phrases: data enrichment, leads come in with no company info, enrichment coverage, firmographic data, which enrichment tool, data freshness."
 category: RevOps
 ---
 
@@ -343,5 +343,12 @@ Always build a failed-enrichment queue:
 - **Waterfall match rates**: Clay independent testing: 78% email match (vs 42% Apollo alone, 38% Hunter alone). BetterContact with 20+ sources: 85-95%. Single provider alone: 35-52%.
 - **Cognism accuracy**: 97% accuracy guarantee; verified emails >93% deliverability; Diamond Data phone: 98% phone-verified. Stronger in EMEA; US/APAC data quality variable. (cognism.com/our-data)
 - **Testing your providers**: No published methodology can replace a pilot with your actual data. Database composition, geography, industry, and company size all affect match rates dramatically. Before committing budget, run a 30-day trial enrichment against a sample of 100-500 records from your actual pipeline. Track match rate, field coverage, and cost per match.
+
+## What good looks like
+
+- Coverage gaps are quantified per field before any provider contract is signed.
+- Providers run in a waterfall sequence with match rate and cost tracked per step.
+- Enriched data lands with freshness targets and a re-enrichment schedule.
+- The go or no-go checklist blocks enrichment spend on segments that cannot use the data.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/deal-desk-operations/SKILL.md
+++ b/skills/rutger-katz/deal-desk-operations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "deal-desk-operations"
-title: Deal desk operations
-description: "Deal desk as a RevOps-owned function: when to stand one up, approval matrix design, discount governance and non-standard terms, quote review workflows, pricing economics for consumption and outcome-based deals, renewal negotiation governance, and maturity progression from ad-hoc approvals to strategic desk. Use when the user mentions deal desk, approval matrix, discount governance, quote SLAs, non-standard terms, pricing exceptions, deal desk ROI, approval velocity, discount leakage, or centralising deal approval authority. Also trigger on \"our reps have too much authority\", \"discounts are all over the place\", \"deals are stalled in approval\", \"we need guardrails on pricing\", \"custom pricing is a bottleneck\", or \"how do we control margin erosion\"."
+title: Discount governance and approval system
+description: "Use this skill when reps hold too much pricing authority, discounts spiral by region, or approval bottlenecks stall deals. Builds the approval matrix by discount depth and deal size, SLA-backed quote workflows, and strategic override lanes that separate noise from genuine exceptions. Produces a matrix routing small discounts to reps, large discounts to leadership and non-standard terms to the deal desk, a three-stage quote process with 24 to 48 hour SLAs, and a 30-day audit loop on exceptions. Rule: if a rep can approve a discount without understanding the margin impact, the approval matrix is too loose. Trigger phrases: discount governance, approval matrix, pricing exceptions, deals stalled in approval, margin erosion, quote SLAs."
 category: RevOps
 ---
 
@@ -265,3 +265,10 @@ Build this over 12-24 months as volume and complexity justify investment.
 ## References
 
 See `references/benchmarks-sourced.md` for full sourcing on all quantitative claims in this skill.
+
+## What good looks like
+
+- Discount approval routes by depth and deal size, and everyone can name their own authority.
+- Quotes clear each review stage inside the SLA, and exceptions carry a written rationale.
+- Exception patterns are audited monthly and recurring ones become policy.
+- Margin impact is visible at approval time, not after close.

--- a/skills/rutger-katz/deal-velocity-engineer/SKILL.md
+++ b/skills/rutger-katz/deal-velocity-engineer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "deal-velocity-engineer"
-title: Deal velocity engineering
-description: "Diagnose and fix deal velocity problems. Sales cycle diagnostics, stage exit criteria, pipeline deflation, zombie deal elimination, multi-threading, mutual action plans, AI-driven deal scoring, revenue intelligence integration (Gong/Chorus), and compression tactics with sourced benchmarks. Trigger on 'deal velocity,' 'sales cycle too long,' 'deals stalling,' 'pipeline velocity,' 'stage exit criteria,' 'zombie deals,' 'pipeline deflation,' 'deals stuck,' 'multi-threading,' 'mutual action plan,' 'deal inspection,' 'pipeline hygiene,' 'cycle time,' 'stage conversion,' 'deals die in negotiation,' 'we keep slipping deals,' 'reps can't close,' or 'pipeline is bloated but nothing closes.' Connects stage gates, deal scoring, inspection cadence, and pipeline deflation into the operating cadence. Includes modern AI/automation patterns (HubSpot Breeze, Salesforce Agentforce, predictive pipeline management). BOUNDARY: For forecast methodology see revops-forecasting. For pipeline visibility and dashboards see pipeline-visibility. For sales methodology (SPICED/MEDDPICC) see sales-methodology. For operating cadence see revenue-operating-cadence."
+title: Sales cycle compression
+description: "Compress sales cycles through stage-gate enforcement and pipeline deflation. Use when deals stall at specific stages, cycles exceed segment benchmarks, or zombie deals inflate the pipeline. Diagnoses the binding constraint (qualification, stage progression, or volume), builds stage exit criteria mapped to buyer actions rather than seller activities, and establishes zombie detection to deflate stale deals. Produces a velocity diagnostic with benchmarked targets and a stage-gate implementation blueprint. Rule: if a deal cannot advance without meeting stage exit criteria, the system is the constraint, not the rep. Trigger phrases: deal velocity, sales cycle too long, deals stalling, zombie deals, stage exit criteria, pipeline is bloated but nothing closes."
 category: RevOps
 ---
 
@@ -421,5 +421,12 @@ Forecast accuracy is a velocity output, not a separate problem. Fix stage defini
 - **pipeline-visibility**: Pipeline dashboards that surface velocity data
 - **sales-methodology**: SPICED and MEDDPICC frameworks that stage gates enforce
 - **revops-handoffs**: Handoff mechanics that affect stage transition speed
+
+## What good looks like
+
+- Every pipeline stage has exit criteria phrased as buyer actions, and deals cannot advance without them.
+- Stale deals get flagged and deflated on a fixed cadence instead of inflating coverage.
+- Cycle time is tracked per segment against a benchmarked target, and the binding constraint is named.
+- Pipeline reviews inspect evidence for stage placement, not rep optimism.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/pricing-monetisation-ops/SKILL.md
+++ b/skills/rutger-katz/pricing-monetisation-ops/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: "pricing-monetisation-ops"
-title: Pricing and monetisation ops
-description: "Pricing and monetization operations for B2B SaaS: designing, implementing, and operating consumption-based and outcome-based pricing models; metering architecture with deduplication and customer mapping; billing system integration for usage, overages, and variable revenue; hybrid contract structures (minimums, ramps, credits); monthly reconciliation and drift detection; revenue recognition for variable contracts; pricing-tier migrations from per-seat to usage without breaking revenue reporting; packaging changes and price increases across renewal cohorts; CPQ and billing platform selection; billing data quality audits. Use when discussing metering infrastructure, consumption billing, hybrid pricing models, variable revenue, price migrations, quote-to-cash consolidation, billing-grade data quality, or revenue reconciliation. Trigger phrases: metering, deduplication, usage billing, consumption pricing, hybrid pricing, price migration, overages, minimums, CPQ platform, billing reconciliation, variable revenue, outcome-based pricing. Also triggers on 'we need to move from per-seat to usage,' 'our billing system can't handle variable revenue,' 'revenue recognition is a nightmare,' or 'we're losing customers on bill shock.'"
-category: Pricing
+title: Consumption billing and revenue operations
+description: "Use this skill when bill shock is killing renewal cohorts, a consumption model breaks revenue recognition, or metering and billing are out of sync. Builds the operational layers: metering (ingestion, deduplication, customer mapping), rating and pricing engines (tiers, overages, minimums, credits), invoicing with audit trails, collections logic, and revenue reconciliation for variable contracts. Produces a data-quality audit of metering leaks, a quote-to-cash integration map, a per-seat-to-usage migration plan that does not break revenue reporting, and an ASC 606 compliance checklist. Rule: consumption pricing is only as good as its metering, billing and reconciliation plumbing; one broken layer breaks them all. Trigger phrases: usage billing, bill shock, metering, price migration, overages, billing reconciliation, variable revenue."
+category: RevOps
 ---
 
 # Pricing and Monetization Operations
@@ -556,5 +556,12 @@ Run the Billing Data Quality Audit. Which check fails worst? Start there. Usuall
 - Normative estimates on revenue recognition complexity: Based on practice patterns across 5,000+ consumption contracts per customer. Re-estimation required monthly for ASC 606 compliance.
 
 See also: `references/benchmarks-sourced.md` for detailed sourcing on all quantitative claims.
+
+## What good looks like
+
+- Usage events are metered once, mapped to the right customer, and reconciled monthly against billed revenue.
+- Overage, minimum and credit terms in contracts match what the billing system can execute.
+- A per-seat-to-usage migration runs without breaking revenue reporting or triggering bill shock.
+- Revenue recognition for variable contracts survives an audit.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/revops-data-governance/SKILL.md
+++ b/skills/rutger-katz/revops-data-governance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "revops-data-governance"
-title: Revenue data governance
-description: "Revenue data governance: the operational discipline every other RevOps skill depends on. Use when the user mentions data governance, data quality, data model, data architecture, field governance, property naming conventions, data hygiene, deduplication, integration data flows, system of record, sync rules, data enrichment, data definitions, one vision of truth, data spine, data quality scoring, validation rules, GDPR, field deprecation, or data audit. Also trigger when someone says 'our reports don't match,' 'our CRM is a mess,' 'we have too many fields,' or describes duplicate accounts, conflicting numbers, stale data. Fix data governance before building metrics or scaling. BOUNDARY: Covers data MODEL, QUALITY, and GOVERNANCE. For HubSpot setup, see revops-hubspot. For metrics, see revops-metrics."
+title: Fix your CRM data chaos
+description: "Use this skill when CRM reports do not match, fields are a mess, hundreds of properties sit unused, or nobody trusts the data. Builds a data model mapped to the customer journey, designs field naming conventions and governance, sets up quality scorecards (completeness, accuracy, consistency, timeliness), and audits integrations to stop data rot. Produces a data dictionary, a field governance process with create and deprecate workflows, and quarterly quality targets. Rule: if a field has no documented owner and no documented use case, delete it. Trigger phrases: our reports do not match, our CRM is a mess, data quality, system of record, deduplication, field governance."
 category: RevOps
 ---
 
@@ -539,5 +539,12 @@ A semantic layer provides consistent, business-friendly vocabulary across the or
 **"Integrations keep breaking":** Map system of record for every data point. Define sync direction. Set up monitoring. Most integration failures come from undefined ownership.
 
 **Cross-references:** For CRM property implementation, see **revops-hubspot**. For tech stack integration decisions, see **revops-tech-stack**. For emergency data audit, see **revops-crisis**.
+
+## What good looks like
+
+- One documented system of record per object, and reports built on it agree with each other.
+- Every active field has an owner and a use case; fields without either are deprecated on a schedule.
+- Data quality is scored on completeness, accuracy, consistency and timeliness, with quarterly targets.
+- New fields go through a create workflow instead of appearing ad hoc.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/revops-forecasting/SKILL.md
+++ b/skills/rutger-katz/revops-forecasting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "revops-forecasting"
-title: Revenue forecasting
-description: "Revenue forecasting methodology, forecast categories, pipeline analysis, and predictability for B2B revenue teams. Use when the user mentions forecasting, revenue forecast, sales forecast, forecast accuracy, forecast categories, commit, best case, upside, pipeline coverage, weighted pipeline, forecast cadence, capacity planning, quota modeling, forecast call, deal inspection, or forecast variance. Also trigger when someone says 'we can't predict our number,' 'our forecast is always wrong,' 'how much will we close this quarter,' 'we can't see our pipeline,' 'deals go stale,' or 'we need better dashboards.' Also trigger on pipeline visibility, pipeline reporting, sales dashboards, pipeline hygiene, stale deals, pipeline health, big deal alerts, or pipeline quality score. BOUNDARY: Covers forecast methodology, accuracy, and pipeline visibility/reporting. For CRM-specific dashboard implementation, see revops-hubspot. For metrics and benchmarks, see revops-metrics."
+title: Forecast accuracy recovery
+description: "Use this skill when the forecast is consistently wrong: over-forecasting, missed quarter-ends, deals slipping unexpectedly. Installs category-based forecasting (Commit, Best Case, Upside), multi-method triangulation combining stage-weighted and historical views, and forecast accuracy diagnostics with benchmarks. Produces a repeatable forecast cadence, the red flags to inspect in forecast calls, and a variance-reduction roadmap. Rule: if a rep cannot explain their Commit deal in 2 minutes, it is not a Commit. Trigger phrases: forecast accuracy, we cannot predict our number, forecast categories, pipeline coverage, forecast call, deals go stale."
 category: RevOps
 ---
 
@@ -245,5 +245,12 @@ Build a forecasting worksheet with 4 sheets: Assumptions (base metrics like win 
 The Renewals tab is especially useful for CS operations; it models the renewal cohort with churn rates and expansion tracking.
 
 Use in: Forecasting methodology buildout, board preparation, operating cadence design.
+
+## What good looks like
+
+- Forecast categories have written definitions and every rep applies them the same way.
+- The quarterly number comes from at least two independent methods that get reconciled, not one gut call.
+- Forecast calls inspect changed deals and red flags, not a full pipeline readout.
+- Variance per category is measured every quarter and drives the next accuracy fix.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/revops-handoffs/SKILL.md
+++ b/skills/rutger-katz/revops-handoffs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "revops-handoffs"
-title: Revenue handoff operations
-description: "Revenue handoff design across the full bow-tie model; Marketing → Sales → Partner/Implementation → CS → Sales (expansion), plus lifecycle marketing and ABM loops. Use when the user mentions handoff, lead routing, speed-to-lead, MQL routing, closed-won handoff, partner handoff, CS-to-sales handback, expansion pipeline, cross-sell pipeline, upsell pipeline, renewal pipeline, territory routing, SLA between teams, transfer document, or AI handoff docs. Also trigger on \"leads fall through the cracks,\" \"CS never knows what sales promised,\" \"we lose momentum after signature,\" \"nobody owns expansion,\" or \"cross-sell has a different buying group.\" BOUNDARY: covers handoff design and SLAs between bow-tie stages. For HubSpot implementation, also consult revops-hubspot. For CS operations, see cs-operations. For SPICED, see sales-methodology."
+title: Design revenue handoffs
+description: "Use this skill when revenue leaks between teams: leads go dark after handover to sales, promised commitments disappear after signature, expansion signals stay invisible, CS never learns what sales committed. Designs handoff protocols across the full revenue bow-tie (marketing to sales, sales to customer, customer to expansion) with speed-to-lead SLAs, context-packet architecture, ownership models, and leading indicators of failure. Produces handoff playbooks per transition, context templates, SLAs with measurement dashboards, and detection rules for leaking revenue. Rule: handoffs are where revenue leaks. Trigger phrases: leads fall through the cracks, closed-won handoff, CS-to-sales handback, speed-to-lead, SLA between teams, nobody owns expansion."
 category: RevOps
 ---
 
@@ -234,5 +234,12 @@ Receiving team rates each handoff 1-5 across: information completeness, promise 
 - KeyBanc (2024). Expansion = 52% of new ARR.
 - Rework (2025). "Deal Handoff Protocol: Standardizing Post-Close Transitions." 45% implementation improvement, 35-40% churn reduction.
 - Forrester/SiriusDecisions. Demand Waterfall: MQL→SQL 39-40% with scoring vs 15-21% without.
+
+## What good looks like
+
+- Every bow-tie transition has a named owner, an SLA, and a context packet the receiving team actually reads.
+- Speed-to-lead is measured against the SLA and breaches alert someone accountable.
+- After signature, CS can see what sales promised without asking.
+- Leak indicators such as unworked leads and silent post-sale accounts sit on a dashboard, not in retrospectives.
 
 > Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/revops-hubspot/SKILL.md
+++ b/skills/rutger-katz/revops-hubspot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "revops-hubspot"
-title: HubSpot implementation for RevOps
-description: "HubSpot implementation patterns for revenue operations teams. Use this skill when the user mentions HubSpot, CRM setup, HubSpot properties, lifecycle stages, lead scoring in HubSpot, HubSpot workflows, HubSpot reporting, HubSpot dashboards, deal pipelines in HubSpot, HubSpot automation, contact/company/deal properties, HubSpot integrations, or asks about CRM architecture for B2B revenue teams using HubSpot. Also trigger when the user asks about mapping a bow tie or funnel model into HubSpot, building RevOps reporting in HubSpot, structuring HubSpot for multi-team revenue operations, cleaning up a messy HubSpot instance, HubSpot data hygiene, or migrating to HubSpot. If someone mentions CRM and they're in a B2B context, this skill is likely relevant even if they don't say \"HubSpot\" explicitly. BOUNDARY: This skill covers HubSpot-specific implementation. For strategic pipeline architecture and framework thinking, see revops-strategy. For ICP BUILDING methodology, see icp-builder. For lead routing rules and assignment logic, see lead-routing (which defers to this skill for CRM-specific implementation). For reporting, dashboards, and pipeline visibility, see revops-pipeline-visibility."
+title: Design HubSpot for revenue operations
+description: "Use this skill when CRM architecture breaks revenue clarity: lifecycle stages that do not match the funnel, unmaintainable properties, reporting that needs three spreadsheets. Covers object model design, lifecycle architecture, property governance, pipeline configuration, automation patterns, and reporting structure for HubSpot. Produces a documented architecture with stage definitions, property naming standards, workflow specs, and a revenue-decision-focused dashboard roadmap. Rule: design for reporting first; if you cannot name the report a property feeds, do not create it. Trigger phrases: HubSpot setup, lifecycle stages, messy HubSpot instance, deal pipelines, HubSpot reporting, CRM architecture."
 category: RevOps
 ---
 
@@ -403,5 +403,12 @@ When building fit scores, audit weights to ensure they do not proxy for protecte
 **Reporting questions:** Push toward revenue-connected reports. If they want an activity report, help them connect it to pipeline outcomes. If they want to know "how many emails did we send," redirect to "how many replies did those emails generate, and how many became pipeline?"
 
 **Cleanup and migration:** Prioritize by revenue impact. Clean active pipeline data first, then active customer records, then historical. Don't clean records that will never produce revenue.
+
+## What good looks like
+
+- Lifecycle stages map one-to-one to the funnel model, with written entry and exit definitions.
+- Every property feeds a named report or automation; unused properties are archived.
+- Pipelines, workflows and dashboards are documented well enough that a new admin can navigate them in a day.
+- Revenue leaders pull decisions from dashboards without exporting to spreadsheets.
 
 > Built by [Neon Triforce](https://neontriforce.com)


### PR DESCRIPTION
Listing repositioning for 10 rutger-katz skills. Same maintenance-batch shape as #64 / #131.

**Stacked on #131** (`sync/library-attribution-sweep`): this branch contains #131's commits because it touches the same files. Merge #131 first and this PR reduces to one commit across 10 SKILL.md files.

What changed per skill (frontmatter + one appended section, bodies untouched):

- Descriptions rewritten pain-first, each with one opinionated rule and a short trigger-phrase tail (replacing keyword-wall openers)
- New display titles: Sales cycle compression, Red account rescue, Forecast accuracy recovery, Fix your CRM data chaos, Design HubSpot for revenue operations, Design revenue handoffs, Discount governance and approval system, Consumption billing and revenue operations, Measure ABM engagement and hand accounts to sales, Choose an enrichment provider and build a waterfall
- `## What good looks like` section added to all 10
- Vendor tool names removed from two descriptions (deal-velocity-engineer, data-enrichment)
- Stray top-level `BOUNDARY:` frontmatter keys removed (deal-desk-operations, pricing-monetisation-ops)
- pricing-monetisation-ops recategorized Pricing -> RevOps

Test prompt: "Our deals keep stalling and the pipeline looks bloated but nothing closes. Where do we start?" should route to Sales cycle compression (deal-velocity-engineer).

Validator passes for all rutger-katz files (pre-existing errors in other contributors' folders left as is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
