### PR TITLE
add event-account-plan

### DIFF
--- a/skills/boaz-descalo/event-account-plan/SKILL.md
+++ b/skills/boaz-descalo/event-account-plan/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: event-account-plan
+title: Event account plan
+description: |
+  Use this skill in the weeks before a conference, trade show, or field event,
+  when an attendee or registration list exists and the question is which
+  companies to work, who to talk to at each one, and what to say. Trigger on
+  "we have the attendee list for the show", "who should we target at this
+  conference", "build the event account plan", "prep the team for the booth",
+  "score this registration export", "which accounts are worth booking before
+  the event". Turns a raw list into a deduplicated, signal-scored, tiered
+  account plan with the buying committee behind each top account, a play per
+  track, and a shared war-room page the floor team and the CRO both read.
+  Leads on competitor tech signals — a dead competitor in the room is the
+  best target on the list.
+category: Events
+tags: [Marketing, Sales]
+contributors: []
+---
+
+Applies once an attendee, registration, or target-audience list exists and there
+is still time to act on it — typically the two weeks before the show. Produces a
+ranked account file, a decision-maker file, and a war-room page: which companies
+to work, the buying committee behind each, and the play per segment. Not a
+summary of the event.
+
+## Collect five things
+
+Ask only for what you cannot find yourself. Missing 1 or 2 blocks the work.
+
+1. **The attendee list** — export, sheet, or paste. Company rows, and named
+   registrants if you are lucky.
+2. **Whose GTM this is** — the vendor's site. Homepage, product pages, and the
+   customers/logos page.
+3. **The event** — name, dates, venue, attendee count, track list. The track
+   list tells you which personas actually show up.
+4. **Credit policy** — ask explicitly whether you may spend enrichment credits.
+   Most users say no. Default to search-only and say so in the deliverable.
+5. **How to treat existing customers** — expansion track (the usual answer) or
+   excluded. Never silently drop them.
+
+## The pipeline
+
+Each step feeds the next and is cheap to redo alone.
+
+1. **Normalize.** Parse to two tables — accounts and named attendees. Dedupe
+   accounts by **parent company, not by row**; big lists are full of divisions
+   registering separately. Merge them, keep every division name in a
+   `sheet_names` field, and count them: multiple divisions registering
+   independently is a buying signal, so carry the count into scoring. Check
+   which columns are actually populated first — a location column that is
+   empty on every row is common.
+2. **Read the ICP before scoring anything.** From the vendor's own site: what
+   the product does, the named buyer personas, the verticals, the
+   deal-blocking compliance regimes, the competitors they name, and the
+   customer logo list. Skip this and your weights are guesses.
+3. **Resolve companies.** Run accounts through whatever company-data connector
+   is available for ID, revenue, employee count, HQ, and industry. Batch by
+   domain. Expect roughly 90% to match; carry the misses through with blanks
+   rather than dropping them.
+4. **Find signals.** Firmographics rank accounts; signals tell you why now.
+   Pull tech-stack tags for the vendor's own product and for every named
+   competitor. **A dead or dying competitor is the best signal that exists**:
+   if one has shut down, been acquired and sunset, or gone end-of-life, its
+   install base must migrate. Search for that explicitly, every time. Read
+   `references/signal-sourcing.md` before the first batch — it covers the
+   connector traps that silently return zero rows.
+5. **Score and tier.** Additive 0–100, weights adapted to the ICP from step 2,
+   with a penalty for partner-motion segments. Full rubric, bands, and tier
+   cuts in `references/scoring-model.md`. Score existing customers on a
+   **separate expansion track** — a customer scores high on everything and
+   will otherwise crowd out every new logo.
+6. **Find the buying committee.** Tier 1 and top expansion accounts only.
+   Names and titles are enough. Target the personas from step 2, cap at about
+   eight per account, rank by persona fit first and seniority second.
+7. **Write the plays.** One per track — migrate the defunct competitor,
+   displace the live ones, new logo, expand customers, booth demo. Each gets a
+   title, an audience, a body, a verbatim opening question a rep can say out
+   loud, and a proof point. Then count buyer-persona titles among the named
+   attendees: if most attendees do not own the budget, say so plainly and
+   re-aim the copy at operational cost. See
+   `references/plays-and-messaging.md`.
+8. **Ship all three deliverables** — accounts file, decision-makers file, and
+   the war-room page. Column lists, page sections, and the verification pass
+   are in `references/deliverables.md`.
+
+## What good looks like
+
+- The best operator resolves the tech stack before touching the score. A list
+  of 400 companies ranked purely on firmographics is a directory; the same list
+  with "runs a competitor that shut down" on eleven rows is a quarter of
+  pipeline. Rank on fit, sequence on signal.
+- The common mistake is generic messaging. A play that could be sent to any
+  vertical at any event has failed — the copy must name the compliance regime,
+  the network zone, the audit, or the workflow that this vertical actually
+  cares about. The second most common mistake is letting vendors, hyperscalers,
+  consultancies, and SIs float into Tier 1; they are a partner motion, not a
+  buyer motion, and they pollute the top of the list.
+- Good output reconciles. Every deduplicated account lands in exactly one tier,
+  existing customers sit on the expansion track, the two written fields — *why
+  this account* and *the angle to open with* — are filled on every Tier 1 row,
+  and the method section states plainly what you could not get.
+
+## Rules
+
+- MUST ask the credit policy before the first connector call, and confirm at
+  the end how much was spent — "none" is a result worth stating.
+- MUST record which fields came from the supplied list and which you sourced;
+  a reader cannot audit a plan whose provenance is invisible.
+- MUST keep existing customers on a separate expansion track, scored
+  separately, never merged into the new-logo ranking.
+- MUST raise sourcing and personal data unprompted: attendee lists are rarely
+  public and connector data is licensed, so the user needs an answer ready for
+  "where did you get this list?". Offer a masked version — initials and titles
+  only — for anything shared outside the team.
+- NEVER collect emails or phone numbers unless the user explicitly asks for
+  them.
+- NEVER drop unmatched or unenriched accounts; carry them with blanks and count
+  them in the funnel.
+- NEVER present a score without the weights that produced it.

