### PR TITLE
add pre-call-script by dyanesh-perumal

### DIFF
--- a/skills/dyanesh-perumal/author.md
+++ b/skills/dyanesh-perumal/author.md
@@ -1,0 +1,15 @@
+---
+name: Dyanesh Perumal
+title: Principal GTM Engineer & Founder, Nett New
+linkedinUrl: https://www.linkedin.com/in/dyaneshp
+companyDomain: nettnew.com
+email: dyanesh@nettnew.com
+---
+
+I build outbound systems for mid-market and enterprise revenue teams — the research,
+the messaging, and the infrastructure a rep needs to run the top rep's playbook on
+day one. Through Nett New I work as a fractional GTM engineer, embedding with founders
+and sales leaders to stand up the first outbound motion or fix one that stalled. My
+skills encode how I prep a rep for a live conversation: earn the right to the call
+with why-you and why-now relevance, lead with the warm route when there is one, and
+sell the meeting rather than the product on the phone.

--- a/skills/dyanesh-perumal/author.md
+++ b/skills/dyanesh-perumal/author.md
@@ -1,5 +1,6 @@
 ---
 name: Dyanesh Perumal
+avatarUrl: https://media.licdn.com/dms/image/v2/D5603AQGm6byIYEes7w/profile-displayphoto-crop_800_800/B56Z8156NEKEAI-/0/1783315804127?e=1790812800&v=beta&t=JGHPR-giUoydrUiz15x4yiudnc6Gl9o7Kk-YmJbCZB4
 title: Principal GTM Engineer & Founder, Nett New
 linkedinUrl: https://www.linkedin.com/in/dyaneshp
 companyDomain: nettnew.com

--- a/skills/dyanesh-perumal/pre-call-script/SKILL.md
+++ b/skills/dyanesh-perumal/pre-call-script/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: pre-call-script
-title: Pre-call script for a named prospect
+title: Script a prospect call that earns the meeting
 description: |
-  Use when a rep has a call booked or dialing planned against one specific named prospect and needs
-  what to say — grounded in that account's research, not a generic template. Produces a one-page
-  script: opener, relevance frame, proof point, one ask, two or three likely objections, and a
-  voicemail. Trigger phrasings: "script for [name]", "call prep", "prep me for [name]", "what do I
-  say to [name]", "brief me on [name]", "how do I approach [name]", "get me ready for my call with
-  [name]", "call script for [company]".
+  Use this skill when a rep has a call booked or dialing against one named prospect, a script would
+  otherwise be improvised on the line, or a first attempt went to voicemail and the retry needs a
+  sharper angle. Builds the call from that account's research: opener, relevance frame tied to a KPI
+  the prospect owns, proof point, one ask, the two or three objections this prospect will actually
+  raise, and a voicemail. Produces a one-page script every line of which traces to a researched
+  fact. Rule: if the prospect cannot answer "why you" and "why now" in the first 20 seconds, the
+  call is a cold read that wastes a rare live connect. Trigger phrases: script for [name], call
+  prep, prep me for [name], what do I say to [name], brief me on [name], get me ready for my call
+  with [name], call script for [company].
 category: Outreach
 tags: [Sales]
 contributors: []
@@ -16,8 +19,8 @@ contributors: []
 Use this when a rep is about to call one named person and needs the words. It produces a one-page
 script every line of which traces to a fact in that account's research.
 
-This is not a template library (`cold-call-scripts`), a call-scoring rubric (`call-scorecards`),
-or an email or LinkedIn sequence (`reach-out`). It is the script for one named person on one call.
+It is the script for one named person on one call — not a reusable template, not a call-scoring
+rubric, not an email or LinkedIn sequence.
 
 The whole call is 2–3 minutes and it sells the meeting, not the product. Anything discovery-grade
 stays out of the script.
@@ -43,8 +46,10 @@ more than yes or no.
 
 **Relevance frame — two to three sentences.** Pick the *one* signal that most directly indicates
 movement on the KPI this person owns, and describe the problem it implies — accurately enough that
