### PR TITLE
boaz-descalo: remove email from profile

### DIFF
--- a/skills/boaz-descalo/author.md
+++ b/skills/boaz-descalo/author.md
@@ -4,7 +4,6 @@ avatarUrl: "https://www.gtmskills.com/authors/boaz-descalo.jpg"
 title: Founder & CEO, Node8
 linkedinUrl: https://www.linkedin.com/in/descalo/
 companyDomain: node8.ai
-email: boaz@node8.ai
 ---
 
 I build and scale AI systems for B2B companies. Today I run Node8, where we partner with teams from early-stage startups to public companies to move from AI strategy to production implementation and measurable adoption. My skills encode the data-plumbing side of GTM — the unglamorous resolution, dedupe, and hygiene steps that decide whether enrichment and outreach downstream actually work.


### PR DESCRIPTION
## What this changes

Removes the `email:` field from `skills/boaz-descalo/author.md`. Profile change only — no skill files touched.

The field is optional in practice: `tools/validate.mjs` treats a missing email as a warning rather than an error, and 49 of the 70 contributor profiles currently ship without one. Validator passes on this branch with the expected warning.

Understood that this means maintainers lose the contact path for review questions and the acceptance card — reachable via the LinkedIn profile on file instead.

## Checklist

- [x] All changes are inside `skills/<my-slug>/` only
- [x] `node tools/validate.mjs` passes locally
- [x] No lifecycle/operational fields anywhere
- [x] No skill content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu1QkwrpXfEgMnYLTwdjc2