--- a/skills/boaz-descalo/event-account-plan/references/deliverables.md
+++ b/skills/boaz-descalo/event-account-plan/references/deliverables.md
@@ -1,0 +1,89 @@
+# Deliverables
+
+Three artifacts, and all three are load-bearing. The two files are what a rep
+works from; the page is what makes the plan a conversation with leadership
+rather than an attachment nobody opens.
+
+## 1. Accounts file
+
+One row per deduplicated account:
+
+| Field | Notes |
+|---|---|
+| rank, tier, track | Track is new-logo / migrate / displace / expand / partner |
+| name, domain | The parent name, not the registered division string |
+| vertical, firmographics | Revenue, employees, HQ — blank where unknown, never zero |
+| score, score components | Ship the components, not just the total |
+| tech signals | Vendor product, each competitor, end-of-life flag |
+| attendee count, attendee names | The people physically in the room |
+| division list | The `sheet_names` field — every string that merged into this row |
+| decision-maker count | Populated for Tier 1 and top expansion only |
+| **why this account** | Written, one or two sentences |
+| **the angle to open with** | Written, specific to this account |
+
+The last two fields are the only ones a rep actually reads under time pressure.
+If they are empty on a Tier 1 row, that row is not finished.
+
+## 2. Decision-makers file
+
+Named attendees first — they will physically be there — then sourced contacts
+behind them. Every row carries account tier, track, persona, and the outreach
+angle, so the file works standalone when someone sorts it or hands one slice to
+one rep.
+
+Names and titles only, unless the user explicitly asked for contact details.
+
+## 3. The war-room page
+
+A single shareable page. Sections that earn their place:
+
+- **KPI row and a funnel** — raw list rows → deduplicated accounts → resolved →
+  in-ICP → tiered → workable leads. The drop at each step is the honest story of
+  the list, and it preempts "why is this only 180 accounts?"
+- **Tier breakdown by vertical** — where the plan is concentrated.
+- **Top ~12 accounts to book before the show** — the only section some readers
+  will look at.
+- **An editable lead plan** — conversion percentage per source × ACV →
+  pipeline, with the inputs editable in the page. This is the section that
+  turns a list review into a CRO conversation, because it lets the reader argue
+  with the assumptions instead of the output.
+- **A filterable, sortable account table** with expandable per-account detail.
+- **Named attendees and decision makers**, filterable by persona.
+- **Plays, messaging themes, and competitor battlecards.**
+- **A method tab** — sources, scoring weights, coverage rates, credits spent,
+  and **what you could not get**. The gaps section is what makes the rest
+  credible.
+- **A team board** — owner and status per account, shared live across everyone
+  who opens the page, so the floor team is not maintaining a private copy each.
+  Use whatever shared-state mechanism the publishing surface offers; a page
+  where each viewer's edits are invisible to the others is worse than a
+  spreadsheet.
+
+## Verification pass
+
+Run all of it before handing anything over:
+
+- Row counts reconcile — every deduplicated account appears in exactly one tier
+  on exactly one track, and the funnel numbers add up to the source row count.
+- Spot-check 10 top accounts by hand against the source rows and the vendor's
+  customers page.
+- Existing customers are on the expansion track, not mixed into new logos.
+- Every play names something specific to its vertical.
+- Every Tier 1 row has both written fields filled.
+- No credit-spending calls were made if the user said no credits, and no emails
+  or phone numbers were collected unless asked.
+- Open the page at phone width and in dark mode. It will be read on a phone,
+  standing up, on a show floor.
+
+## Two things to raise unprompted
+
+**Sourcing.** Attendee lists are rarely public and connector data is licensed.
+If the deliverable will be shown to anyone outside the team holding those
+licenses, state plainly what came from where — and make sure the user has an
+answer ready for "where did you get this list?" before they need it.
+
+**Personal data.** A finished plan contains hundreds of named individuals and
+their titles. That is normal for an internal sales asset and a real exposure in
+anything shared more widely. Offer to produce a masked version — initials and
+titles only, no names, no attendee-level detail — for external circulation.
+Offer it; do not wait to be asked.