-they hear their own situation read back. Not a feature. Not the product. Expect two or three angles
-per persona before one lands. See `references/worked-examples.md`.
+they hear their own situation read back. Not a feature. Not the product. When two signals compete,
+rank by how directly each maps to a KPI this person owns; break a remaining tie toward the most
+recent, most time-bound one — it carries the most "why now". Expect two or three angles per persona
+before one lands. See `references/worked-examples.md`.
 
 **Proof point — one sentence.** One named customer in a comparable situation, stated as an outcome
 not a capability ("their reps stopped writing follow-ups by hand," not "we automate follow-ups").
@@ -92,6 +97,8 @@ Let that bias the signal you lead with next time; once you have the rows it outr
 - MUST make *why you* and *why now* answerable from the script alone. No why-now signal → say so in
   the header line, do not manufacture urgency.
 - MUST lead the opener with the warm route whenever one exists.
+- When signals compete, rank by KPI-ownership first, recency second — never average them into a
+  vague frame that fits several.
 - If the prospect meets the frame with a flat correction ("that's not really our situation"), do
   not defend it — drop straight to the ask. A wrong frame argued is the call lost.
 - NEVER open with a greeting followed by a pitch.

--- a/skills/dyanesh-perumal/pre-call-script/SKILL.md
+++ b/skills/dyanesh-perumal/pre-call-script/SKILL.md
@@ -74,9 +74,9 @@ End with the contact block: best number, LinkedIn URL, email, and which channel 
 - The prospect can answer two questions 20 seconds in: why is this person calling me, and why now.
 - The frame is in the prospect's own language and never names the solution category — in
   conservative industries the category word ("software", "the platform") triggers a reflexive no.
-- Read on the live call (rules of thumb, not measured rates): a short time-to-first-question and
-  answers longer than yes/no mean they are leaning in; past three minutes the call has drifted
-  into selling the product — pull back to booking.
+- As a rough read on the live call: a short time-to-first-question and answers longer than yes/no
+  mean they are leaning in; past three minutes the call has drifted into selling the product —
+  pull back to booking.
 - The mediocre version opens with a greeting and a company intro, pitches a capability instead of
   an outcome, and could be read to anyone in the segment.
 

