### PR TITLE
add event-room-intelligence

### DIFF
--- a/skills/ariel-cohen/event-room-intelligence/SKILL.md
+++ b/skills/ariel-cohen/event-room-intelligence/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: "event-room-intelligence"
+title: Event room intelligence
+description: "Use this skill 1 to 3 days before any face-to-face event where you hold a registration export (a talk, conference, dinner, booth) and the question is 'I have the attendee CSV, who should I talk to?'. It maps every registrant to a company, joins the list against the live CRM, LinkedIn-verifies every person's title and employer, sizes and funds every company, hand-authors the buying committee for every account worth hunting, and prints a phone-readable PDF dossier: one account per page, warm hunt accounts first, each card telling you within five seconds who the buyer is, whether they are in the room, and what to say. Also answers 'room intelligence', 'attendee report', 'prep me for the event', 'who is coming from which accounts'."
+category: Events
+tags: [Sales, Marketing]
+---
+
+# Event room intelligence
+
+Runs 1 to 3 days before a face-to-face event, as soon as the registration export exists. Produces a phone-readable PDF dossier, one account per page, that the people walking the floor read on the way in: who the buyer is at every account in the room, whether they are physically there, and the one-line play.
+
+## Template placeholders
+
+Replace every `{{...}}` before running. The card-anatomy reference lists them with defaults.
+
+- `{{PRODUCT}}` - Your product's name
+- `{{CRM}}` - Your CRM; read live, never from an export
+- `{{PROFILE_LOOKUP}}` - Your LinkedIn profile lookup (URL scrape plus name-and-company profile search). Must return photo, current headline, current employer, work email
+- `{{COMPANY_LOOKUP}}` - Your company enrichment for employee count, total raised, last round
+- `{{HUNT_TIER}}` - The tier that makes an account a hunt target when someone from it is in the room (default: **Gold and above at MQL stage**)
+- `{{LARGE_COMPANY_FLOOR}}` - Size above which an untiered company still gets a full card (default: **200+ employees or $50M+ raised**)
+- `{{DEMOTE_LIST}}` - Giant, well-known logos that stay in the dossier but move to the end of the cold list (enterprise-gated, or no buyer in the room)
+- `{{COMPETITORS}}` - Competitors; they get a watch-list line, never a card
+- `{{ALIAS_LIST}}` - Your maintained registrant-name-to-domain overrides, grown event over event
+- `{{LOOKUP_BATCH}}` - Companies per enrichment sub-agent when sizing fans out (default: **12**)
+- `{{FLOOR_TEAM}}` - Who from your side attends and reads the dossier
+
+## Inputs (ask once)
+
+The registration export (name, email, approval status, and whatever title, company, and LinkedIn fields the form collected), the event date, who from `{{FLOOR_TEAM}}` attends, and the goal: hunt deals, meet customers, or recruit. Everything else is derived.
+
+## Phase 1 - Map every registrant to a company
+
+Run the waterfall in order and record which rung matched, because the rung sets the confidence you show on the card:
+
+1. Business email domain (skip free-mail domains, and a small list of tracking or redirect domains that masquerade as companies).
+2. The registration form's company field, normalised.
+3. `{{ALIAS_LIST}}`: manual name-to-domain overrides for people you know registered with a personal address.
+4. Name match against the roster of a prior event, where the same person was already mapped.
+
+Personal-email registrants who fail all four rungs stay unmapped until Phase 3 resolves them from LinkedIn. Deduplicate on domain plus normalised name, keeping the approved row over the invited one. Read `references/company-mapping-waterfall.md` for the free-mail list, the alias-list format, and the dedup rules.
+
+## Phase 2 - Join against the live CRM
+
+For every mapped company, read from `{{CRM}}` in this order: tier tags, funnel stage, owner, open deal and amount, customer status (active and ever-paid). Tiers move daily; a tier export from earlier in the week is already wrong. Also pull any stage or tier mismatch (a low tier sitting at MQL stage is a data bug, not a hunt target) and the competitor tag.
+
+## Phase 3 - Verify every person on LinkedIn
+
+For every registrant and every buying-committee contact, run `{{PROFILE_LOOKUP}}`:
+
+- With a profile URL: scrape it for photo, current headline, current employer, work email.
+- Without one: profile-search by name plus mapped company, then apply the match rules. A single first name needs both a first-name match and a company match. A full-name match with no company evidence is a `name-only` match and is labelled as unverified on the card.
+- If the current employer no longer matches the mapped company, mark the person `moved` and show where they are now.
+- Every untitled or first-name-only registrant gets this pass. Invite-only rows hide the seniors: last run, 39 Director-and-above people carried no title in the export, and a VP of Global Sales Development surfaced only because her first name plus email domain resolved on LinkedIn. She was the buyer for the whole use case.
+
+Trust the LinkedIn read over `{{CRM}}`. Between 25 and 35 percent of CRM contacts had changed jobs at the last run. The original hand-raiser at one hunt account had left; the person being sequenced at another had become COO somewhere else. Both would have been the wrong name to walk up with.
+
+Cost and effort marker: roughly $4 of `{{PROFILE_LOOKUP}}` credits for about 130 people. Checkpoint every batch to a file so a retry never re-spends.
+
+## Phase 4 - Size and fund every company
+
+For every mapped company, get employee count, total raised, and last round from `{{COMPANY_LOOKUP}}`. Fan out in batches of `{{LOOKUP_BATCH}}` with one approval for the whole run; 132 companies took about 13 minutes. No account with an attendee may reach the dossier without size and funding; if the provider returns nothing, say `unresolved` on the card rather than leaving it blank.
+
+## Phase 5 - Hand-author the buying committee
+
+For every hunt, warm, large-company, deal, and customer account, write the committee by hand from `{{CRM}}` history, account notes, and the Phase 3 reads: name, title, role in the deal, LinkedIn, email. Decision maker first, then sponsor, then champion or hand-raiser, then the RevOps or systems influencer, then people merely in the room, departed contacts last with a `left` label and their new employer. Read `references/buying-committee-rubric.md` before writing any card.
+
+## Phase 6 - Build and print
+
+Assemble the HTML from the joined data and print to PDF. Cards come first and are ordered: hunt accounts (`{{HUNT_TIER}}` with people in the room), warm accounts, large companies, open deals, customers. Within a group, sort by number of approved attendees, then invited attendees. `{{DEMOTE_LIST}}` goes to the end of the cold list. After the cards: room stats, seniors hidden in the invite list, faces grid, role mix, company map, competitor watch list, full directory, methodology. Card content and print settings are specified in `references/card-anatomy-and-sort-order.md`.
+
+Deliver as a local file only. Read `references/day-of-and-after-checklist.md` for how the floor team uses it and how to close the loop after the event.
+
+## What good looks like
+
+- **What the expert notices first: who came as a group.** Several registrants from one company, and above all a manager plus their team, is the strongest signal in the room. Last run a cybersecurity company registered eight people, its entire sales-development org including the VP. The delegation was itself the buying signal. The play was a team demo, and naming the RevOps director already in a direct-message thread with the CEO so both threads would meet.
+- **Second look: the untitled and first-name-only rows.** These are where the seniors sit. A dossier that only covers people with a job title on the form has missed the buyers.
+- **The common mistake is trusting CRM titles.** A quarter to a third of them are stale. The second mistake is producing a company table when the job is a floor plan of who to hunt. The third is a face grid: rejected, the per-account card is the product.
+- **The numbers from the last run**, useful as a sanity check: 254 registrants, 170 mapped to 132 companies, 87 already in the CRM, 47 dossiers, 39 Director-and-above people with no title in the export.
+- **Print for the phone**: 20px body, 120px avatars, no intro page, the first page is the first card, the group label lives inside the card so there are no heading-only pages.
+- **The quality bar**: you can read it on your phone walking in; hunt accounts come first; for every card you know within five seconds who the buyer is, whether they are in the room, and what to say. Every person has a photo, a current title, and an email, or is explicitly marked `unresolved`. No account with an attendee is missing size and funding.
+
+## Rules
+
+- MUST LinkedIn-verify every title and employer before the event. A CRM title is a hint, never the label on a card.
+- MUST resolve every untitled and first-name-only registrant through profile search before calling anyone undetected.
+- MUST read tiers, stages, owners, and deal values live from `{{CRM}}` at build time.
+- MUST mark every person who could not be resolved as `unresolved` or `unverified match`; never present a guess as a fact.
+- NEVER publish or share the dossier outside `{{FLOOR_TEAM}}` and the account owners. It contains personal data and deal values; it is a local file, not a link.
+- NEVER send outreach from this skill. It recommends who to approach and what to ask; humans send.

