### PR TITLE
add procurement-navigation by rutger-katz

### DIFF
--- a/skills/rutger-katz/procurement-navigation/SKILL.md
+++ b/skills/rutger-katz/procurement-navigation/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: "procurement-navigation"
+title: Procurement and security review navigation
+description: "Navigate the buyer procurement gauntlet from selected to signed. Use when a verbally-won deal enters security review, legal redlines, and vendor onboarding, and the close date starts slipping at contract stage. Maps the gauntlet early, pre-bakes the artifact pack, runs security, legal, and privacy reviews in parallel on a mutual close plan, and negotiates procurement without giving away the deal the sales team already won. Produces a gauntlet map, an artifact pack checklist, and a parallel-track close plan. Rule: a deal is not won until it clears the buying machinery; map the gauntlet before the proposal, not after selection. Trigger phrases: procurement, security questionnaire, stuck in legal, DPA, vendor onboarding, close date slipping at contract stage."
+category: Deals
+---
+
+# Procurement Navigation: The Deal After the Deal
+
+The most demoralizing loss in B2B is the deal that was won and then wasn't: champion committed, terms shaken on, and then six weeks of security questionnaires, redlines, and a procurement analyst with a mandate, while the close date rolls forward and the champion's momentum bleeds out. The market data says drag is fatal, not cosmetic: deals that close within about 50 days of TOTAL cycle time win at roughly 47%, versus roughly 20% for deals that stretch past that mark (Ebsta x Pavilion GTM Benchmarks, 2025 edition). The figure measures the whole deal, not the contracting phase alone; the point is that procurement is where the late weeks get added to deals that were on pace, and almost all of that drag is schedulable in advance.
+
+The core rule: **the gauntlet is mapped before the proposal, started in parallel, and run on a mutual plan.** Surprise is the enemy; none of the steps are actually surprising.
+
+## Map the Gauntlet Early
+
+The decision-process questions that qualification should have answered become, at proposal stage, a concrete checklist built WITH the champion:
+
+1. Every step between "yes" and "signed," in their order: security review, privacy/DPA, legal, procurement negotiation, vendor onboarding, signature chain.
+2. Per step: who runs it, typical duration, what they need from you, and what has killed vendors there before. Champions answer this question happily; they want the deal to land too.
+3. The steps that can run in parallel (almost all of them) versus the true dependencies. Serial-by-default is the buyer's habit, not a law; a champion armed with a parallel plan is your best process negotiator.
+4. Calendar traps: fiscal-year close, holiday freezes, the legal team's known backlog, signer vacations. An August signature chain has lost weeks before it starts.
+
+If the champion cannot answer these, the deal-qualification decision-process score just fell, and that is better learned now than at "stuck in legal, week five."
+
+## The Artifact Pack: Pre-Baked, Versioned, Owned
+
+Most procurement delay is you, slowly assembling answers that never change. Maintain a standing pack with an owner and a review date:
+
+- Security: completed standard questionnaires (the common industry formats), certifications and audit reports (up to date and shareable under NDA), architecture and data-flow one-pager, sub-processor list, incident-response summary.
+- Legal and privacy: your paper (MSA/DPA templates), your standard positions on the five clauses that always get negotiated (liability caps, indemnity, data terms, termination, SLAs), and the fallback position per clause agreed with counsel IN ADVANCE, so redline rounds take days, not committee cycles.
+- Commercial and admin: insurance certificates, tax and banking forms, the vendor-onboarding basics every large buyer requests.
+
+Response time to a security questionnaire is a sales metric during this phase. Same-week answers signal an organization worth buying from; a three-week scramble signals risk to the exact people whose job is smelling it.
+
+## Run It on a Mutual Close Plan
+
+Convert the gauntlet map into a dated, shared plan the buyer co-owns: every step, owner on each side, due date, and the go-live the buyer wants at the top, so every slip is framed in THEIR cost, not your quota. Review it weekly with the champion. Two rules keep it honest:
+
+- A deal in the gauntlet is not Commit-grade until the remaining steps are enumerated with dates and owners. "In legal" is not a status; "redlines returned, our counsel responds Thursday, one open clause" is.
+- When a step stalls, escalate through the sponsor with the go-live cost stated, and spend executive-to-executive capital on true blockages only. One well-aimed exec call outperforms four polite check-ins.
+
+## Negotiate Procurement's Game Without Losing Yours
+
+Procurement's mandate is savings and risk reduction; respect the job, do not re-litigate the deal:
+
+- Re-anchor on the business case the champion already sold (this is why the evaluation readout and its numbers exist). Procurement discounts percentages; they respect documented value.
+- Every concession is traded, never given: term length, case study rights, expansion options, payment terms, reference calls. A discount given free at this stage reprices this account forever and teaches the buyer's procurement that your first number is decoration (concession governance itself lives in deal-desk-operations).
+- Hold the walk-away line set before this phase began, and let procurement win something visible that costs you little; the analyst has a scorecard too.
+
+## Feed the System
+
+Log per deal: gauntlet duration by step, which artifacts were missing, which clauses ate the calendar, where the plan slipped. Three deals in, you have your own procurement benchmark; five deals in, the artifact pack and fallback positions cover 90% of what any buyer will ask, and contracting stops being weather.
+
+## What Good Looks Like
+
+The strongest operators can name, on the day the buyer says yes, every step to signature with an owner and a date, and their security questionnaire turnaround is measured in days. The common failure: treating the verbal yes as the finish line, meeting the gauntlet as a series of surprises, letting the close date roll weekly, and paying a late unearned discount just to end it, the exact sequence that turns a won deal into a 20-percent-win-rate long-cycle statistic. You know it works when contract-stage slippage stops appearing in forecast variance and the champion describes your process, unprompted, as the easiest vendor onboarding they have run.
+
+## Diagnostic Questions
+
+1. For your current late-stage deals: can anyone list the remaining steps to signature with owners and dates? Which ones are guesses?
+2. How long did the security review take on your last three enterprise deals, and how much of that was your own response time?
+3. Do your standard contract fallback positions exist in writing, pre-agreed with counsel, or does every redline round convene a committee?
+4. What did you concede at contract stage last year that was never traded for anything?
+5. Which calendar traps (fiscal close, freezes, signer availability) sit inside your current quarter's committed deals, and who has checked?
+
+Provenance: read `references/procurement-provenance.md`.
+
+> Built by [Neon Triforce](https://neontriforce.com)

--- a/skills/rutger-katz/procurement-navigation/references/procurement-provenance.md
+++ b/skills/rutger-katz/procurement-navigation/references/procurement-provenance.md
@@ -1,0 +1,17 @@
+# Procurement Navigation: Provenance and Practice-Based Rules
+
+## Externally sourced
+
+- Deals closing within ~50 days win at ~47% versus ~20% for deals stretching past that mark (Ebsta x Pavilion GTM Benchmarks, 2025 edition; 655K opportunities, $48B pipeline; checked September 2026, still the latest full dataset). Used to establish that contract-stage drag is a win-rate variable, not an admin nuisance.
+
+## Deliberately excluded
+
+Procurement-cycle-length statistics published by procurement-software vendors (average security review durations, contract cycle times) were excluded: self-interested samples without published methodology. The skill's feed-the-system section exists precisely so an organization builds its own gauntlet benchmark within a handful of deals, which beats any external figure.
+
+## Practice-based rules (validate against your own deals)
+
+- Mapping the gauntlet with the champion at proposal stage, and the parallel-versus-serial redesign.
+- The standing artifact pack with owner and review date; same-week questionnaire turnaround as a sales metric.
+- Pre-agreed clause fallback positions with counsel.
+- The mutual close plan with buyer-cost framing, the enumerated-steps standard for Commit-grade status, and sponsor-routed escalation on true blockages only.
+- Concessions traded, never given, at contract stage.


### PR DESCRIPTION
New skill: Procurement and security review navigation (category: Deals). One skill, one PR.

Includes a What good looks like section and one sourced reference file. Description is pain-first with a single rule and a short trigger tail; no vendor names, no cross-skill references.

Test prompt: "The deal is verbally agreed but it has been stuck in security review and legal for six weeks. What now?"

Validator passes for this folder; pre-existing errors in other contributors folders left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