--- a/skills/dyanesh-perumal/pre-call-script/SKILL.md
+++ b/skills/dyanesh-perumal/pre-call-script/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pre-call-script
+title: Pre-call script for a named prospect
+description: |
+  Use when a rep has a call booked or dialing planned against one specific named prospect and needs
+  what to say — grounded in that account's research, not a generic template. Produces a one-page
+  script: opener, relevance frame, proof point, one ask, two or three likely objections, and a
+  voicemail. Trigger phrasings: "script for [name]", "call prep", "prep me for [name]", "what do I
+  say to [name]", "brief me on [name]", "how do I approach [name]", "get me ready for my call with
+  [name]", "call script for [company]".
+category: Outreach
+tags: [Sales]
+contributors: []
+---
+
+Use this when a rep is about to call one named person and needs the words. It produces a one-page
+script every line of which traces to a fact in that account's research.
+
+This is not a template library (`cold-call-scripts`), a call-scoring rubric (`call-scorecards`),
+or an email or LinkedIn sequence (`reach-out`). It is the script for one named person on one call.
+
+The whole call is 2–3 minutes and it sells the meeting, not the product. Anything discovery-grade
+stays out of the script.
+
+## Before you script
+
+1. Load the account research and the contact's role, tenure, and the KPI they were hired to move.
+2. Check the CRM for prior contact. A logged call makes this a follow-up — acknowledge the last
+   conversation, lead with something new, do not restart the pitch.
+3. Check for a warm route: a referral, a mutual connection, a prior touch, an event. If one
+   exists, it leads the opener and nothing else competes with it.
+4. If the contact is marked not-interested or already in an opportunity, stop and confirm with the
+   rep before writing anything.
+5. On a second attempt or a conservative-industry prospect, open the matching reference before
+   writing a line — the wrong frame is the most common way this script wastes a rare live connect.
+
+## Build the script
+
+**Opener — one or two sentences.** With a warm route, name it first: the referrer, the connection,
+the shared context. Cold, it has to make the prospect feel *this was researched, and it is about
+me* inside the first breath. Never a greeting followed by a pitch. End on a question that invites
+more than yes or no.
+
+**Relevance frame — two to three sentences.** Pick the *one* signal that most directly indicates
+movement on the KPI this person owns, and describe the problem it implies — accurately enough that
+they hear their own situation read back. Not a feature. Not the product. Expect two or three angles
+per persona before one lands. See `references/worked-examples.md`.
+
+**Proof point — one sentence.** One named customer in a comparable situation, stated as an outcome
+not a capability ("their reps stopped writing follow-ups by hand," not "we automate follow-ups").
+No named match → drop it rather than force one. Never invent a customer or a number.
+
+**The ask — one sentence, one ask.** Sell the meeting. A specific, low-commitment next step beats
+"do you have 30 minutes" — a short working session, a teardown, a peer benchmark.
+
+**Objections — two or three, the ones *this* prospect is most likely to raise** given their
+seniority, company stage, and industry. State each as they would say it; answer in one or two
+sentences that acknowledge without conceding and end with a question. Method and library in
+`references/objections-and-branches.md`; read `references/from-live-dialing.md` before a
+conservative industry or a second attempt.
+
+**Voicemail — 75 words maximum, ~30 seconds.** First name, one specific reason for the call tied to
+their role or company, your name, one next step. No performance percentages, no "just reaching out."
+
+End with the contact block: best number, LinkedIn URL, email, and which channel to lead with.
+
+## What good looks like
+
+- The frame names the problem behind a KPI the prospect personally owns, not a pain the company has
+  in the abstract. The average script describes the company's situation; a good one describes
+  *this person's* mandate.
+- Delete the opener and the rest still stands on the frame and the ask. If it collapses, the
+  personalization was decoration.
+- The prospect can answer two questions 20 seconds in: why is this person calling me, and why now.
+- The frame is in the prospect's own language and never names the solution category — in
+  conservative industries the category word ("software", "the platform") triggers a reflexive no.
+- Read on the live call (rules of thumb, not measured rates): a short time-to-first-question and
+  answers longer than yes/no mean they are leaning in; past three minutes the call has drifted
+  into selling the product — pull back to booking.
+- The mediocre version opens with a greeting and a company intro, pitches a capability instead of
+  an outcome, and could be read to anyone in the segment.
+
+## After the call
+
+Mark the frame with one word: **landed**, **fell flat** (a flat correction or no reaction), or
+**not reached**. Over a dozen calls a pattern shows — which signal types land for which persona.
+Let that bias the signal you lead with next time; once you have the rows it outranks instinct.
+
+## Rules
+
+- MUST trace every line to a specific fact in the research; no invented signals, customers, or numbers.
+- MUST make *why you* and *why now* answerable from the script alone. No why-now signal → say so in
+  the header line, do not manufacture urgency.
+- MUST lead the opener with the warm route whenever one exists.
+- If the prospect meets the frame with a flat correction ("that's not really our situation"), do
+  not defend it — drop straight to the ask. A wrong frame argued is the call lost.
+- NEVER open with a greeting followed by a pitch.
+- NEVER try to close the product on the call — the only goal is the meeting.
+- Keep the whole call to 2–3 minutes; anything discovery-grade stays out.
+- Voicemail is 75 words or fewer, one ask.

--- a/skills/dyanesh-perumal/pre-call-script/references/from-live-dialing.md
+++ b/skills/dyanesh-perumal/pre-call-script/references/from-live-dialing.md
@@ -1,53 +1,50 @@
 # Patterns from live dialing
 
-These are field observations from running this script across dialing sessions into
-industrial-manufacturing decision-makers. They are why the rules in the parent skill are
-rules and not suggestions.
+Five patterns that hold up on the phone with industrial and conservative-industry
+buyers. Read before scripting for those segments or for a second attempt.
 
 ## The category word ends the call
 
-A foundry managing director shut the call down the moment the words "software" and "tech"
-were said — before the relevance frame had landed. The pattern held across other
-conservative-industry contacts: naming the *solution category* triggers a reflexive "not
-for us," and once that reflex fires the call is over.
+Naming the solution category — "software", "a platform", "a tool", "AI" — triggers a
+reflexive "not for us" from conservative-industry buyers, often before the relevance
+frame has landed. Once that reflex fires the call is over.
 
-The fix is not a softer tone. It is to describe the problem in the language of how the
-business runs — "how your branch and dealer pipeline is being tracked" — and never name
-the category the solution belongs to. The category word can appear on the booked call, not
-the cold one.
+The fix is not a softer tone. Describe the problem in the language of how the business
+runs — "how your branch and dealer pipeline is tracked" — and never name the category
+the solution belongs to. The category word can appear on the booked call, not the cold
+one.
 
 ## The retry opener that keeps the door open
 