--- a/skills/ariel-cohen/event-room-intelligence/references/buying-committee-rubric.md
+++ b/skills/ariel-cohen/event-room-intelligence/references/buying-committee-rubric.md
@@ -1,0 +1,62 @@
+---
+title: "Buying committee rubric"
+description: "Which roles go on a card, in what order, how to label departed contacts, and the three worked cases that shaped the rubric."
+---
+
+# Buying committee rubric
+
+Hand-author the committee for every hunt, warm, large-company, deal, and customer account. No automated committee has beaten a person reading the account history for ten minutes; the automation is for finding the people's current title, photo, and email, not for deciding who matters.
+
+## Roles and order
+
+Sort the committee by the rank below. Ties keep the order you wrote them in.
+
+| Rank | Role label on the card | Who | Why first |
+|---|---|---|---|
+| 0 | Decision maker / Economic buyer / Budget / Sign-off | The person whose signature closes it | The floor team must know within five seconds who the buyer is |
+| 1 | Exec sponsor | The executive who wants it to happen but does not own budget | Second-most valuable handshake |
+| 2 | Champion / Hand-raiser / Technical evaluator | Whoever raised their hand, ran the trial, or is evaluating | They know you; open with them, then ask for the intro up the ranks |
+| 3 | Influencer | RevOps, GTM engineering, systems owner, the manager of the team that would use `{{PRODUCT}}` | Often the one who blocks or unblocks |
+| 4 | In the room | A registrant from the account with no deal role yet | Listed so nobody is a blind handshake |
+| 9 | Left | Departed contact | Kept for history, sorted last, never approached with the old name |
+
+A person can be both a registrant and a committee member; show them in both blocks of the card, and in the committee block say "in the room" in the note.
+
+## Each committee line
+
+`Name | current title (LinkedIn-verified) | role label | LinkedIn URL | email | one-line note`
+
+The note is the operational fact: "coordinating internally, needs CFO sign-off", "ran three systems, sees consolidation as the win", "not yet engaged directly", "owes headcount numbers for the trial". If you cannot write a note, ask whether the person belongs on the card at all.
+
+## Labelling departed contacts
+
+- Role becomes `Left` and the note says where they went and their new title: `now COO at <new company>`.
+- If the new company is in the room or in the CRM, add a cross-reference line on that company's card; a hand-raiser who moved is a warm start at the new employer, and the old account needs a new champion.
+- Never delete them. The dossier is also the record of why the old play stopped working.
+
+## Which accounts get a committee
+
+| Group | Committee depth |
+|---|---|
+| Hunt | Full: buyer, sponsor, champion, influencer, in-the-room |
+| Deal | Full, copied from the live opportunity, then re-verified on LinkedIn |
+| Customer | Buyer plus the heaviest users, so expansion and reference asks land with the right people |
+| Warm | Buyer plus whoever engaged last |
+| Large company | Buyer for the relevant function only, looked up fresh; enough that the handshake with the individual contributor has somewhere to go |
+
+Every large company above `{{LARGE_COMPANY_FLOOR}}` with an attendee gets this treatment, not only the accounts the CRM already rates highly. Last run 21 of the 47 cards were large companies that were not yet worked, and the committee lookups turned several of them into warm accounts.
+
+## Three cases that shaped the rubric
+
+**The delegation.** A cybersecurity company registered eight people: the whole sales-development org and the VP who runs it. The delegation itself was the buying signal. Committee: the VP as decision maker, the RevOps director (already in a direct-message thread with the CEO, not registered) as influencer, the sales-development managers as in-the-room. Play: team demo on site, and name the RevOps director so the two threads meet.
+
+**The hidden buyer.** A VP of Global Sales Development appeared on the invite list with no title and a first name. Profile search on first name plus company found her. She became the rank-0 line on a card that would otherwise have shown three individual contributors and no buyer.
+
+**The stale names.** At one hunt account the original hand-raiser had left the company. At another, the contact being sequenced had become COO elsewhere. The CRM said both were current. Without the LinkedIn pass the team would have walked up asking for people who no longer worked there. Both became `Left` lines with a cross-reference, and both accounts got a new rank-0 line before the event.
+
+## Email resolution order for committee members
+
+1. Work email from the LinkedIn profile scrape.
+2. Work email already in `{{CRM}}`.
+3. Email-address enrichment by name plus domain through your enrichment provider.
+4. If all three fail, show the LinkedIn link alone and label `no email`. Do not guess a pattern-based address onto a card that people will act on.

