### PR TITLE
add call-followup-sweep

### DIFF
--- a/skills/boaz-descalo/call-followup-sweep/SKILL.md
+++ b/skills/boaz-descalo/call-followup-sweep/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: call-followup-sweep
+title: Call follow-up sweep
+description: |
+  Use this skill when a day or a week of customer calls has piled up and the
+  follow-through is owed but unwritten. Trigger on "review my calls this week",
+  "draft my follow-ups", "what do I owe people", "what did I promise on these
+  calls", "catch me up on yesterday's calls", "did anything fall through this
+  week". Asks which window to sweep, reads every call in it, extracts the
+  commitments — especially the ones you made — and returns one drafted email per
+  account that earns one, the list of calls that earn none and why, and the
+  promises still open from earlier sweeps. Produces drafts only; it never sends.
+category: Deals
+tags: [Sales, Customer Success]
+contributors: []
+---
+
+Applies when a batch of customer calls has happened and the follow-through is
+owed. Produces a per-account draft for the calls that earn one, a no-email list
+with reasons for the calls that don't, and an aging report of commitments still
+open from prior sweeps. Nothing is ever sent.
+
+## The sweep
+
+1. **Ask the window before anything else.** Day or week — never guess, and never
+   default to "all recent calls". The window changes the output: a day sweep is
+   mostly fresh drafts while the call is still warm; a week sweep is mostly an
+   aging and pattern report with fewer, denser drafts. If the answer is "week",
+   confirm whether it means the trailing five business days or the calendar week
+   — on a Wednesday those differ by half a book.
+2. **Pull every call in the window** from wherever calls are recorded —
+   transcripts, recordings, or the user's own notes. Capture account, attendees,
+   date, and duration for each. A scheduled call with no recording is a finding,
+   not a gap: list it as unverified rather than dropping it silently.
+3. **Extract commitments, not summary.** Read
+   `references/commitment-extraction.md` before the first call. Four things get
+   pulled from every transcript — what you committed to, what they committed to,
+   the question you didn't answer, and any date that was named out loud. The
+   first category is the one that loses deals and the one reps skip.
+4. **Triage which calls earn an email.** Read `references/triage-rubric.md`.
+   Most calls in a given week do not. The value of a sweep is subtraction — a
+   run that drafts an email for every call has done nothing a calendar couldn't.
+5. **Dedupe by account, not by call.** Three calls with one account in one week
+   is one email to that account, built from all three. Separate drafts to the
+   same company arriving the same morning read as an unmanaged vendor.
+6. **Draft to the call's shape.** Read `references/draft-patterns.md` — the
+   email a stalled renewal needs is not the email a first discovery needs. Cap
+   every draft at 150 words and three visible action items; overflow goes to a
+   named next call, not a longer email.
+7. **Report the sweep, don't just dump drafts.** Lead with commitments aged past
+   three business days, then the drafts, then the no-email list with a one-line
+   reason each, then any pattern that showed up across calls — the same
+   objection landing three times in a week is worth more than any single draft.
+
+## What good looks like
+
+- The best operator extracts their own promises first. Reps instinctively
+  mirror the customer's pain back at them, because that is what the transcript
+  is loudest about — but the thing that actually rots a deal is the seller's
+  unshipped "I'll get you the security doc by Thursday". A sweep that surfaces
+  customer pain and misses two of the user's own open promises has failed at
+  its only irreplaceable job.
+- The common mistake is the recap email. Both people were on the call; a
+  narration of it is filler that buys nothing. The follow-up exists to date the
+  commitments, put in writing the one thing that would otherwise be disputed
+  later, and hand the champion something forwardable to people who weren't
+  there. If a draft would still make sense with the account name swapped out,
+  it is a template, not a follow-up.
+- Good output is auditable and mostly negative space: every action item carries
+  a named owner and a date, the no-email list is typically longer than the draft
+  list, aging commitments appear above fresh drafts, and the user can see at a
+  glance which calls were read and which could not be.
+
+## Rules
+
+- MUST ask whether the window is a day or a week before reading anything.
+- MUST produce drafts only. NEVER send, schedule, or queue a message, and never
+  write to the CRM as part of a sweep — the user reviews and sends by hand.
+- MUST attach a named owner and an explicit date to every action item, or state
+  plainly that the call never produced one.
+- MUST list calls that were skipped or unreadable, with the reason, rather than
+  returning a clean report over partial coverage.
+- NEVER invent a commitment, a date, or a number that was not said on the call;
+  quote or flag the absence.
+- NEVER write in a register the user has not used — a draft that has to be
+  rewritten for voice is worse than no draft.