-After a first touch that went to email or voicemail, the opener that got a conversation
-was not a fresh pitch. It named the specific earlier message, declined to let it "sit in
-your inbox," and asked for two minutes now *or* a named better time:
+On a second attempt after a first touch went to email or voicemail, a fresh pitch
+performs worse than an opener that references the specific earlier message and asks for
+two minutes now *or* a named better time:
 
-> "Following up on the note I sent last week about how [specific thing] is being tracked.
+> "Following up on the note I sent last week about how [specific thing] is tracked.
 > Didn't want it to sit in your inbox — got two minutes now, or is there a better time
 > this week?"
 
 It works because it introduces nothing new to object to. The prospect already has the
-context; the ask is just whether now is the moment.
+context; the only question is whether now is the moment.
 
 ## Connect rate is low — the frame has to be right before you dial
 
-A three-and-a-half hour session produced five dials and zero live decision-maker
-conversations: one no-answer, one decline-to-email, one assistant voicemail, one hard no.
-That is a normal session, not a bad one. The consequence for this skill: there is no
-improvising the relevance frame on the call, because most calls never happen. The script
-is prepared work done against research, and the rare live connect is where all of its
-value is realized.
+Most cold dials never reach a live decision-maker: a session is mostly no-answers,
+voicemails, and declines-to-email, with live conversations the exception. The
+consequence for this skill: the relevance frame cannot be improvised on the call,
+because the call usually doesn't happen. The script is prepared work against research,
+and the rare live connect is where its value lands.
 
 ## A converted prospect leaves the cold flow
 
-The one prospect who booked a meeting moved off the dial list and into the pipeline the
-same day. The pre-call script's job ends when the meeting is set — the next contact is a
-meeting brief, not another cold dial. Re-dialing a booked contact with a cold script is an
+Once a prospect books a meeting they move off the dial list into the pipeline. The
+pre-call script's job ends when the meeting is set — the next contact is a meeting
+brief, not another cold dial. Re-dialing a booked contact with a cold script is an
 error the script should never produce.
 
-## The warm route outperformed every cold dial in the set
+## The warm route outperforms the cold dial
 
-The single warm-route play — an alma-mater connection referenced in reply to the
-prospect's own post — produced a real response thread where the cold dials in the same
-period produced none. When a warm route exists, it is not a nicer opener; it is a
-different and better play, and it leads.
+A warm-route opener — a mutual connection, a reply to the prospect's own post, a
+referral — produces replies where cold dials into the same segment produce none. When
+a warm route exists it is not a nicer opener; it is a different and better play, and it
+leads.

--- a/skills/dyanesh-perumal/pre-call-script/references/from-live-dialing.md
+++ b/skills/dyanesh-perumal/pre-call-script/references/from-live-dialing.md
@@ -1,0 +1,53 @@
+# Patterns from live dialing
+
+These are field observations from running this script across dialing sessions into
+industrial-manufacturing decision-makers. They are why the rules in the parent skill are
+rules and not suggestions.
+
+## The category word ends the call
+
+A foundry managing director shut the call down the moment the words "software" and "tech"
+were said — before the relevance frame had landed. The pattern held across other
+conservative-industry contacts: naming the *solution category* triggers a reflexive "not
+for us," and once that reflex fires the call is over.
+
+The fix is not a softer tone. It is to describe the problem in the language of how the
+business runs — "how your branch and dealer pipeline is being tracked" — and never name
+the category the solution belongs to. The category word can appear on the booked call, not
+the cold one.
+
+## The retry opener that keeps the door open
+
+After a first touch that went to email or voicemail, the opener that got a conversation
+was not a fresh pitch. It named the specific earlier message, declined to let it "sit in
+your inbox," and asked for two minutes now *or* a named better time:
+
+> "Following up on the note I sent last week about how [specific thing] is being tracked.
+> Didn't want it to sit in your inbox — got two minutes now, or is there a better time
+> this week?"
+
+It works because it introduces nothing new to object to. The prospect already has the
+context; the ask is just whether now is the moment.
+
+## Connect rate is low — the frame has to be right before you dial
+
+A three-and-a-half hour session produced five dials and zero live decision-maker
+conversations: one no-answer, one decline-to-email, one assistant voicemail, one hard no.
+That is a normal session, not a bad one. The consequence for this skill: there is no
+improvising the relevance frame on the call, because most calls never happen. The script
+is prepared work done against research, and the rare live connect is where all of its
+value is realized.
+
+## A converted prospect leaves the cold flow
+
+The one prospect who booked a meeting moved off the dial list and into the pipeline the
+same day. The pre-call script's job ends when the meeting is set — the next contact is a
+meeting brief, not another cold dial. Re-dialing a booked contact with a cold script is an
+error the script should never produce.
+
+## The warm route outperformed every cold dial in the set
+
+The single warm-route play — an alma-mater connection referenced in reply to the
+prospect's own post — produced a real response thread where the cold dials in the same
+period produced none. When a warm route exists, it is not a nicer opener; it is a
+different and better play, and it leads.