--- a/skills/ariel-cohen/event-room-intelligence/references/card-anatomy-and-sort-order.md
+++ b/skills/ariel-cohen/event-room-intelligence/references/card-anatomy-and-sort-order.md
@@ -1,0 +1,80 @@
+---
+title: "Card anatomy and sort order"
+description: "Exactly what one account card contains, how cards are grouped and ordered, what follows the cards, and the print settings for phone reading."
+---
+
+# Card anatomy and sort order
+
+The card is the product. Everything else in the dossier is supporting material. Do not replace cards with a table or a face grid; both were tried and rejected because neither answers "who is the buyer and are they here" in five seconds.
+
+## One card, top to bottom
+
+| Block | Content | Source |
+|---|---|---|
+| Group label | Inside the card, top-left: Hunt, Warm, Large company, Deal, Customer | Phase 6 grouping |
+| Header | Company name, domain, CRM owner (or "no owner") | Live `{{CRM}}` read |
+| Size line | `1,200 employees · Series C 2024 · $85M raised`, or `public`, or `bootstrapped`; any note such as "acquired by X" or "in insolvency" | `{{COMPANY_LOOKUP}}` |
+| Status label | Right-aligned: `Tier · Stage · $deal · owner first name` | Live `{{CRM}}` read |
+| Why | Two to four sentences: what the relationship is, what happened last, who is engaged, what is blocking | Account notes plus CRM history, hand-written |
+| In the room | Every registrant from this company: photo, name linked to LinkedIn, verified title, approval status, email | Phase 3 |
+| Decision makers and champions | The buying committee in rubric order: photo, name, title, role in the deal, email, one-line note | Phase 5 |
+| Play | One line: who to approach, what to ask, who on `{{FLOOR_TEAM}}` takes the name afterwards | Hand-written |
+
+### Title rendering
+
+Show the registration-form title, and when the LinkedIn title differs, append `LinkedIn: <current title>` in a muted style. Both matter: the form title is what the person calls themselves this week; the LinkedIn title is what their employer calls them.
+
+### Person labels
+
+- `unverified match`: profile chosen on name alone, no company evidence. Keep the photo, keep the doubt visible.
+- `LinkedIn now: <title> at <company>`: the person has moved. On a registrant it means they may show up representing someone else; on a committee contact it means do not use this name.
+- `left`: departed committee contact, sorted last.
+- `unresolved`: no profile found after URL scrape, profile search, and email-based enrichment. Never leave the label off and hope.
+
+## Grouping
+
+| Group | Definition | Cards get |
+|---|---|---|
+| Hunt | `{{HUNT_TIER}}` accounts with at least one person in the room | Full committee, demo-booking play |
+| Warm | High-tier or newly relevant accounts with no MQL alert yet; one named VP or a dated meeting moves them | Full committee |
+| Large company | Above `{{LARGE_COMPANY_FLOOR}}`, mostly untiered or mid-tier, mostly represented by an individual contributor | Committee looked up so no handshake is blind |
+| Deal | Open opportunity in `{{CRM}}` | Committee, and a play that says "do not pitch, advance" |
+| Customer | Active or ever-paid | Say thanks, collect a reference, find the expansion seat |
+
+Anything else with an approved attendee goes in the directory table after the cards with a one-line note. Competitors get a watch-list line, never a card, and the note says "be friendly, do not demo".
+
+## Sort order (do not re-litigate)
+
+1. Groups in this order: Hunt, Warm, Large company, Deal, Customer. Cold and warm-but-unworked accounts are what the floor team needs first; deals and customers already have owners and next steps.
+2. `{{DEMOTE_LIST}}` accounts sink to the end of the cold list regardless of tier: enterprise-gated, or no buyer in the room. They stay in the dossier because a stray VP may still walk in.
+3. Within a group: accounts with approved attendees before invite-only accounts, then by tier, then by number of approved attendees descending, then invited attendees descending.
+4. Within a card, committee members follow the rubric order in `buying-committee-rubric.md`.
+
+## After the cards, in this order
+
+1. **Room in numbers**: registrants, approved, mapped, companies, in CRM, tier counts, stage counts.
+2. **Seniors hiding in the invite list**: every Director-and-above person whose registration row carried no title, with the LinkedIn-resolved title. Last run this section held 39 people.
+3. **Faces on the floor**: every approved attendee as a photo chip, priority accounts first. This is the recognition aid for the door, not a replacement for the cards.
+4. **Role mix**: bars by role bucket (founder or C-suite, sales leadership, sales development, account executive, RevOps and GTM engineering, marketing, partnerships, customer success, consultant, investor, job seeker, other).
+5. **Company map**: full table of every mapped company with size, round, industry, HQ, tier, stage, attendee count, attendee chips.
+6. **Watch list**: competitors and partners in the room.
+7. **Everyone on the list**: the unmapped and small-company remainder.
+8. **Methodology and data limitations**: sources, match confidence counts, and what was not resolved.
+
+## Print settings
+
+- Body 20px, avatars 120px in the cards (72px thumbnails elsewhere), embedded as base64 so the PDF is self-contained.
+- One account per page: page-break before every card, no page break inside a card.
+- No cover, no table of contents, no group heading pages. Page one is the first hunt card.
+- Print from headless Chrome to PDF, writing into the event folder. Verify the first page is a card before sending.
+- Expect roughly 5 to 7 MB for 47 cards with embedded photos. Fine for a phone.
+
+## Placeholder defaults
+
+| Placeholder | Default |
+|---|---|
+| `{{HUNT_TIER}}` | Gold and above at MQL stage |
+| `{{LARGE_COMPANY_FLOOR}}` | 200+ employees or $50M+ raised |
+| `{{LOOKUP_BATCH}}` | 12 companies per sub-agent |
+| `{{DEMOTE_LIST}}` | Empty until you have a giant logo with no buyer in the room |
+| `{{ALIAS_LIST}}` | Empty on the first event, then carried forward |