--- a/skills/boaz-descalo/event-account-plan/references/plays-and-messaging.md
+++ b/skills/boaz-descalo/event-account-plan/references/plays-and-messaging.md
@@ -1,0 +1,80 @@
+# Plays and messaging
+
+Generic messaging is the most common failure of this whole skill. A finished
+plan can have perfect scoring and still be worthless if the copy could be sent
+to any vertical at any event. What follows is the structure that stops that.
+
+## One play per track
+
+Five tracks cover almost every event. Write one play for each that has accounts
+in it, and skip the ones that do not.
+
+| Track | Who it is for | The wedge |
+|---|---|---|
+| Migrate | Accounts on a defunct or end-of-life competitor | Their deadline, not yours — a forced migration with a date attached |
+| Displace | Accounts on a live competitor | The specific gap, not a feature list |
+| New logo | High-fit accounts with no competitor tag | The problem, before the category |
+| Expand | Existing customers | A division, team, or workflow not yet covered |
+| Booth demo | Anyone who walks up | What can be shown in four minutes |
+
+## Play anatomy
+
+Every play carries five parts. A play missing any of them will not survive
+contact with a rep on a show floor.
+
+1. **Title** — how the team refers to it out loud, all week.
+2. **Who it is for** — the track, plus the persona inside it. "IT operations
+   leads at accounts running an end-of-life competitor", not "Tier 1".
+3. **The body** — three or four sentences a rep can internalize, naming the
+   specific thing that vertical cares about: the compliance regime, the network
+   zone, the audit cycle, the ticket queue, the certification deadline.
+4. **A verbatim opening question** — one sentence, in quotes, that a rep can say
+   out loud at a booth without adapting it. This is the part teams actually
+   use and the part most plans omit. It should be answerable by a stranger in
+   one breath and should reveal whether the person has the problem.
+5. **The proof point** — the customer, the number, or the reference that makes
+   the claim survive a follow-up question.
+
+## The persona-mix check
+
+Before finalizing any of it, count buyer-persona titles among the named
+attendees.
+
+If most attendees do not own the budget for what is being sold — extremely
+common when a security product is marketed at an infrastructure or operations
+event — say so plainly in the deliverable and change the aim of the copy. Do not
+quietly write persona-perfect messaging for people who will not be in the room.
+
+The re-aim is always the same move: lead on operational cost rather than on the
+product category. Cycle time, ticket volume, audit hours, on-call load, manual
+steps per change. An operations lead who cannot sign a security purchase can
+absolutely describe the pain to someone who can — but only if the opening
+question was about their day rather than about your category.
+
+## Anti-patterns
+
+- **The category pitch.** Opening with what the product is rather than what the
+  person is dealing with. Fails hardest at a booth, where the listener has
+  eight seconds and forty other booths.
+- **The feature list as displacement play.** "We do X, Y, and Z better" loses to
+  a single named gap the person has already felt.
+- **One play for all verticals.** If the body reads the same for a hospital
+  system and a regional bank, neither will recognize themselves in it.
+- **The unaskable opener.** A question that takes twenty words of setup is not
+  an opener. If a rep would rephrase it, it is not verbatim.
+- **Treating the migrate track like the displace track.** An account whose
+  vendor has gone end-of-life is not being sold to — they are shopping, on a
+  clock, and the play is to be the easiest option, not the best one.
+- **Aggression on the competitor.** Naming a competitor's failure works when the
+  buyer already knows it. Telling them it happened reads as a sales tactic, even
+  when it is true.
+
+## What the plays are for
+
+The plays are the part of the deliverable a human reads before walking onto the
+floor, and the only part that gets quoted back. Every line should survive being
+read on a phone, standing up, thirty seconds before a conversation.
+
+Write them last, after scoring — but write them for the accounts, not for the
+tiers. A play that names something real about eleven migrate-track accounts is
+worth more than five plays covering the whole list evenly.