--- a/skills/dyanesh-perumal/pre-call-script/references/objections-and-branches.md
+++ b/skills/dyanesh-perumal/pre-call-script/references/objections-and-branches.md
@@ -1,0 +1,57 @@
+# Objections and script branches
+
+## Which branch is this call
+
+Pick the branch before writing a line. Running the cold-open script on a warm-route call burns the
+referral; running the follow-up script on someone who has never spoken to you reads as a mix-up.
+
+| Situation | What changes in the script |
+|---|---|
+| Warm route (referral, mutual connection, prior touch, event) | Opener names the route first. Relevance frame still does the work, but the referrer buys 10 extra seconds of attention — use them on the frame, not on rapport. |
+| Cold, no route | Opener must earn attention on research alone. Highest bar for the relevance frame. |
+| Second attempt, no prior conversation (voicemail, no-answer) | Not a new cold open. One line referencing the earlier attempt, then straight to a sharper frame or a new angle. |
+| Follow-up after a real conversation | Acknowledge what was said last time, lead with something genuinely new — a fresh signal, a new customer story, an answer to what they raised. Never restart the pitch. |
+| Gatekeeper-heavy org | Script a 15-second version of the frame for the gatekeeper — why this is relevant to the person you're asking for — plus the full script for when you're through. |
+| Seniority mismatch (reached someone above or below the target) | Reframe to that person's altitude: an executive hears risk and strategy, a manager hears operational load. Do not deliver the target's script to the wrong level. |
+| Marked not-interested or in an open opportunity | Stop. Confirm with the rep before scripting. If re-engaging, the opener acknowledges the prior outcome and leads with what is actually new. |
+
+## Objection library
+
+**Derive the objections, don't pick from a list.** Every ICP disqualifier carries a prediction
+about what that kind of company will push back on — invert each one into the objection a real
+prospect there would voice, in their words. Company under the size floor → "we're too small for
+this." No ops function → "who would even own this." The list below is a fallback for common
+shapes, not the starting point.
+
+State each as they would say it; answer in one or two sentences that acknowledge without conceding
+and end with a question.
+
+**"Send me an email."**
+> Fair — I'll do that. So it's not generic, what's the one thing worth me putting at the top: [gap A]
+> or [gap B]?
+
+**"We already have a tool for that."**
+> Most teams at your stage do. The ones I talk to still lose time on [specific gap the tool doesn't
+> close] — is that the case for you, or have you got that covered too?
+
+**"No budget right now."**
+> Not asking you to spend anything. The meeting is 20 minutes to see whether [problem] is costing
+> you enough to matter — if it isn't, that's a useful answer too. Worth a look?
+
+**"I'm not the right person."**
+> Understood. Who owns [KPI / process] day to day — and would it help if I framed it for them, or
+> would you rather introduce us?
+
+**"Call me next quarter."**
+> Happy to. So next quarter isn't a cold start — what would need to have changed by then for this to
+> be worth a proper conversation?
+
+**"We tried something like this before and it didn't work."**
+> That's the most common reason teams stall on it. What broke last time — the rollout, the data, or
+> the fit? If it was [X], that's exactly the part worth 20 minutes.
+
+## Voicemail, when there is no answer
+
+75 words maximum, about 30 seconds read aloud. First name at the start, one specific reason for the
+call tied to their role or company, your name and company, one next step. No performance
+percentages. No "just reaching out" or "hope you're well." One ask only.