--- a/skills/boaz-descalo/call-followup-sweep/references/commitment-extraction.md
+++ b/skills/boaz-descalo/call-followup-sweep/references/commitment-extraction.md
@@ -1,0 +1,85 @@
+# Commitment extraction
+
+How to read a call transcript for the four things that survive it. Everything
+else in a transcript is context; these four are the only things that create an
+obligation, and they are what the sweep is for.
+
+## The four categories
+
+Extract into these buckets, in this order. The order is deliberate — category 1
+is the one reps skip and the one that costs deals.
+
+| # | Category | What it sounds like | Why it matters |
+|---|---|---|---|
+| 1 | **You committed** | "I'll send…", "let me check with…", "I can get you…", "we'll put together…" | The seller's unshipped promise is the single most common silent deal-killer. Nobody chases you for it; they just downgrade you. |
+| 2 | **They committed** | "I'll loop in…", "let me get approval…", "I'll pull those numbers…" | This is your legitimate reason to follow up, and the thing to make legible in writing so it does not quietly evaporate. |
+| 3 | **Question you didn't answer** | a direct question followed by a pivot, "good question, let me come back to that", a number you approximated | An unanswered question is an open objection wearing a polite face. It resurfaces at procurement. |
+| 4 | **Date named out loud** | "before end of quarter", "our board meets the 14th", "we're heads-down until after launch" | Their dates, not yours, set the real cadence. A date said once on a call is worth more than any cadence rule. |
+
+## The extraction pass
+
+1. **Read for first-person future tense from the seller's side.** Search the
+   transcript for the seller's own "I'll", "I can", "we'll", "let me". This
+   single pass catches most of category 1 and takes under a minute per call.
+2. **Read for the same from the buyer's side** — category 2.
+3. **Find every question mark from the buyer and check whether an answer
+   followed.** A question that got a story instead of an answer is category 3.
+   So is any answer containing "roughly", "I think", "around" attached to a
+   number, price, timeline, or security claim.
+4. **Collect every date, deadline, and time-bounded phrase** regardless of who
+   said it — category 4. Convert relative phrases ("end of next month") to
+   actual dates against the call date, and mark them as inferred.
+5. **Note who was on the call and did not speak.** A silent attendee on a
+   multi-stakeholder call is a stakeholder signal, not a commitment. It belongs
+   in the sweep report, not in the email.
+
+## What gets missed
+
+- **The conditional promise.** "If you want, I can put together a rough number"
+  is a commitment the moment the buyer says "yeah". Reps hear the "if" and file
+  it as optional; buyers hear the offer and wait for it.
+- **The delegated promise.** "I'll ask our solutions team to look at that"
+  creates an obligation on the seller even though the work belongs to someone
+  else. It ages exactly like a direct promise and is forgotten faster.
+- **The promise made in the last ninety seconds.** Wrap-up is where most
+  commitments are made and where transcript attention is lowest. Read the final
+  ninety seconds twice.
+- **The number said aloud.** Any price, discount, timeline, headcount, or SLA
+  figure spoken on a call is a commitment in the buyer's memory whether or not
+  it was qualified. Extract every one and flag the ones that were hedged, so the
+  user can decide whether to confirm or correct it in writing.
+- **The thing the buyer repeated.** If a buyer raises the same concern twice in
+  one call, it is the actual blocker regardless of what the stated next step is.
+
+## Worked example
+
+Transcript excerpt, discovery call, 34 minutes, two attendees on the buyer side:
+
+> **Buyer (Dana, VP Ops):** …the part I keep coming back to is whether this
+> survives our SOC 2 review. Last vendor took four months.
+> **Seller:** Totally fair. We've been through it a bunch — I'll dig up the
+> report and get it over to you.
+> **Buyer:** Great. And what does this look like at 40 seats instead of 12?
+> **Seller:** Roughly it scales linearly, so call it low five figures, but let
+> me confirm with our team and come back with a real number.
+> **Buyer:** Okay. I'll get Marcus to sit in next time — he owns the budget.
+> **Buyer:** …and honestly the SOC 2 thing is the piece I need resolved before
+> I can take this anywhere internally.
+> **(Second buyer attendee: silent for the full call.)**
+
+Extraction:
+
+- **You committed** — (a) send the SOC 2 report, no date given; (b) come back
+  with a real 40-seat number, no date given.
+- **They committed** — Dana brings Marcus, budget owner, to the next call.
+- **Question you didn't answer** — 40-seat pricing. Hedged aloud as "low five
+  figures", which is now anchored whether or not it was meant to be.
+- **Date named** — none explicit. Nothing to convert; say so rather than
+  inventing "next week".
+- **Signals for the report** — SOC 2 raised twice, second time as an explicit
+  internal blocker: this is the real gate, not pricing. One buyer attendee never
+  spoke; worth naming before the next call.
+
+The draft that follows from this leads with the SOC 2 report and a date, states
+the 40-seat number as pending with a date, and confirms Marcus for the next
+call. It does not recap what Dana said about her last vendor.