--- a/skills/boaz-descalo/event-account-plan/references/scoring-model.md
+++ b/skills/boaz-descalo/event-account-plan/references/scoring-model.md
@@ -1,0 +1,114 @@
+# Scoring model
+
+Additive, 0–100, one score per account. Additive rather than multiplicative on
+purpose: a rep can read a score and see which component earned it, and you can
+defend any ranking line by line when the CRO asks why a logo they recognize sits
+in Tier 2.
+
+Adapt the weights to the ICP you read off the vendor's site. The table below is
+a sane default for a product sold into a technical buyer at a mid-to-large
+company, not a universal truth.
+
+| Component | Range | How to set it |
+|---|---|---|
+| Industry fit | 0–30 | Rank the verticals from the ICP research, not from instinct |
+| Size | 4–15 | By revenue band |
+| Tech signal | 0–25 | Defunct competitor 25 · live competitor 15 |
+| Named attendee | 0–25 | +5 if their title matches a buyer persona |
+| Multi-division | 0–10 | 2 per extra division that registered |
+| Segment penalty | −15 to −25 | Partner-motion segments |
+
+## Industry fit (0–30)
+
+Take the verticals the vendor names on its own site and rank them. A workable
+default shape:
+
+- 30 — a vertical named on the homepage or with a dedicated solution page
+- 20 — named in customer stories or on a product page, but not headlined
+- 10 — adjacent: same buyer, same compliance regime, different label
+- 0 — outside the ICP entirely
+
+Two-thirds of the spread in a finished list comes from this component and the
+tech signal. If everything scores 20, you have not read the site closely enough.
+
+## Size (4–15)
+
+By revenue band, with employee count as the fallback when revenue is missing —
+and it will be missing on a fifth of a typical list. Set the bands off the
+vendor's actual deal sizes; the shape is a floor of 4 so that an unknown-size
+account still ranks on its other components rather than falling out of the list.
+Never score a blank as zero: a blank is missing data, not a small company.
+
+## Tech signal (0–25)
+
+The highest-leverage component and the one most lists skip.
+
+- **25 — defunct competitor.** Shut down, acquired and sunset, or end-of-life.
+  The install base has no choice but to move, and the timeline is somebody
+  else's deadline rather than yours.
+- **15 — live competitor.** A displacement conversation. Real, slower, and
+  worth a different play than a green field.
+- **0 — no competitor tag.** Not evidence of absence; tech-tag coverage is
+  partial on most data sources. Say so in the method section rather than
+  implying the account runs nothing.
+
+The vendor's own tech tag does not score here. It routes the account to the
+expansion track instead.
+
+## Named attendee (0–25)
+
+Someone physically in the room is worth more than any firmographic. Score the
+presence, then add 5 when the title matches one of the buyer personas from the
+ICP research. An account with three named attendees and no persona match is
+worth less than an account with one attendee who owns the budget.
+
+## Multi-division (0–10)
+
+Two points per additional division that registered independently, capped at 10.
+Divisions registering separately means separate budgets noticed the same event
+in the same quarter without coordinating. Capping at 10 keeps a sprawling
+conglomerate from outranking a focused ICP account on org chart alone.
+
+## Segment penalty (−15 to −25)
+
+Vendors, hyperscalers, consultancies, and systems integrators are a partner
+motion, not a buyer motion. Left unpenalized they colonize the top of the list:
+they are large, they are technical, they send many attendees, and a rep who
+calls them wastes the pre-show window. Penalize the segment rather than deleting
+the rows — they are still worth a partner conversation, on a different track.
+
+## Tiering
+
+- **Tier 1** — top ~50 accounts. Full treatment: buying committee, both written
+  fields, an owner assigned before the show.
+- **Tier 2** — next ~100. Scored and angled, worked opportunistically.
+- **Tier 3** — the remainder. Present in the file, not in anyone's plan.
+
+Tune the cuts to the size of the team walking the floor, not to the size of the
+list. Five reps cannot work 50 Tier 1 accounts in two weeks; two hundred
+attendees do not produce 50 accounts worth that treatment. The tier boundary is
+a capacity decision wearing a scoring costume.
+
+## The expansion track
+
+Existing customers — flagged by the vendor's own tech tag **or** a logo on the
+customers page — score on a **separate ranked list**. They will otherwise
+dominate: a customer matches the ICP by definition, is the right size by
+definition, and often sends the most attendees. Running one ranking for both
+means the new-logo motion silently disappears from the top of the file, and
+nobody notices until the show is over.
+
+Score the expansion list on expansion logic — divisions not yet using the
+product, attendees from teams outside the current footprint, and named
+competitors present alongside the vendor's own tag (a competitive displacement
+happening inside an existing account is the most urgent row in the whole file).
+
+## Sanity checks before you publish the ranking
+
+- Every deduplicated account appears in exactly one tier on exactly one track.
+- Spot-check the top 10 by hand against the source rows and the customers page.
+  Two of ten being wrong means a mapping bug, not bad luck.
+- Look at what sits at ranks 45–55. The accounts straddling the Tier 1 line are
+  where a mis-weighted component shows up most visibly.
+- Check the score distribution. A list where nothing scores above 60 usually
+  means the industry-fit ranking was done from instinct.

