### PR TITLE
dyanesh-perumal: rehost avatar on gtmskills.com

### DIFF
--- a/skills/dyanesh-perumal/author.md
+++ b/skills/dyanesh-perumal/author.md
@@ -1,6 +1,6 @@
 ---
 name: Dyanesh Perumal
-avatarUrl: https://media.licdn.com/dms/image/v2/D5603AQGm6byIYEes7w/profile-displayphoto-crop_800_800/B56Z8156NEKEAI-/0/1783315804127?e=1790812800&v=beta&t=JGHPR-giUoydrUiz15x4yiudnc6Gl9o7Kk-YmJbCZB4
+avatarUrl: "https://www.gtmskills.com/authors/dyanesh-perumal.jpg"
 title: Principal GTM Engineer & Founder, Nett New
 linkedinUrl: https://www.linkedin.com/in/dyaneshp
 companyDomain: nettnew.com


### PR DESCRIPTION
Points avatarUrl at the re-hosted copy on gtmskills.com instead of the expiring LinkedIn CDN URL, so the next sync does not clobber the DB row. Profile-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STdFBe5nsud4YMuq5Tfpbp