--- a/skills/ariel-cohen/event-room-intelligence/references/company-mapping-waterfall.md
+++ b/skills/ariel-cohen/event-room-intelligence/references/company-mapping-waterfall.md
@@ -1,0 +1,59 @@
+---
+title: "Company mapping waterfall"
+description: "The four-rung waterfall that turns a registration row into a company, the alias-list logic that grows across events, and the dedup rules."
+---
+
+# Company mapping waterfall
+
+Every downstream number (companies in the CRM, tier counts, who gets a card) depends on this step. Last run: 254 registrants, 170 mapped to 132 companies. The 84 that did not map were personal-email registrants with no company field, and roughly a third of those resolved later from LinkedIn.
+
+## Rung 1 - Business email domain
+
+Take the domain after `@`, lower-cased. Skip it if it is on the free-mail list, then treat the remainder as the company domain.
+
+Free-mail list to start from: `gmail.com yahoo.com yahoo.co.uk hotmail.com hotmail.co.uk outlook.com outlook.de live.com msn.com icloud.com me.com aol.com protonmail.com proton.me gmx.com mail.com ymail.com` plus your local consumer providers. Add any domain you discover to be a tenant default (an `onmicrosoft.com` subdomain) or a personal vanity domain.
+
+Two domain traps that need a fix table, not the free-mail list:
+
+- **Tracking and redirect domains**: a marketing-suite subdomain such as `email.<vendor>.com` maps to the vendor; a link-shortener domain maps to whichever company the person is known to be at.
+- **Vanity personal domains of known people**: keep a `domain -> real company domain` fix so the row does not become a one-person company.
+
+Record `src = email`.
+
+## Rung 2 - Registration form company field
+
+If the email domain is free-mail and the form has a company field, normalise it (strip `Ltd`, `Inc`, `Group`, `Technologies`, `Software`, `LLC`, parentheses, punctuation) and match it against company names already seen in `{{CRM}}` or prior rosters. A match sets the domain; no match keeps the raw name for Phase 3 profile search. Record `src = form`.
+
+## Rung 3 - The alias list
+
+`{{ALIAS_LIST}}` is a normalised-name-to-domain map you maintain by hand and carry from event to event. Normalise a name by NFKD-folding accents, lower-casing, and stripping everything that is not a letter or digit, so `José Núñez-García` and `jose nunez garcia` collide.
+
+It holds three kinds of entry:
+
+1. **Known people who register with a personal address.** Once you resolve them on LinkedIn, add them so the next event maps them on rung 3 without spending a lookup.
+2. **Corrections from verification.** When Phase 3 shows the person has moved, the alias points at the NEW company, and a correction record carries the new title so the card shows current reality.
+3. **Non-Latin names.** Names in a local script rarely match anything automatically; store the exact string as typed.
+
+Record `src = manual`. Review the alias list before every event and delete entries older than two events unless re-verified; people move.
+
+## Rung 4 - Prior-roster name match
+
+Load the attendee lists of prior events you have already mapped and build a normalised-name-to-domain index from them. A hit here is weaker than the other rungs (same name, different person is possible), so mark `src = prior` and let Phase 3 confirm the company.
+
+## Unmapped rows
+
+Rows that fail all four rungs stay on the roster with `dom = null`. They are not dropped: Phase 3 runs a name-only profile search restricted to the event's country, and any hit with a plausible current employer gets a `name-only` confidence and a candidate domain. First-name-only rows go through the same search with the email domain root as the company hint when the domain is not free-mail. This is how a first-name-only invite row became a Senior VP of Sales at a funded fintech last run.
+
+## Dedup
+
+- Key is `(domain, normalised name)`. Process approved rows before invited rows so the approved row wins.
+- Keep a `dup = true` flag on the loser instead of deleting; the directory count should still show every registration.
+- Same name, two different domains: keep both. The person may have registered from an old and a new employer, which is itself a move signal.
+
+## Title hygiene before role classification
+
+Blank out titles that are actually the company name or a single word like `yes`. Fix obvious typos of `Founder`. Then classify each title into a role bucket with regex rules, most specific first: job seeker, then sales-development leadership before sales-development IC, then founder and C-suite, sales leadership, sales management, account executive, RevOps and GTM engineering, GTM generalist, marketing, partnerships, customer success, engineering and product, consultant, investor, other. Print every title that landed in `other` and fix the rules until that list is short.
+
+## Output of this phase
+
+A roster with `id, name, email, status, form title, form company, linkedin url, dom, src, created` per registrant, and a company list with `domain, name, employee count, industry, HQ, in_crm, tier, stage, owner, tags, n_attendees, attendees[]`. Print the counts (registrants, mapped, companies, in CRM) and the tier and stage distributions before moving on; they are the first line of the methodology section.