--- a/skills/boaz-descalo/event-account-plan/references/signal-sourcing.md
+++ b/skills/boaz-descalo/event-account-plan/references/signal-sourcing.md
@@ -1,0 +1,94 @@
+# Signal sourcing
+
+Firmographics decide *which* accounts. Signals decide *why now*, and why-now is
+what makes a rep pick up the phone in the two weeks before a show. Read this
+before the first batch of connector calls — every trap below costs hours if you
+rediscover it live.
+
+## The signal hierarchy
+
+Get as many as the connectors allow, in this order of value:
+
+1. **Tech-stack tags for the vendor's own product and for every named
+   competitor.** The single highest-value query in the pipeline. Own product →
+   existing customer, routed to the expansion track. Competitor → displacement
+   target, scored.
+2. **A dead or dying competitor.** Search for this explicitly, every time, by
+   name: shut down, acquired and sunset, end-of-life, no longer sold. Its
+   install base *must* migrate and the deadline is not yours to create. Nothing
+   else on this list converts like it.
+3. **Existing-customer flag** — the vendor's tech tag OR the logo on the
+   customers page. Two sources because both are incomplete; a logo page lags
+   churn and a tech tag misses private deployments.
+4. **Scoops, news, funding rounds, exec hires** — Tier 1 only. Rich, slow, and
+   not worth pulling for 400 accounts.
+5. **Intent topics** — if the account has them enabled. Many do not. Check
+   rather than assume, and record the coverage rate in the method section.
+
+## Connector traps
+
+**Contact search with a title filter usually accepts only ONE company at a
+time.** Pass eight company IDs together with a job-title list and you get zero
+rows back — not an error, not a warning, an empty result that looks like the
+accounts simply have no matching people. Two workarounds, both far better than
+fifty single-company calls:
+
+- Filter by **department** (Information Technology, for example) plus
+  **management level**. This does accept many company IDs at once.
+- Filter by **job function**, which is more precise. Look the function IDs up
+  first, then batch about eight company IDs per call with a page size of 100
+  and filter titles yourself afterwards.
+
+Run both passes and merge. Department catches the executives; job function
+catches the hands-on owners who will actually be at the booth.
+
+**Look up enum values before filtering.** Industries, departments, job
+functions, tech products, and metro regions are controlled vocabularies.
+Guessing returns either an error or — worse — a silently empty result. Note
+whether the field wants the `id` or the `name`; it differs field to field within
+the same connector.
+
+**Tech-product lookups usually need the vendor name first**, then the products
+belonging to that vendor. One call per vendor. Do this for the vendor's own
+product and every competitor named on their site, before scoring.
+
+**Big results overflow the context window.** A batched contact search returns on
+the order of 65,000 characters. When the harness saves an oversized result to a
+file, do not read it back in — write a small script that parses every saved
+result file and keep the raw payloads out of the conversation entirely. The
+pipeline is designed as separate steps precisely so this stays possible.
+
+**Know which calls cost credits.** Search, lookup, and scoops are typically
+free; enrich and research calls are not. A "no credits" answer rules out every
+enrich-style call and every find-and-enrich tool, and it means no emails and no
+phone numbers anywhere in the deliverable. Confirm at the end that you spent
+none — an explicit "zero credits spent" line in the method section is worth
+writing.
+
+## Match rates and what to do with misses
+
+Expect roughly 90% of accounts to resolve against a company-data connector.
+Carry the missing 10% through the whole pipeline with blank firmographics rather
+than dropping them: an unresolved row is usually a small private company, a
+regional division, or a name typed into a registration form by hand — and a
+named attendee from an unresolved company is still a named attendee in the room.
+
+Never let a blank become a zero. Blank size, blank industry, and blank tech tags
+each need to read as *unknown* in the score and in the file, because the fix for
+unknown (ask a human, search the web) is different from the fix for low.
+
+## What to write down about coverage
+
+Signals are worth exactly as much as a reader's confidence in them, and that
+confidence comes from stating the gaps. For each signal type, record:
+
+- how many accounts you queried, and how many returned anything
+- which competitors you had tech tags for and which you did not
+- whether intent was available at all
+- what you searched for and did not find — especially the dead-competitor
+  search, since a null result there is a real finding
+
+A plan that says "eleven accounts run a competitor that reached end-of-life,
+tech-tag coverage was 62%, so treat the absence of a tag as unknown" is
+trustworthy. The same plan without those numbers is a spreadsheet of guesses
+with good formatting.