--- a/skills/boaz-descalo/call-followup-sweep/references/draft-patterns.md
+++ b/skills/boaz-descalo/call-followup-sweep/references/draft-patterns.md
@@ -1,0 +1,94 @@
+# Draft patterns
+
+The shape of the email, by what the call actually was. Every pattern below caps
+at 150 words and three visible action items. Overflow becomes a named next call,
+never a longer email.
+
+## The universal spine
+
+Every draft, regardless of type, is four moves in this order:
+
+1. **The one thing** — the single most consequential item, in the first line.
+   Usually the user's own commitment with a date on it.
+2. **The commitments, dated and owned** — a short list, each with a name and a
+   date. Theirs and yours, in the same list, so the reciprocity is visible.
+3. **The forwardable sentence** — one sentence a champion can paste to someone
+   who was not on the call, stating what this is and why it matters to them.
+4. **One ask** — a booked slot, a document, an introduction. Exactly one.
+
+No greeting paragraph, no "it was great speaking with you", no recap of what
+they told you about their business. They were there.
+
+## By call type
+
+**First discovery.** Lead with the thing you owe. The forwardable sentence
+carries the most weight here, because the person who decides is usually not on a
+first call. Ask for the next meeting with two concrete slots. Do not attach
+collateral unless it was asked for by name.
+
+**Technical or security review.** Lead with the artifact and its date. Answer
+the unanswered question in writing or state exactly when you will. This is the
+one call type where being slightly longer is correct — a security contact
+forwards the email itself as evidence. Still no recap.
+
+**Pricing or commercial call.** Restate every number that was said aloud, in
+writing, correctly. If a figure was hedged on the call ("call it low five
+figures"), either confirm it or correct it now — this is the entire purpose of
+the email. Ambiguity here is what becomes a procurement fight.
+
+**Stalled or re-engagement call.** One paragraph. Name the gap plainly without
+apologizing for it, state what changed since, make one ask. If nothing has
+changed since the last touch, the correct output is no email and a note to that
+effect.
+
+**Renewal or customer check-in.** Lead with what you owe them operationally, not
+with commercial terms. Commitments here are usually support or roadmap items
+and they age worse than sales promises because nobody is chasing them.
+
+**Multi-call account (deduped).** Structure by workstream, not by call. Two
+headers maximum. The recipient should not be able to tell it was assembled from
+three conversations.
+
+## Anti-patterns
+
+- **The recap.** Any draft whose first paragraph narrates the call. If the email
+  would still make sense to someone who did not attend *and* to someone who did,
+  it is doing neither job.
+- **The swappable draft.** If replacing the account name produces a valid email
+  for a different account, it is a template. Something said on the call must be
+  in it, ideally quoted.
+- **The stacked ask.** Three questions at the end. The recipient answers the
+  easiest one and the other two die.
+- **The undated commitment.** "I'll get that over to you shortly." Shortly is
+  not a date and creates the exact rot the sweep exists to catch.
+- **The apology opener.** "Sorry for the delay" spends the first line on the
+  seller's feelings. State the new date and move.
+- **Borrowed voice.** A draft written in a register the user does not use costs
+  more to fix than to write from scratch. Match their prior sent mail; when
+  there is no sample, stay plain and short and say that voice was not matched.
+
+## Worked example
+
+From the discovery call in `commitment-extraction.md` — Dana, VP Ops, SOC 2
+raised twice, 40-seat pricing hedged aloud, Marcus joining next time.
+
+> **Subject:** SOC 2 report + 40-seat pricing
+>
+> Dana — SOC 2 report is attached; that was the piece you said had to be
+> resolved before this goes anywhere internally, so it goes first.
+>
+> - SOC 2 Type II report — attached (me, today)
+> - Confirmed 40-seat pricing — I'll send the real number Thursday, not the
+>   rough one I gave on the call (me, Thu)
+> - Marcus joining the next session (you)
+>
+> For Marcus: we handle the workflow your team is running manually today, and
+> the open question is what it costs at 40 seats rather than whether it works.
+>
+> Thursday or Friday afternoon for the next one — which is easier?
+
+Why it works: the user's own two commitments are dated and owned, the hedged
+number is explicitly flagged as being corrected rather than left to anchor, the
+forwardable sentence is written for Marcus rather than for Dana, and there is
+exactly one ask. It never mentions Dana's last vendor, which is the most
+memorable and least useful thing she said.

--- a/skills/boaz-descalo/call-followup-sweep/references/triage-rubric.md
+++ b/skills/boaz-descalo/call-followup-sweep/references/triage-rubric.md
@@ -1,0 +1,80 @@
+# Triage rubric
+
+Which calls earn an email, which get nothing, and how open commitments age.
+The sweep's value is subtraction: a run that drafts one email per call has
+replaced a calendar, not a judgment.
+
+## Does this call earn an email?
+
+A call earns a draft if **any one** of these is true:
+
+| Trigger | Weight | Note |
+|---|---|---|
+| The user committed to something | **Always** | One unshipped promise is sufficient on its own. No other trigger is needed. |
+| A number, price, or SLA was said aloud | **Always** | Put it in writing correctly now, or inherit the buyer's version of it later. |
+| A date was named by the buyer | High | Their date sets the cadence; acknowledge it in writing so it becomes shared. |
+| A new stakeholder appeared or was promised | High | The email is what gets forwarded to them. Write it for the person who wasn't there. |
+| A question went unanswered | High | Answer it in the draft, or name the date you will. |
+| Next step discussed but not on a calendar | Medium | The draft's only job is to convert it to a booked slot. |
+| An objection surfaced for the second time | Medium | Address it in writing, plainly, once. |
+
+A call earns **no email** when all of the following hold:
+
+- Neither side committed to anything.
+- No number, price, or date was said aloud.
+- The next meeting is already on the calendar.
+- No new stakeholder, no unanswered question, no repeated objection.
+
+In practice this covers standing check-ins, mid-project status calls, and
+already-booked second meetings. On a typical week sweep, **roughly half to two
+thirds of calls earn no email** — if a sweep is drafting for 90% of the book,
+the triage is not running and the output is noise.
+
+Three additional no-email cases, regardless of triggers:
+
+- **Already handled.** A thread to that account exists post-call. Say so; do not
+  draft a second one.
+- **Internal call.** No external attendee — extract commitments for the aging
+  report only.
+- **Unverified call.** No recording, no transcript, no notes. It goes on the
+  coverage list as unread. Never draft from a calendar title alone.
+
+## Dedupe rules
+
+- **One account, one email.** Multiple calls with the same account inside one
+  window collapse into a single draft built from all of them, addressed to the
+  most senior participant who was on the most recent call.
+- **One thread, one ask.** If two calls with an account produced two unrelated
+  asks, the draft carries the one that gates the other and names the second as
+  coming separately.
+- **Different accounts, same parent company** stay separate unless the same
+  person was on both calls.
+
+## Aging thresholds
+
+Applied to every open commitment carried forward from prior sweeps. These are
+business days from the call the commitment was made on.
+
+| Age | State | What the sweep does |
+|---|---|---|
+| 0–2 days | Fresh | List under the account. No special treatment. |
+| 3–5 days | **Aging** | Flag it. Lead the account's draft with it. |
+| 6–10 days | **Overdue** | Surface at the top of the sweep report, above all fresh drafts, with the original quote and date. |
+| 11+ days | **Rotted** | Report separately. Do not silently fold into a normal follow-up — a two-week-late promise needs the delay named in the draft, not glossed over. |
+
+Two rules that matter more than the thresholds:
+
+- **A commitment with no date attached ages from the call date**, not from some
+  implied grace period. "I'll send that over" made eleven days ago is rotted,
+  not pending.
+- **Aging beats freshness in the report order, always.** A user reading a sweep
+  top-to-bottom should hit their oldest broken promise before their newest
+  drafted email. Ordering the report by call date instead of by age is the most
+  common way this skill gets rendered useless.
+
+## Coverage reporting
+
+Every sweep states, before any draft: calls in window, calls read, calls
+unverified, drafts produced, no-email count, open commitments by age bucket. A
+sweep that reports drafts without reporting coverage is claiming completeness it
+has not earned.


### PR DESCRIPTION
## What this skill does

Sweeps a day or a week of customer calls — the window is asked for, never assumed — extracts the commitments made on each (especially the user's own), triages which calls actually earn a follow-up, and returns one draft per account that does. Drafts only; the skill never sends, schedules, or writes to the CRM.

Fills a gap between the existing post-call skills: this is the batch retrospective across a time window, where `post-meeting-execution` runs per-meeting, `stage-aware-follow-up` handles one deal's next touch, and `pull-call-review` diagnoses a single transcript.

`SKILL.md` is a 753-word spine; the depth sits in three reference pages — commitment extraction (four-category taxonomy + worked transcript), triage rubric (which calls earn nothing, dedupe, aging thresholds), and draft patterns (six call-type shapes, anti-patterns, worked draft).

## Checklist (mirrors the review gates — check honestly)

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [ ] First contribution: `author.md` is included with a real name, avatar, and LinkedIn — n/a, profile already exists from `company-domain-resolver`
- [x] Body speaks in GTM verbs — zero vendor tool names
- [x] Has a `## What good looks like` section with real judgment (not just steps)
- [x] No lifecycle/operational fields (`prefix`, `isDefault`, …) anywhere
- [x] Nothing sends data anywhere the reader doesn't own; no secrets, no injection patterns, no ungated destructive actions
- [x] I'm okay with this being MIT-licensed with attribution via my creator profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu1QkwrpXfEgMnYLTwdjc2