--- a/skills/dyanesh-perumal/pre-call-script/references/worked-examples.md
+++ b/skills/dyanesh-perumal/pre-call-script/references/worked-examples.md
@@ -1,0 +1,68 @@
+# Worked examples: picking the relevance frame
+
+The relevance frame is the hardest part of the script and the part that earns the call. The move is
+always the same: find the one signal that most directly indicates the prospect has to move a KPI,
+then describe the problem that signal implies in their own terms. Two real shapes follow.
+
+## Example 1 — the company just opened a second location
+
+**Signal:** a second office or plant announced, a second-site hiring push, a new-region page on the
+site.
+
+**Why it maps to a KPI:** whoever owns operations or revenue for that expansion is now measured on
+the new site performing like the first one. That is the mandate.
+
+**The problem behind the signal:** the processes that ran inside one meeting room — the standup, the
+pipeline review, the handoffs people did by walking across the floor — do not survive being split
+across two locations. Site two ends up disconnected from site one. The playbook that was tacit is
+now a liability because it was never written down.
+
+**Frame, spoken:**
+
+> "You've opened the [city] site this year. The teams I work with hit the same wall around then —
+> everything that used to happen because people were in one room stops working once it's two
+> locations, and the second site drifts. Is that showing up for you yet, or is it still early?"
+
+**What makes it good:** it names the expansion (researched), names a problem the person owning the
+expansion actually feels, and ends on a question that is not yes/no. It never mentions a product.
+
+**Angles that came before this one landed:** "growing pains" (too vague), "you're hiring a lot"
+(not a problem, just an observation), "onboarding at scale" (real, but not what this persona is
+measured on). Expect two or three misses per persona before the frame lands.
+
+## Example 2 — the company made its first outbound sales hire
+
+**Signal:** a first SDR / outbound manager / head of sales development role posted or filled, at a
+company that has been marketing-led or ad-led until now. Corroborate with tool evaluations — job
+descriptions listing a dialer, a sequencer, a data provider — which say they are building the motion
+from zero.
+
+**Why it maps to a KPI:** that hire is on the hook for a pipeline number from a channel the company
+has never run. Everything they need to hit it is missing.
+
+**The problem behind the signal — the six things that person has to solve:**
+
+| Gap | The question they can't yet answer |
+|---|---|
+| Attribution | How do marketing-qualified leads get separated from outbound-sourced and credited to the new team? |
+| Playbook | Is there anything a rep can run from day one, or does every rep improvise? |
+| Playbook authorship | Who actually writes it, and when? |
+| Infrastructure | Are there dialers and inboxes set up to place calls and land email in the right place? |
+| Data | Is there contact data good enough to work from? |
+| Addressable market | Is there a written ICP precise enough to define the total market the team is working? |
+
+**Frame, spoken:**
+
+> "You've brought in [name] to build outbound — first hire into that motion, from what I can see.
+> The pattern I see is they spend the first quarter building plumbing instead of selling: no
+> day-one playbook, attribution not split out from marketing, data and dialing infra still being
+> stood up. Where is [name] spending time right now?"
+
+**What makes it good:** the signal (first outbound hire) is a direct indicator of the KPI (new
+pipeline from a new channel). The frame lists specific, checkable gaps rather than "scaling is
+hard." The ask that follows is a working session on one of those gaps — selling the meeting, not
+the system.
+
+**The proof point that pairs with it:** name a comparable company where the first outbound hire had
+a written playbook and split attribution in week one, and what that let them do — an outcome, not
+"we set up their outbound."


### PR DESCRIPTION
<!-- One skill per PR. All changes inside your own skills/<your-slug>/ directory. -->

## What this skill does

Scripts a cold or follow-up call to one named prospect from that account's research — opener, KPI-tied relevance frame, proof point, one ask, likely objections, voicemail. The pass/fail test is whether the prospect can answer *why you* and *why now* in the first 20 seconds; the call is capped at 2–3 minutes and sells the meeting, not the product. Ships `author.md` (first submission — Dyanesh Perumal, Nett New) plus three reference pages: frame-selection worked examples, objections & branches, and patterns from live dialing.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/dyanesh-perumal/` only
- [x] `node tools/validate.mjs` passes locally
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

<!-- avatarUrl omitted in author.md — fine to re-host the LinkedIn photo per AGENTS.md. -->