--- a/skills/ariel-cohen/event-room-intelligence/references/day-of-and-after-checklist.md
+++ b/skills/ariel-cohen/event-room-intelligence/references/day-of-and-after-checklist.md
@@ -1,0 +1,42 @@
+---
+title: "Day-of and after-event checklist"
+description: "How the floor team uses the dossier on the day, and how to close the loop afterwards by crossing LinkedIn connection requests and profile views against the roster."
+---
+
+# Day-of and after-event checklist
+
+## The day before
+
+- [ ] Re-run the live `{{CRM}}` join. Tiers and stages move daily; a dossier built three days out has drifted.
+- [ ] Re-check approval status. Late approvals from hunt accounts change the card order.
+- [ ] Confirm the PDF opens on a phone with page one as the first hunt card, and that photos render (embedded, not linked).
+- [ ] Send the file directly to `{{FLOOR_TEAM}}` and the owners of the deal accounts. No public link, no shared drive folder with broad access.
+- [ ] Agree who takes which hunt accounts. Two people approaching the same buyer looks uncoordinated.
+
+## On the day
+
+- [ ] Read the hunt cards on the way in. Five seconds per card: buyer, in the room or not, the play.
+- [ ] Use the faces grid at the door for recognition, then go back to the card before speaking.
+- [ ] Open with the champion or hand-raiser where one exists; ask for the intro to the rank-0 person rather than cold-approaching the buyer.
+- [ ] For delegations (a manager plus their team), offer a group demo slot instead of five separate conversations.
+- [ ] For deal accounts: do not pitch. Collect intel, confirm next steps, hand the name to the owner.
+- [ ] For customers: thank, ask for a reference, find the expansion seat.
+- [ ] Competitors on the watch list: be friendly, do not demo.
+- [ ] Capture every conversation as a two-line note (who, what they said, what they want next) before leaving the venue. Memory decays by the next morning.
+
+## After the event (within 48 hours)
+
+The dossier is also the join key for everything the event produced.
+
+1. **Cross the connection-request list against the roster.** Pull the pending and accepted LinkedIn connection requests received by each member of `{{FLOOR_TEAM}}` in the event window. Match by normalised name against the roster. Last run about 40 percent of requesters were on the registration list; the remainder are people who heard the talk second-hand or came unregistered, and they need mapping and sizing from scratch.
+2. **Cross the profile-view list the same way.** Profile views in the event window are a weaker signal than requests but the overlap with hunt-account attendees is the list to follow up first.
+3. **Tag the cohort at ingest.** Every matched person and account gets an event note in `{{CRM}}` and account memory: `event: <slug>, attended / requested / viewed, met by <name>, said <two lines>`. Without the tag, downstream scoring treats these as anonymous signals with no context.
+4. **Update the alias list.** Every registrant you resolved manually, every mover you found, goes into `{{ALIAS_LIST}}` so the next event maps them on rung 3.
+5. **Update the committee.** Every `Left` line becomes a CRM contact update; every new rank-0 person becomes a CRM contact if missing. This is the one CRM write this skill produces, and it is a human-reviewed batch, not an automated sync.
+6. **Hand-offs.** The conversation notes from the floor go to the account owners as a list, one line per account, in card order. Outreach is theirs to send.
+
+## What not to do
+
+- Do not publish the dossier as a web page or a shared link, even internally. It carries personal data, photos, work emails, and deal values.
+- Do not send any message from this skill. It recommends; humans send.
+- Do not reuse last event's dossier for a follow-up event without re-running Phases 2 and 3. The whole point is that titles and tiers are current.


### PR DESCRIPTION
<!-- One skill per PR. All changes inside your own skills/<your-slug>/ directory. -->

## What this skill does

Pre-event room intelligence: 1 to 3 days before a face-to-face event, turn the registration export into a phone-readable PDF dossier, one account per page, hunt accounts first, with LinkedIn-verified people, live CRM tier/stage/deal, company size and funding, a hand-authored buying committee, and a one-line play per card. Ships four references: card anatomy and sort order, the company-mapping waterfall, the buying-committee rubric, and the day-of / after-event checklist.

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only (`skills/ariel-cohen/event-room-intelligence/`)
- [x] `node tools/validate.mjs` passes locally (0 errors; only pre-existing author.md warnings across the repo)
- [x] First contribution: `author.md` is included with a real name, avatar, and LinkedIn (not a first contribution; existing `skills/ariel-cohen/author.md` untouched)
- [x] Body speaks in GTM verbs — zero vendor tool names (CRM, profile lookup, company lookup are `{{PLACEHOLDER}}`s)
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions (the skill never sends outreach; the only CRM write is a human-reviewed contact-update batch after the event)
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

Examples in the skill and references are anonymized; no real attendee names, emails, or companies from the source report are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ91xZYwWVqD71uon1sSW9