### PR DESCRIPTION
## What this is

`skills/boaz-descalo/event-account-plan` — turns a conference or trade-show attendee list into a prioritized account plan: deduplicated accounts, a signal-based score, tiers, the buying committee behind each top account, a play per track, and a shared war-room page.

The wedge is competitor tech signals. Firmographics rank accounts; a competitor that has gone end-of-life tells you which ones have to move this quarter.

## How it differs from the neighbours

- `ariel-cohen/event-room-intelligence` runs 1–3 days out and produces a per-person PDF dossier for the floor team. This one runs ~2 weeks out and produces the account plan and messaging that dossier assumes already exists.
- `ido-goldberg/event-radar` fires *after* attendance, routing individual attendees to follow-up. This one is the pre-show planning pass on the whole list.
- `dave-engel/conference-recommendation` picks which events to attend. This one starts once that decision is made.

## Contents

- `SKILL.md` — the spine: five inputs, an eight-step pipeline, what good looks like, MUST/NEVER rules
- `references/scoring-model.md` — the additive 0–100 rubric component by component, tier cuts, the separate expansion track, sanity checks
- `references/signal-sourcing.md` — the signal hierarchy and the connector traps that silently return zero rows
- `references/plays-and-messaging.md` — five tracks, play anatomy, the persona-mix check, anti-patterns
- `references/deliverables.md` — column lists for both files, war-room page sections, the verification pass

## Checklist

- [x] Files only under `skills/boaz-descalo/`
- [x] Slug globally unique, kebab-case, `name` matches folder
- [x] `node tools/validate.mjs` passes
- [x] Tool-agnostic — no vendor tool names anywhere
- [x] `## What good looks like` present
- [x] No lifecycle keys, no URLs, no secrets, no data sent anywhere the reader doesn't own
- [x] Human approval gates: credit policy asked before spend, no contact details collected unless requested, masked version offered for external sharing
- [x] `author.md` already merged — not touched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu1QkwrpXfEgMnYLTwdjc2